### PR TITLE
(Re) Enable bootstrap server for non "enclaves" servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Bug Fixes
 
 - Improved database data structures using Maps and Sets instead of Vectors where uniqueness is required 
-
+- Enable bootstrap server for non "enclaves" servers
 
 ## [4.6.0] - 2023-09-01
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,7 +1206,7 @@ dependencies = [
 
 [[package]]
 name = "cosmian_kms_python"
-version = "4.7.0"
+version = "4.6.0"
 dependencies = [
  "cloudproof",
  "cosmian_kmip",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,13 +1206,12 @@ dependencies = [
 
 [[package]]
 name = "cosmian_kms_python"
-version = "4.6.0"
+version = "4.7.0"
 dependencies = [
  "cloudproof",
  "cosmian_kmip",
  "cosmian_kms_client",
  "cosmian_kms_utils",
- "leb128",
  "pyo3",
  "pyo3-asyncio",
  "pyo3-build-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "sha1",
  "smallvec",
  "tokio",
@@ -918,7 +918,7 @@ dependencies = [
  "chrono",
  "cosmian_crypto_core",
  "hex",
- "rand 0.8.5",
+ "rand",
  "rand_distr",
  "regex",
  "sha2",
@@ -1033,7 +1033,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "percent-encoding",
- "rand 0.8.5",
+ "rand",
  "sha2",
  "subtle",
  "time 0.3.17",
@@ -1093,7 +1093,7 @@ dependencies = [
  "p384",
  "pkcs8",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
  "sha2",
  "signature",
  "tiny-keccak",
@@ -1112,7 +1112,7 @@ dependencies = [
  "base64 0.21.4",
  "cosmian_crypto_core",
  "never",
- "rand 0.8.5",
+ "rand",
  "tiny-keccak",
  "zeroize",
 ]
@@ -1170,7 +1170,7 @@ dependencies = [
  "libsgx",
  "openssl",
  "predicates",
- "rand 0.8.5",
+ "rand",
  "ratls",
  "regex",
  "reqwest",
@@ -1212,6 +1212,7 @@ dependencies = [
  "cosmian_kmip",
  "cosmian_kms_client",
  "cosmian_kms_utils",
+ "leb128",
  "pyo3",
  "pyo3-asyncio",
  "pyo3-build-config",
@@ -1259,7 +1260,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "tempdir",
  "thiserror",
  "time 0.3.17",
  "tokio",
@@ -1360,7 +1360,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "740fe28e594155f10cfc383984cbefd529d7396050557148f79cb0f621204124"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -1372,7 +1372,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "typenum",
 ]
 
@@ -1671,7 +1671,7 @@ dependencies = [
  "hkdf",
  "pem-rfc7468",
  "pkcs8",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "subtle",
  "zeroize",
@@ -1769,7 +1769,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -1845,12 +1845,6 @@ checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
@@ -1999,7 +1993,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -2636,7 +2630,7 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "serde",
 ]
 
@@ -2652,7 +2646,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "zeroize",
 ]
@@ -2887,7 +2881,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
 dependencies = [
  "base64ct",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -2997,7 +2991,7 @@ checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "pkcs5",
- "rand_core 0.6.4",
+ "rand_core",
  "spki",
 ]
 
@@ -3048,7 +3042,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b79004a05337e54e8ffc0ec7470e40fa26eca6fe182968ec2b803247f2283c"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -3193,26 +3187,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -3222,23 +3203,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -3256,7 +3222,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -3270,7 +3236,7 @@ dependencies = [
  "der",
  "ecdsa",
  "p256",
- "rand 0.8.5",
+ "rand",
  "rand_chacha",
  "rustls 0.21.7",
  "sev_quote",
@@ -3287,15 +3253,6 @@ name = "rawsql"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f70b36c8415361d34d90adf494f45bc18e568f909b5946d27c79559ddd812fa8"
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
-]
 
 [[package]]
 name = "redis"
@@ -3378,15 +3335,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3466,7 +3414,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core 0.6.4",
+ "rand_core",
  "signature",
  "spki",
  "subtle",
@@ -3881,7 +3829,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 dependencies = [
  "digest",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -4090,7 +4038,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand 0.8.5",
+ "rand",
  "rsa",
  "serde",
  "sha1",
@@ -4129,7 +4077,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_json",
  "sha1",
@@ -4253,16 +4201,6 @@ name = "target-lexicon"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
-]
 
 [[package]]
 name = "tempfile"
@@ -4445,7 +4383,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
 dependencies = [
  "pin-project",
- "rand 0.8.5",
+ "rand",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ env_logger = "0.10"
 hex = "0.4"
 http = "0.2"
 josekit = "0.8.3"
+leb128 = "0.2"
 native-tls = "0.2"
 num-bigint = { version = "0.4", features = ["rand", "serde"] }
 openssl = { version = "0.10", features = ["vendored"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,6 @@ env_logger = "0.10"
 hex = "0.4"
 http = "0.2"
 josekit = "0.8.3"
-leb128 = "0.2"
 native-tls = "0.2"
 num-bigint = { version = "0.4", features = ["rand", "serde"] }
 openssl = { version = "0.10", features = ["vendored"] }

--- a/crate/server/Cargo.toml
+++ b/crate/server/Cargo.toml
@@ -64,7 +64,6 @@ sqlx = { version = "0.7.1", default-features = false, features = [
     "postgres",
     "sqlite",
 ] }
-tempdir = "0.3"
 thiserror = { workspace = true }
 time = { workspace = true, features = ["local-offset", "formatting"] }
 # this version of tokio should be the same as the one used in actix-web

--- a/crate/server/src/bootstrap_server/certificate/mod.rs
+++ b/crate/server/src/bootstrap_server/certificate/mod.rs
@@ -2,9 +2,9 @@
 //! It will attempt to generate a RA-TLS certificate if the target OS is Linux.
 //! If that fails or if the target OS is not Linux, it will generate a standard TLS certificate.
 //!
-//! The choice of making the detection OS-dependent is because RA-TLS is only supported on Linux via the ra_tls crate.
+//! The choice of making the detection OS-dependent is because RA-TLS is only supported on Linux via the ratls crate.
 //! This is debatable as the availability of enclave technology (SGX, TDX, SEV-SNP) is not OS-dependent.
-//! The ra_tls should support generating the self-signed cert on the given technologies (or lack thereof)
+//! The ratls crate should support generating the self-signed cert on the given technologies (or lack thereof)
 //! based on runtime detection of its availability.
 
 #[cfg(target_os = "linux")]

--- a/crate/server/src/bootstrap_server/certificate/mod.rs
+++ b/crate/server/src/bootstrap_server/certificate/mod.rs
@@ -1,0 +1,36 @@
+//! This module contains the code to generate a self-signed certificate for the server.
+//! It will attempt to generate a RA-TLS certificate if the target OS is Linux.
+//! If that fails or if the target OS is not Linux, it will generate a standard TLS certificate.
+//!
+//! The choice of making the detection OS-dependent is because RA-TLS is only supported on Linux via the ra_tls crate.
+//! This is debatable as the availability of enclave technology (SGX, TDX, SEV-SNP) is not OS-dependent.
+//! The ra_tls should support generating the self-signed cert on the given technologies (or lack thereof)
+//! based on runtime detection of its availability.
+
+#[cfg(target_os = "linux")]
+mod ra_tls;
+mod tls;
+
+use openssl::{
+    pkey::{PKey, Private},
+    x509::X509,
+};
+
+use crate::result::KResult;
+
+#[cfg(target_os = "linux")]
+pub(crate) fn generate_self_signed_cert(
+    subject: &str,
+    expiration_days: u64,
+) -> KResult<(PKey<Private>, X509)> {
+    ra_tls::generate_self_signed_ra_tls_cert(subject, expiration_days)
+        .or(tls::generate_self_signed_tls_cert(subject, expiration_days))
+}
+
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn generate_self_signed_cert(
+    subject: &str,
+    expiration_days: u64,
+) -> KResult<(PKey<Private>, X509)> {
+    tls::generate_self_signed_tls_cert(subject, expiration_days)
+}

--- a/crate/server/src/bootstrap_server/certificate/ra_tls.rs
+++ b/crate/server/src/bootstrap_server/certificate/ra_tls.rs
@@ -17,18 +17,3 @@ pub(crate) fn generate_self_signed_ra_tls_cert(
 
     Ok((private_key, cert))
 }
-
-#[cfg(test)]
-mod tests {
-    use crate::result::KResult;
-
-    #[test]
-    fn generate_self_signed_ra_tls_cert() -> KResult<()> {
-        let (_pkey, cert) = super::generate_self_signed_ra_tls_cert("test", 10)?;
-        assert_eq!(
-            format!("{:?}", cert.subject_name()),
-            format!("{:?}", cert.issuer_name())
-        );
-        Ok(())
-    }
-}

--- a/crate/server/src/bootstrap_server/certificate/ra_tls.rs
+++ b/crate/server/src/bootstrap_server/certificate/ra_tls.rs
@@ -1,0 +1,34 @@
+use openssl::{
+    pkey::{PKey, Private},
+    x509::X509,
+};
+use ratls::generate::generate_ratls_cert;
+
+use crate::{error, result::KResult};
+pub(crate) fn generate_self_signed_ra_tls_cert(
+    subject: &str,
+    expiration_days: u64,
+) -> KResult<(PKey<Private>, X509)> {
+    let (private_key, cert) = generate_ratls_cert(subject, vec![], expiration_days, None, true)
+        .map_err(|e| error::KmsError::RatlsError(e.to_string()))?;
+
+    let cert = X509::from_pem(cert.as_bytes())?;
+    let private_key = PKey::private_key_from_pem(private_key.as_bytes())?;
+
+    Ok((private_key, cert))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::result::KResult;
+
+    #[test]
+    fn generate_self_signed_ra_tls_cert() -> KResult<()> {
+        let (_pkey, cert) = super::generate_self_signed_ra_tls_cert("test", 10)?;
+        assert_eq!(
+            format!("{:?}", cert.subject_name()),
+            format!("{:?}", cert.issuer_name())
+        );
+        Ok(())
+    }
+}

--- a/crate/server/src/bootstrap_server/server.rs
+++ b/crate/server/src/bootstrap_server/server.rs
@@ -183,6 +183,10 @@ pub async fn start_https_bootstrap_server(
             .server_params
             .bootstrap_server_params
             .bootstrap_server_expiration_days,
+        bootstrap_server
+            .server_params
+            .bootstrap_server_params
+            .ensure_ra_tls,
     )?;
     // Create and configure an SSL acceptor with the certificate and key
     let mut builder = SslAcceptor::mozilla_intermediate(SslMethod::tls())?;

--- a/crate/server/src/config/command_line/bootstrap_server_config.rs
+++ b/crate/server/src/config/command_line/bootstrap_server_config.rs
@@ -31,6 +31,11 @@ pub struct BootstrapServerConfig {
     /// The hostname will be that configured in --hostname
     #[clap(long, env("KMS_BOOTSTRAP_SERVER_PORT"), default_value("9998"))]
     pub bootstrap_server_port: u16,
+
+    /// Ensure RA-TLS is available and used.
+    /// The server will not start if this is not the case.
+    #[clap(long, env("KMS_ENSURE_RA_TLS"), default_value("false"))]
+    pub ensure_ra_tls: bool,
 }
 
 impl Default for BootstrapServerConfig {
@@ -41,6 +46,7 @@ impl Default for BootstrapServerConfig {
                 .to_string(),
             bootstrap_server_port: 9998,
             bootstrap_server_expiration_days: 365,
+            ensure_ra_tls: false,
         }
     }
 }

--- a/crate/server/src/config/params/server_params.rs
+++ b/crate/server/src/config/params/server_params.rs
@@ -147,6 +147,10 @@ impl fmt::Debug for ServerParams {
                     .bootstrap_server_params
                     .bootstrap_server_expiration_days,
             )
+            .field(
+                "bootstrap server ensure RA-TLS",
+                &self.bootstrap_server_params.ensure_ra_tls,
+            )
         } else {
             &mut x
         };

--- a/crate/server/src/config/params/server_params.rs
+++ b/crate/server/src/config/params/server_params.rs
@@ -64,6 +64,10 @@ pub struct ServerParams {
 
     /// Use a bootstrap server (inside an enclave for instance)
     pub bootstrap_server_params: BootstrapServerParams,
+
+    /// Ensure RA-TLS is available and used.
+    /// The server will not start if this is not the case.
+    pub ensure_ra_tls: bool,
 }
 
 impl ServerParams {
@@ -105,6 +109,7 @@ impl ServerParams {
             force_default_username: conf.force_default_username,
             verify_cert,
             bootstrap_server_params: conf.bootstrap_server.clone(),
+            ensure_ra_tls: conf.bootstrap_server.ensure_ra_tls,
         };
         Ok(server_conf)
     }
@@ -206,6 +211,7 @@ impl Clone for ServerParams {
             enclave_params: self.enclave_params.clone(),
             verify_cert: self.verify_cert.clone(),
             bootstrap_server_params: self.bootstrap_server_params.clone(),
+            ensure_ra_tls: self.ensure_ra_tls,
         }
     }
 }

--- a/crate/server/src/core/operations/import.rs
+++ b/crate/server/src/core/operations/import.rs
@@ -49,14 +49,11 @@ fn parse_certificate_and_create_tags(
     let (_, x509) = parse_x509_certificate(&pem.contents)?;
 
     if !x509.validity().is_valid() {
-        return Err(KmsError::Certificate(format!(
-            "Cannot import expired certificate. Certificate details: {x509:?}"
-        )))
+        warn!(
+            "The certificate is expired. Certificate details: {:?}",
+            x509.validity()
+        );
     }
-    debug!(
-        "parse_certificate_and_create_tags: Certificate is not expired: {:?}",
-        x509.validity()
-    );
 
     let cert_spki = get_certificate_subject_key_identifier(&x509)?;
     debug!(

--- a/crate/server/src/lib.rs
+++ b/crate/server/src/lib.rs
@@ -2,7 +2,6 @@
 //! since it is declared, all the modules in other Files
 //! will be resolved against the lib. So everything is exported
 
-// #[cfg(target_os = "linux")]
 pub mod bootstrap_server;
 pub mod config;
 pub mod core;
@@ -16,7 +15,6 @@ pub mod routes;
 use std::{pin::Pin, sync::mpsc};
 
 use actix_web::dev::ServerHandle;
-// #[cfg(target_os = "linux")]
 use bootstrap_server::start_kms_server_using_bootstrap_server;
 use config::ServerParams;
 pub use database::KMSServer;

--- a/crate/server/src/lib.rs
+++ b/crate/server/src/lib.rs
@@ -2,7 +2,7 @@
 //! since it is declared, all the modules in other Files
 //! will be resolved against the lib. So everything is exported
 
-#[cfg(target_os = "linux")]
+// #[cfg(target_os = "linux")]
 pub mod bootstrap_server;
 pub mod config;
 pub mod core;
@@ -16,7 +16,7 @@ pub mod routes;
 use std::{pin::Pin, sync::mpsc};
 
 use actix_web::dev::ServerHandle;
-#[cfg(target_os = "linux")]
+// #[cfg(target_os = "linux")]
 use bootstrap_server::start_kms_server_using_bootstrap_server;
 use config::ServerParams;
 pub use database::KMSServer;
@@ -33,14 +33,10 @@ pub fn start_server(
     kms_server_handle_tx: Option<mpsc::Sender<ServerHandle>>,
 ) -> Pin<Box<dyn Future<Output = KResult<()>>>> {
     if server_params.bootstrap_server_params.use_bootstrap_server {
-        Box::pin(
-            #[cfg(not(target_os = "linux"))]
-            Box::new(futures::future::err(error::KmsError::NotSupported(
-                "Can't run bootstrap server on other OS than Linux".to_owned(),
-            ))),
-            #[cfg(target_os = "linux")]
-            start_kms_server_using_bootstrap_server(server_params, kms_server_handle_tx),
-        )
+        Box::pin(start_kms_server_using_bootstrap_server(
+            server_params,
+            kms_server_handle_tx,
+        ))
     } else {
         Box::pin(start_kms_server(server_params, kms_server_handle_tx))
     }

--- a/delivery/Dockerfile.standalone
+++ b/delivery/Dockerfile.standalone
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04 as builder
 
-LABEL version="4.6.0"
+LABEL version="4.6.1"
 LABEL name="Cosmian KMS docker container"
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/documentation/docs/bootstrap.md
+++ b/documentation/docs/bootstrap.md
@@ -22,6 +22,14 @@ Two options can be used to further configure the bootstrap server TLS connection
 
 - `--bootstrap-server-port <BOOTSTRAP_SERVER_PORT>` to specify the bootstrap server TLS port. The default value is `9998`. When changed, the docker port mapping must be updated accordingly.
 
+
+##### Running inside a confidential VM
+
+When [running in a zero-trust environment](./zero_trust.md) inside a confidential VM, the bootstrap server should be started with the `--ensure-ra-tls` option. This will ensure that the bootstrap server self-signed TLS certificate contains information (a `quote`) that will enable the `ckms` client to verify the correctness of the environment (correct confidential hardware and correct KMS server code). Such server certificate is called an "RA TLS certificate" where RA stands for "Remote Attestation".
+
+If the `ensure-ra-tls` option is enabled on a machine that does not have a confidential CPU, the bootstrap server will fail to start.
+
+
 #### Available configurations
 
 - Database: A database must be configured for the KMS server to start. If parameters have been passed on the command line, they will be overridden by those passed to the bootstrap server.

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -222,6 +222,11 @@ Options:
           [env: KMS_BOOTSTRAP_SERVER_PORT=]
           [default: 9998]
 
+      --ensure-ra-tls
+          Ensure RA-TLS is available and used. The server will not start if this is not the case
+          
+          [env: KMS_ENSURE_RA_TLS=]
+
       --root-data-path <ROOT_DATA_PATH>
           The root folder where the KMS will store its data A relative path is taken relative to the user HOME directory
 


### PR DESCRIPTION
A recent MR limits the use of the bootstrap server to "enclaves" and is doing an OS-dependent detection.
The bootstrap server may help supply configuration via API rather than on the command line, including on Linux.
Also, the PR was breaking tests for developers on MacOS.

This PR fixes these 3 issues. 

The mechanism can be further improved, and the following note was added in `bootstrap_server/certificate/mod.rs`

```
//! This module contains the code to generate a self-signed certificate for the server.
//!
//! On Linux: the code will attempt to generate a self-signed RA-TLS certificate.
//! If that fails and `ensure_ra_tls` is set the server will fail starting
//! otherwise it will generate a standard self-signed TLS certificate.
//!
//! On other targets, the code will generate a standard self-signed TLS certificate.
//! If `ensure_ra_tls` is set, the server will fail starting
//! with an error message explaining that RA-TLS is not available for this platform.
//!
//! The choice of making the detection OS-dependent is because RA-TLS is only supported on Linux via the ratls crate.
//! Intel and AMD stopped shipping drivers for other targets.

```