### PR TITLE
Serialize encrypted header for each chunk

### DIFF
--- a/crate/cli/src/actions/cover_crypt/encrypt.rs
+++ b/crate/cli/src/actions/cover_crypt/encrypt.rs
@@ -1,17 +1,14 @@
-use std::{fs::File, io::Write, path::PathBuf};
+use std::path::PathBuf;
 
 use clap::Parser;
-use cloudproof::reexport::{
-    cover_crypt::EncryptedHeader,
-    crypto_core::bytes_ser_de::{Deserializer, Serializable},
-};
 use cosmian_kmip::kmip::kmip_types::CryptographicAlgorithm;
 use cosmian_kms_client::KmsRestClient;
 use cosmian_kms_utils::crypto::generic::kmip_requests::build_encryption_request;
 
 use crate::{
     actions::shared::utils::{
-        read_bytes_from_file, read_bytes_from_files_to_bulk, write_single_encrypted_data,
+        read_bytes_from_file, read_bytes_from_files_to_bulk, write_bulk_encrypted_data,
+        write_single_encrypted_data,
     },
     cli_bail,
     error::{result::CliResultHelper, CliError},
@@ -99,100 +96,11 @@ impl EncryptAction {
             .data
             .context("The encrypted data are empty")?;
 
-        // Write the encrypted files
+        // Write the encrypted data
         if cryptographic_algorithm == CryptographicAlgorithm::CoverCryptBulk {
-            self.write_bulk_encrypted_data(&data)
+            write_bulk_encrypted_data(&data, &self.input_files, self.output_file.as_ref())
         } else {
             write_single_encrypted_data(&data, &self.input_files[0], self.output_file.as_ref())
         }
-    }
-
-    /// Store multiple encrypted data on disk
-    ///
-    /// The input data is serialized using LEB128 (bulk mode).
-    /// Each chunk of data will be stored in its own file on disk.
-    ///
-    /// Each file written begins with a copy of the encrypted header, this way
-    /// any chunk serialized in a file is usable on its own.
-    ///
-    /// Bulk encryption / decryption scheme
-    ///
-    /// ENC request
-    /// | `nb_chunks` (LEB128) | `chunk_size` (LEB128) | `chunk_data` (plaintext)
-    ///                           <-------------- `nb_chunks` times ------------>
-    ///
-    /// ENC response
-    /// | EH | `nb_chunks` (LEB128) | `chunk_size` (LEB128) | `chunk_data` (encrypted)
-    ///                                <-------------- `nb_chunks` times ------------>
-    ///
-    /// DEC request
-    /// | `nb_chunks` (LEB128) | size(EH + `chunk_data`) (LEB128) | EH | `chunk_data` (encrypted)
-    ///                                                             <------ chunk with EH ------>
-    ///                          <------------------------ `nb_chunks` times ------------------->
-    ///
-    /// DEC response
-    /// | `nb_chunks` (LEB128) | `chunk_size` (LEB128) | `chunk_data` (plaintext)
-    ///                           <------------- `nb_chunks` times ------------->
-    ///
-    fn write_bulk_encrypted_data(&self, encrypted_data: &[u8]) -> Result<(), CliError> {
-        // read encrypted header
-        let mut de = Deserializer::new(encrypted_data);
-        let encrypted_header = EncryptedHeader::read(&mut de)
-            .map_err(|_| {
-                CliError::Conversion(
-                    "Unable to recognize encrypted header structure from slice".to_string(),
-                )
-            })?
-            .serialize()
-            .map_err(|_| {
-                CliError::Conversion(
-                    "Unable to serialize encrypted header structure to bytes".to_string(),
-                )
-            })?;
-
-        // number of encrypted chunks
-        let nb_chunks = {
-            let len = de.read_leb128_u64()?;
-            usize::try_from(len).map_err(|_| {
-                CliError::Conversion(format!(
-                    "size of vector is too big for architecture: {len} bytes",
-                ))
-            })?
-        };
-
-        (0..nb_chunks).try_for_each(|idx| {
-            // get chunk of data from slice
-            let chunk_data = de.read_vec_as_ref()?;
-
-            // reuse input file names if there are multiple inputs (and ignore `self.output_file`)
-            let output_file = if nb_chunks == 1 {
-                self.output_file
-                    .clone()
-                    .unwrap_or_else(|| self.input_files[idx].with_extension("enc"))
-            } else if let Some(output_file) = &self.output_file {
-                let file_name = &self.input_files[idx].file_name().ok_or_else(|| {
-                    CliError::Conversion(format!(
-                        "cannot get file name from input file {:?}",
-                        self.input_files[idx],
-                    ))
-                })?;
-                output_file.join(PathBuf::from(file_name).with_extension("enc"))
-            } else {
-                self.input_files[idx].with_extension("enc")
-            };
-
-            let mut buffer =
-                File::create(&output_file).with_context(|| "failed to write the encrypted file")?;
-
-            buffer
-                .write_all(&encrypted_header)
-                .with_context(|| "failed to write the encrypted header to file")?;
-            buffer
-                .write_all(chunk_data)
-                .with_context(|| "failed to write the encrypted data to file")?;
-
-            println!("The encrypted file is available at {output_file:?}");
-            Ok(())
-        })
     }
 }

--- a/crate/cli/src/actions/shared/utils/file_utils.rs
+++ b/crate/cli/src/actions/shared/utils/file_utils.rs
@@ -206,7 +206,12 @@ pub fn read_bytes_from_files_to_bulk(input_files: &[PathBuf]) -> Result<Vec<u8>,
     Ok(ser.finalize().to_vec())
 }
 
