### PR TITLE
ci: cleanup

### DIFF
--- a/.github/workflows/python_and_docker.yml
+++ b/.github/workflows/python_and_docker.yml
@@ -15,7 +15,6 @@ jobs:
       toolchain: nightly-2023-03-20
 
   build-and-push-image:
-    # runs-on: [self-hosted, not-docker]
     runs-on: ubuntu-22.04
     container: docker:19.03.15
 
@@ -47,10 +46,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Make sure no docker layers are created
-        run: |
-          docker rmi -f $(docker images | grep "ghcr.io/cosmian/kms") || true
-
       - name: Build and tag docker container
         uses: docker/build-push-action@v3
         with:
@@ -72,11 +67,6 @@ jobs:
           docker tag ${{ env.REGISTRY_IMAGE }}:main ${BUILD_IMAGE}
           # Push the tagged image
           docker push ${BUILD_IMAGE}
-
-      - name: Docker check container
-        run: |
-          docker rmi -f $(docker images | grep "ghcr.io/cosmian/kms") || true
-          docker run --rm ${{ steps.meta.outputs.tags }} --help
 
     outputs:
       image-tag: ${{ steps.meta.outputs.version }}

--- a/scripts/build_push_docker.sh
+++ b/scripts/build_push_docker.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-set -x
-
-# requires a `docker login ghcr.io -u <USER>` before running
-docker rmi -f "$(docker images | grep "ghcr.io/cosmian/kms")"
-docker build . -f delivery/Dockerfile.standalone -t ghcr.io/cosmian/kms:4.4.2
-docker push ghcr.io/cosmian/kms:4.4.2


### PR DESCRIPTION
remove tests (docker run) on fresh generated container (since it is already done later in python_tests.yml and because it failed the last build)