### PR TITLE
Improve error handling for KMIP data serialization

### DIFF
--- a/crate/kmip/src/kmip/mod.rs
+++ b/crate/kmip/src/kmip/mod.rs
@@ -1,4 +1,3 @@
-pub mod data_to_encrypt;
 pub mod kmip_data_structures;
 pub mod kmip_objects;
 pub mod kmip_operations;

--- a/crate/server/src/core/certificate/parsing.rs
+++ b/crate/server/src/core/certificate/parsing.rs
@@ -53,7 +53,7 @@ pub(crate) fn get_common_name(name: &X509Name<'_>) -> KResult<String> {
     // - no Common Name on a X509 certificate is forbidden
     // - multiple Common Name on a X509 certificate is forbidden...
 
-    debug!("get_common_name: name: {}", name);
+    debug!("get_common_name: name: {name}");
     let common_name = name
         .iter_common_name()
         .next()

--- a/crate/utils/src/crypto/cover_crypt/encryption.rs
+++ b/crate/utils/src/crypto/cover_crypt/encryption.rs
@@ -12,7 +12,6 @@ use cloudproof::reexport::{
 use cosmian_kmip::{
     error::KmipError,
     kmip::{
-        data_to_encrypt::DataToEncrypt,
         kmip_objects::Object,
         kmip_operations::{Encrypt, EncryptResponse, ErrorReason},
         kmip_types::{CryptographicAlgorithm, CryptographicParameters},
@@ -21,7 +20,10 @@ use cosmian_kmip::{
 use tracing::{debug, trace};
 
 use crate::{
-    crypto::cover_crypt::attributes::policy_from_attributes, error::KmipUtilsError,
+    crypto::{
+        cover_crypt::attributes::policy_from_attributes, generic::data_to_encrypt::DataToEncrypt,
+    },
+    error::KmipUtilsError,
     EncryptionSystem,
 };
 

--- a/crate/utils/src/crypto/generic/data_to_encrypt.rs
+++ b/crate/utils/src/crypto/generic/data_to_encrypt.rs
@@ -1,7 +1,7 @@
 use cloudproof::reexport::crypto_core::bytes_ser_de::{Deserializer, Serializer};
+use cosmian_kmip::{error::KmipError, kmip::kmip_operations::ErrorReason};
 
-use super::kmip_operations::ErrorReason;
-use crate::error::KmipError;
+use crate::error::KmipUtilsError;
 
 /// Structure used to encrypt with Covercrypt or ECIES
 ///
@@ -30,7 +30,7 @@ pub struct DataToEncrypt {
 impl DataToEncrypt {
     /// Serialize the data to encrypt to bytes
     #[must_use]
-    pub fn to_bytes(&self) -> Vec<u8> {
+    pub fn to_bytes(&self) -> Result<Vec<u8>, KmipUtilsError> {
         // Compute the size of the buffer
         let mut mem_size = 1 // for encryption policy
             + 1 // for metadata
@@ -45,24 +45,20 @@ impl DataToEncrypt {
         // Write the encryption policy
         let mut se = Serializer::with_capacity(mem_size);
         if let Some(encryption_policy) = &self.encryption_policy {
-            se.write_vec(encryption_policy.as_bytes())
-                .expect("cannot serialize enc policy vec");
+            se.write_vec(encryption_policy.as_bytes())?;
         } else {
-            se.write_leb128_u64(0)
-                .expect("cannot serialize enc policy 0 len");
+            se.write_leb128_u64(0)?;
         }
         // Write the metadata
         if let Some(metadata) = &self.header_metadata {
-            se.write_vec(metadata)
-                .expect("cannot serialize metadata vec");
+            se.write_vec(metadata)?;
         } else {
-            se.write_leb128_u64(0)
-                .expect("cannot serialize metadata 0 len");
+            se.write_leb128_u64(0)?;
         }
         // Write the plaintext
         let mut bytes = se.finalize().to_vec();
         bytes.extend_from_slice(&self.plaintext);
-        bytes
+        Ok(bytes)
     }
 
     pub fn try_from_bytes(bytes: &[u8]) -> Result<Self, KmipError> {
@@ -119,7 +115,7 @@ mod tests {
                 header_metadata: Some(String::from("äbcdef").into_bytes()),
                 plaintext: String::from("this is a plain text à è ").into_bytes(),
             };
-            let bytes = data_to_encrypt.to_bytes();
+            let bytes = data_to_encrypt.to_bytes().unwrap();
             let data_to_encrypt_full_deserialized = DataToEncrypt::try_from_bytes(&bytes).unwrap();
             assert_eq!(data_to_encrypt, data_to_encrypt_full_deserialized);
         }
@@ -130,7 +126,7 @@ mod tests {
                 header_metadata: None,
                 plaintext: String::from("this is a plain text à è ").into_bytes(),
             };
-            let bytes = data_to_encrypt.to_bytes();
+            let bytes = data_to_encrypt.to_bytes().unwrap();
             let data_to_encrypt_full_deserialized = DataToEncrypt::try_from_bytes(&bytes).unwrap();
             assert_eq!(data_to_encrypt, data_to_encrypt_full_deserialized);
         }
@@ -141,7 +137,7 @@ mod tests {
                 header_metadata: Some(String::from("äbcdef").into_bytes()),
                 plaintext: String::from("this is a plain text à è ").into_bytes(),
             };
-            let bytes = data_to_encrypt.to_bytes();
+            let bytes = data_to_encrypt.to_bytes().unwrap();
             let data_to_encrypt_full_deserialized = DataToEncrypt::try_from_bytes(&bytes).unwrap();
             assert_eq!(data_to_encrypt, data_to_encrypt_full_deserialized);
         }
@@ -152,7 +148,7 @@ mod tests {
                 header_metadata: None,
                 plaintext: String::from("this is a plain text à è ").into_bytes(),
             };
-            let bytes = data_to_encrypt.to_bytes();
+            let bytes = data_to_encrypt.to_bytes().unwrap();
             let data_to_encrypt_full_deserialized = DataToEncrypt::try_from_bytes(&bytes).unwrap();
             assert_eq!(data_to_encrypt, data_to_encrypt_full_deserialized);
         }

--- a/crate/utils/src/crypto/generic/kmip_requests.rs
+++ b/crate/utils/src/crypto/generic/kmip_requests.rs
@@ -1,7 +1,6 @@
 use cosmian_kmip::{
     error::KmipError,
     kmip::{
-        data_to_encrypt::DataToEncrypt,
         kmip_data_structures::KeyWrappingSpecification,
         kmip_objects::{Object, ObjectType},
         kmip_operations::{Decrypt, Encrypt, Import, Revoke},
@@ -11,6 +10,8 @@ use cosmian_kmip::{
         },
     },
 };
+
+use super::data_to_encrypt::DataToEncrypt;
 
 /// Build a `Revoke` request to revoke the key identified by `unique_identifier`
 pub fn build_revoke_key_request(
@@ -47,6 +48,7 @@ pub fn build_encryption_request(
             plaintext,
         }
         .to_bytes()
+        .map_err(|e| KmipError::NotSupported(e.to_string()))?
     } else {
         plaintext
     };

--- a/crate/utils/src/crypto/generic/kmip_requests.rs
+++ b/crate/utils/src/crypto/generic/kmip_requests.rs
@@ -3,7 +3,7 @@ use cosmian_kmip::{
     kmip::{
         kmip_data_structures::KeyWrappingSpecification,
         kmip_objects::{Object, ObjectType},
-        kmip_operations::{Decrypt, Encrypt, Import, Revoke},
+        kmip_operations::{Decrypt, Encrypt, ErrorReason, Import, Revoke},
         kmip_types::{
             Attributes, CryptographicAlgorithm, CryptographicParameters, KeyWrapType,
             RevocationReason,
@@ -48,7 +48,7 @@ pub fn build_encryption_request(
             plaintext,
         }
         .to_bytes()
-        .map_err(|e| KmipError::NotSupported(e.to_string()))?
+        .map_err(|e| KmipError::KmipError(ErrorReason::Invalid_Message, e.to_string()))?
     } else {
         plaintext
     };

--- a/crate/utils/src/crypto/generic/mod.rs
+++ b/crate/utils/src/crypto/generic/mod.rs
@@ -1,1 +1,2 @@
+pub mod data_to_encrypt;
 pub mod kmip_requests;


### PR DESCRIPTION
- Move the `DataToEncrypt` struct outside `kmip` crate to `utils` crate
- Use `Result` instead of unwrapping + rework calling sites

fixes #46 