-/// Write each decrypted data to its own file.
+/// Write bulk decrypted data
+///
+/// Bulk data is compound of multiple chunks of data.
+/// Sizes are written using LEB-128 serialization.
+///
+/// Each chunk of plaintext data is written to its own file.
 pub fn write_bulk_decrypted_data(
     plaintext: &[u8],
     input_files: &[PathBuf],
@@ -228,28 +233,81 @@ pub fn write_bulk_decrypted_data(
         // get chunk of data from slice
         let chunk_data = de.read_vec_as_ref()?;
 
-        // Write the decrypted files
+        // Write plaintext data to its own file
         // Reuse input file names if there are multiple inputs (and ignore `output_file`)
-        let output_file = if nb_chunks == 1 {
-            output_file.map_or_else(
-                || input_files[idx].with_extension("plain"),
+        let input_file = &input_files[idx];
+        let output_file = match output_file {
+            Some(output_file) if nb_chunks > 1 => {
+                let file_name = input_file.file_name().ok_or_else(|| {
+                    CliError::Conversion(format!(
+                        "cannot get file name from input file {input_file:?}",
+                    ))
+                })?;
+                output_file.join(PathBuf::from(file_name).with_extension("plain"))
+            }
+            _ => output_file.map_or_else(
+                || input_file.with_extension("plain"),
                 std::clone::Clone::clone,
-            )
-        } else if let Some(output_file) = &output_file {
-            let file_name = input_files[idx].file_name().ok_or_else(|| {
-                CliError::Conversion(format!(
-                    "cannot get file name from input file {:?}",
-                    input_files[idx],
-                ))
-            })?;
-            output_file.join(PathBuf::from(file_name).with_extension("plain"))
-        } else {
-            input_files[idx].with_extension("plain")
+            ),
         };
 
         write_bytes_to_file(chunk_data, &output_file)?;
 
         println!("The decrypted file is available at {output_file:?}");
+        Ok(())
+    })
+}
+
+/// Write bulk encrypted data
+///
+/// Bulk data is compound of multiple chunks of data.
+/// Sizes are written using LEB-128 serialization.
+///
+/// Each chunk of data:
+/// - is compound of encrypted header + encrypted data
+/// - is written to its own file.
+pub fn write_bulk_encrypted_data(
+    plaintext: &[u8],
+    input_files: &[PathBuf],
+    output_file: Option<&PathBuf>,
+) -> Result<(), CliError> {
+    let mut de = Deserializer::new(plaintext);
+
+    // number of encrypted chunks
+    let nb_chunks = {
+        let len = de.read_leb128_u64()?;
+        usize::try_from(len).map_err(|_| {
+            CliError::Conversion(format!(
+                "size of vector is too big for architecture: {len} bytes",
+            ))
+        })?
+    };
+
+    (0..nb_chunks).try_for_each(|idx| {
+        // get chunk of data from slice
+        let chunk_data = de.read_vec_as_ref()?;
+
+        // Write encrypted data to its own file
+        // Reuse input file names if there are multiple inputs (and ignore `output_file`)
+        let input_file = &input_files[idx];
+        let output_file = match output_file {
+            Some(output_file) if nb_chunks > 1 => {
+                let file_name = input_file.file_name().ok_or_else(|| {
+                    CliError::Conversion(format!(
+                        "cannot get file name from input file {input_file:?}",
+                    ))
+                })?;
+                output_file.join(PathBuf::from(file_name).with_extension("enc"))
+            }
+            _ => output_file.map_or_else(
+                || input_file.with_extension("enc"),
+                std::clone::Clone::clone,
+            ),
+        };
+
+        write_bytes_to_file(chunk_data, &output_file)?;
+
+        println!("The encrypted file is available at {output_file:?}");
         Ok(())
     })
 }

--- a/crate/utils/src/crypto/cover_crypt/decryption.rs
+++ b/crate/utils/src/crypto/cover_crypt/decryption.rs
@@ -84,6 +84,26 @@ impl CovercryptDecryption {
     ///
     /// The input encrypted data is serialized using LEB128 (bulk mode).
     /// Each chunk of data is decrypted and serialized back to LEB128.
+    ///
+    /// Bulk encryption / decryption scheme
+    ///
+    /// ENC request
+    /// | `nb_chunks` (LEB128) | `chunk_size` (LEB128) | `chunk_data` (plaintext)
+    ///                           <-------------- `nb_chunks` times ------------>
+    ///
+    /// ENC response
+    /// | EH | `nb_chunks` (LEB128) | `chunk_size` (LEB128) | `chunk_data` (encrypted)
+    ///                                <-------------- `nb_chunks` times ------------>
+    ///
+    /// DEC request
+    /// | `nb_chunks` (LEB128) | size(EH + `chunk_data`) (LEB128) | EH | `chunk_data` (encrypted)
+    ///                                                             <------ chunk with EH ------>
+    ///                          <------------------------ `nb_chunks` times ------------------->
+    ///
+    /// DEC response
+    /// | `nb_chunks` (LEB128) | `chunk_size` (LEB128) | `chunk_data` (plaintext)
+    ///                           <------------- `nb_chunks` times ------------->
+    ///
     fn bulk_decrypt(
         &self,
         encrypted_bytes: &[u8],


### PR DESCRIPTION
It facilitates the work for clients, as they do not need to the deserialization of the encrypted header first, and just need to consider a chunk (enc header + enc data) as a blob of data to store. 