### PR TITLE
Ci/add tests

### DIFF
--- a/.github/workflows/cargo_build.yml
+++ b/.github/workflows/cargo_build.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   kms-build:
-    name: Build KMS on ${{ inputs.distribution }}
+    name: Build ${{ inputs.archive-name }}
     runs-on: ${{ inputs.distribution }}
     steps:
       - name: Display cpuinfo

--- a/.github/workflows/python_and_docker.yml
+++ b/.github/workflows/python_and_docker.yml
@@ -79,3 +79,41 @@ jobs:
     secrets: inherit
     with:
       kms-version: ${{ needs.build-and-push-image.outputs.image-tag }}
+
+  cloudproof_js:
+    needs:
+      - build-and-push-image
+      - pyo3
+    uses: Cosmian/reusable_workflows/.github/workflows/cloudproof_js.yml@develop
+    with:
+      branch: v9.1.0
+      target: wasm32-unknown-unknown
+      kms-version: ${{ needs.build-and-push-image.outputs.image-tag }}
+      findex-cloud-version: 0.1.0
+      copy_fresh_build: false
+
+  cloudproof_java:
+    needs:
+      - build-and-push-image
+      - pyo3
+    uses: Cosmian/reusable_workflows/.github/workflows/cloudproof_java_in_docker.yml@develop
+    with:
+      branch: v6.0.0
+      target: x86_64-unknown-linux-gnu
+      extension: so
+      destination: linux-x86-64
+      os: ubuntu-20.04
+      kms-version: ${{ needs.build-and-push-image.outputs.image-tag }}
+      findex-cloud-version: 0.1.0
+      copy_fresh_build: false
+
+  cloudproof_python:
+    needs:
+      - build-and-push-image
+      - pyo3
+    uses: Cosmian/reusable_workflows/.github/workflows/cloudproof_python.yml@develop
+    with:
+      branch: v4.0.2
+      target: x86_64-unknown-linux-gnu
+      kms-version: ${{ needs.build-and-push-image.outputs.image-tag }}
+      copy_fresh_build: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,7 +953,6 @@ dependencies = [
  "cosmian_kms_utils",
  "env_logger",
  "hex",
- "josekit",
  "libsgx",
  "predicates",
  "rand",
@@ -962,7 +961,6 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "strum_macros",
  "tempfile",
  "thiserror",
  "tokio",
@@ -979,14 +977,12 @@ version = "4.5.0"
 dependencies = [
  "cosmian_kmip",
  "cosmian_kms_utils",
- "hex",
  "http",
  "josekit",
  "reqwest",
  "serde",
  "serde_json",
  "thiserror",
- "tracing",
 ]
 
 [[package]]
@@ -1021,7 +1017,6 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "base64 0.21.2",
- "bitflags 2.3.3",
  "clap",
  "cloudproof",
  "cosmian_kmip",
@@ -1036,8 +1031,6 @@ dependencies = [
  "josekit",
  "lazy_static",
  "libsgx",
- "libsqlite3-sys",
- "once_cell",
  "openssl",
  "rawsql",
  "reqwest",
@@ -1058,15 +1051,11 @@ name = "cosmian_kms_utils"
 version = "4.5.0"
 dependencies = [
  "argon2",
- "bitflags 2.3.3",
  "cloudproof",
  "cosmian_kmip",
- "leb128",
  "num-bigint",
  "serde",
  "serde_json",
- "strum",
- "strum_macros",
  "thiserror",
  "tiny-keccak",
  "tracing",
@@ -2031,7 +2020,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326"
 dependencies = [
  "cc",
- "openssl-sys",
  "pkg-config",
  "vcpkg",
 ]

--- a/crate/cli/Cargo.toml
+++ b/crate/cli/Cargo.toml
@@ -23,13 +23,11 @@ cosmian_kmip = { path = "../kmip" }
 cosmian_kms_client = { path = "../client" }
 cosmian_kms_utils = { path = "../utils" }
 hex = { workspace = true }
-josekit = { workspace = true }
 libsgx = { path = "../libsgx" }
 rand = "0.8"
 serde = { workspace = true }
 serde_json = { workspace = true }
 strum = { workspace = true }
-strum_macros = { workspace = true }
 thiserror = { workspace = true }
 tokio = { version = "1.25", features = ["full"] }
 uuid = { workspace = true }

--- a/crate/client/Cargo.toml
+++ b/crate/client/Cargo.toml
@@ -8,11 +8,9 @@ license-file = "../../LICENSE.md"
 [dependencies]
 cosmian_kmip = { path = "../kmip" }
 cosmian_kms_utils = { path = "../utils" }
-hex = { workspace = true, features = ["serde"] }
 http = { workspace = true }
 josekit = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-tracing = { workspace = true }

--- a/crate/server/Cargo.toml
+++ b/crate/server/Cargo.toml
@@ -35,7 +35,6 @@ alcoholic_jwt = "4091"
 async-recursion = "1.0"
 async-trait = "0.1"
 base64 = { workspace = true }
-bitflags = { workspace = true }
 clap = { workspace = true, features = ["env", "std"] }
 cloudproof = { workspace = true }
 cosmian_kmip = { path = "../kmip" }
@@ -50,8 +49,6 @@ http = { workspace = true }
 josekit = { workspace = true }
 lazy_static = "1.4"
 libsgx = { path = "../libsgx" }
-libsqlite3-sys = { version = "0.26.0", default-features = false, features = ["bundled-sqlcipher-vendored-openssl"] }
-once_cell = "1.17"
 openssl = { workspace = true }
 rawsql = "0.1"
 reqwest = { workspace = true }

--- a/crate/utils/Cargo.toml
+++ b/crate/utils/Cargo.toml
@@ -10,15 +10,11 @@ curve25519 = []
 
 [dependencies]
 argon2 = "0.5.0"
-bitflags = { workspace = true }
 cloudproof = { workspace = true }
 cosmian_kmip = { path = "../kmip" }
-leb128 = { workspace = true }
 num-bigint = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-strum = { workspace = true }
-strum_macros = { workspace = true }
 thiserror = { workspace = true }
 tiny-keccak = { version = "2.0.2", features = ["shake"] } # TODO(E.C): should be fixed in cosmian_crypto_core
 tracing = { workspace = true }


### PR DESCRIPTION
- [x] check support of current KMS in cloudproof_js, cloudproof_java and cloudproof_python
- [x] remove useless dependencies (missed by cargo-udeps) 