### PR TITLE
Automatic generation of CLI documentation

### DIFF
--- a/crate/cli/src/actions/markdown.rs
+++ b/crate/cli/src/actions/markdown.rs
@@ -106,6 +106,7 @@ fn write_command(
                 }
                 write!(out, "`]")?;
             }
+            writeln!(out)?;
         }
         writeln!(out)?;
     }

--- a/crate/cli/src/actions/markdown.rs
+++ b/crate/cli/src/actions/markdown.rs
@@ -1,0 +1,186 @@
+use std::{fmt::Write, fs::File, io::Write as io_Write};
+
+use clap::{builder::StyledStr, Command, Parser};
+
+use crate::error::CliError;
+
+/// Generate the CLI documentation as markdown
+#[derive(Parser, Debug)]
+pub struct MarkdownAction {}
+
+impl MarkdownAction {
+    pub async fn process(&self, cmd: &Command) -> Result<(), CliError> {
+        let mut output = String::new();
+
+        write_command(&mut output, "", "", cmd)?;
+
+        println!("{}", output);
+        let mut f = File::create("/tmp/output.md")?;
+        f.write_all(output.as_bytes())?;
+
+        Ok(())
+    }
+}
+
+fn write_command(
+    out: &mut dyn Write,
+    index: &str,
+    parent: &str,
+    cmd: &Command,
+) -> Result<(), CliError> {
+    if !parent.is_empty() {
+        writeln!(out, "---")?;
+        writeln!(out)?;
+    }
+    let full_command = if parent.is_empty() {
+        "ckms".to_string()
+    } else {
+        format!("{} {}", parent, cmd.get_name())
+    };
+    writeln!(out, "## {index} {full_command}")?;
+
+    writeln!(
+        out,
+        "**{:?}**",
+        cmd.get_about()
+            .map(|about| about.to_string())
+            .unwrap_or_default()
+    )?;
+    writeln!(out, "### Usage")?;
+    write!(out, "`{full_command}")?;
+    if cmd.has_subcommands() {
+        write!(out, " <subcommand>")?;
+    }
+    if cmd.get_arguments().next().is_some() {
+        write!(out, " [options]")?;
+    }
+    for pos in cmd.get_positionals() {
+        writeln!(out, " {}", pos)?;
+    }
+    writeln!(out, "`")?;
+
+    for (i, arg) in cmd.get_arguments().enumerate() {
+        if i == 0 {
+            writeln!(out, "### Arguments")?;
+        }
+        write!(out, "`")?;
+        if let Some(long) = arg.get_long() {
+            write!(out, "--{}", long)?;
+        }
+        if let Some(short) = arg.get_short() {
+            write!(out, " [-{}]", short)?;
+        }
+        if let Some(n) = arg.get_value_names() {
+            if let Some(n) = n.get(0) {
+                write!(out, " <{}>", n)?;
+            }
+        }
+        write!(out, "`")?;
+        if let Some(help) = arg.get_help() {
+            write!(out, " ")?;
+            to_md(out, help)?;
+        }
+        if !arg.get_possible_values().is_empty() {
+            writeln!(out)?;
+            write!(out, "Possible values:  `")?;
+            for (i, pv) in arg.get_possible_values().iter().enumerate() {
+                if i > 0 {
+                    write!(out, ", ")?;
+                }
+                write!(out, "{:?}", pv.get_name())?;
+            }
+            write!(out, "`")?;
+            let default_values = arg.get_default_values();
+            if !default_values.is_empty() {
+                write!(out, " [default: `")?;
+                for (i, default_value) in default_values.iter().enumerate() {
+                    if i > 0 {
+                        write!(out, ", ")?;
+                    }
+                    write!(out, "{:?}", default_value)?;
+                }
+                write!(out, "`]")?;
+            }
+        }
+        writeln!(out)?;
+    }
+
+    writeln!(out)?;
+    let sub_commands = write_subcommands(out, index, &full_command, cmd)?;
+    for (i, sub_command) in sub_commands.into_iter().enumerate() {
+        let index = if index.is_empty() {
+            format!("{}", i + 1)
+        } else {
+            format!("{}.{}", index, i + 1)
+        };
+        write_command(out, &index, &full_command, sub_command)?;
+    }
+    writeln!(out)?;
+    Ok(())
+}
+
+fn write_subcommands<'a>(
+    write: &mut dyn Write,
+    parent_index: &str,
+    parent_command: &str,
+    cmd: &'a Command,
+) -> Result<Vec<&'a Command>, CliError> {
+    let mut sc = Vec::new();
+    for (i, sub_command) in cmd.get_subcommands().enumerate() {
+        if i == 0 {
+            writeln!(write, "### Subcommands")?;
+            writeln!(write)?;
+        }
+        let index = if parent_index.is_empty() {
+            format!("{}", i + 1)
+        } else {
+            format!("{}.{}", parent_index, i + 1)
+        };
+        let full_command = if parent_command.is_empty() {
+            sub_command.get_name().to_string()
+        } else {
+            format!("{} {}", parent_command, sub_command.get_name())
+        };
+        let sub_command_anchor = format!("{index} {full_command}")
+            .to_lowercase()
+            .replace(' ', "-")
+            .replace('.', "");
+        write!(write, "**`{}`**", sub_command.get_name())?;
+        write!(write, " [[{index}]](#{sub_command_anchor}) ")?;
+        if let Some(about) = sub_command.get_about() {
+            write!(write, " ")?;
+            to_md(write, about)?;
+        }
+        writeln!(write)?;
+        sc.push(sub_command);
+    }
+    Ok(sc)
+}
+
+fn to_md(out: &mut dyn Write, ss: &StyledStr) -> Result<(), CliError> {
+    let s = ss.to_string();
+    let split = s.split('\n');
+    let mut in_list = false;
+    for line in split {
+        if in_list {
+            if line.trim().starts_with('-') {
+                // still in list
+                writeln!(out, "{}", line)?;
+            } else {
+                // no more in list
+                in_list = false;
+                writeln!(out)?;
+                writeln!(out, "{}", line)?;
+            }
+        } else if line.trim().starts_with('-') {
+            // first line of list
+            in_list = true;
+            writeln!(out)?;
+            writeln!(out, "{}", line)?;
+        } else {
+            // still not in list
+            writeln!(out, "{}", line)?;
+        }
+    }
+    Ok(())
+}

--- a/crate/cli/src/actions/mod.rs
+++ b/crate/cli/src/actions/mod.rs
@@ -5,6 +5,7 @@ pub mod cover_crypt;
 pub mod elliptic_curves;
 pub mod login;
 pub mod logout;
+pub mod markdown;
 pub mod new_database;
 pub mod shared;
 pub mod symmetric;

--- a/crate/cli/src/error/mod.rs
+++ b/crate/cli/src/error/mod.rs
@@ -1,5 +1,7 @@
 use std::{array::TryFromSliceError, str::Utf8Error};
 
+#[cfg(test)]
+use assert_cmd::cargo::CargoError;
 use cosmian_kmip::{
     error::KmipError,
     kmip::{kmip_operations::ErrorReason, ttlv::error::TtlvError},
@@ -9,10 +11,8 @@ use cosmian_kms_utils::error::KmipUtilsError;
 use openssl::error::ErrorStack;
 use pem::PemError;
 use thiserror::Error;
-pub mod result;
 
-#[cfg(test)]
-use assert_cmd::cargo::CargoError;
+pub mod result;
 
 // Each error type must have a corresponding HTTP status code (see `kmip_endpoint.rs`)
 #[derive(Error, Debug)]
@@ -203,6 +203,12 @@ impl From<RestClientError> for CliError {
 impl From<PemError> for CliError {
     fn from(e: PemError) -> Self {
         Self::Conversion(format!("PEM error: {}", e))
+    }
+}
+
+impl From<std::fmt::Error> for CliError {
+    fn from(e: std::fmt::Error) -> Self {
+        Self::Default(e.to_string())
     }
 }
 

--- a/crate/cli/src/main.rs
+++ b/crate/cli/src/main.rs
@@ -1,6 +1,6 @@
 use std::process;
 
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
 use cosmian_kms_cli::{
     actions::{
         access::AccessAction,
@@ -10,6 +10,7 @@ use cosmian_kms_cli::{
         elliptic_curves::EllipticCurveCommands,
         login::LoginAction,
         logout::LogoutAction,
+        markdown::MarkdownAction,
         new_database::NewDatabaseAction,
         shared::{GetAttributesAction, LocateObjectsAction},
         symmetric::SymmetricCommands,
@@ -42,6 +43,7 @@ enum CliCommands {
     Ec(EllipticCurveCommands),
     GetAttributes(GetAttributesAction),
     Locate(LocateObjectsAction),
+    Markdown(MarkdownAction),
     NewDatabase(NewDatabaseAction),
     ServerVersion(ServerVersionAction),
     #[command(subcommand)]
@@ -78,6 +80,12 @@ async fn main_() -> Result<(), CliError> {
         return Ok(())
     }
 
+    if let CliCommands::Markdown(action) = opts.command {
+        let command = <Cli as CommandFactory>::command();
+        action.process(&command).await?;
+        return Ok(())
+    }
+
     let kms_rest_client = conf.initialize_kms_client()?;
 
     match opts.command {
@@ -93,6 +101,9 @@ async fn main_() -> Result<(), CliError> {
         CliCommands::GetAttributes(action) => action.process(&kms_rest_client).await?,
         CliCommands::Login(action) => action.process().await?,
         CliCommands::Logout(action) => action.process().await?,
+        _ => {
+            println!("Error");
+        }
     };
 
     Ok(())

--- a/crate/cli/src/main.rs
+++ b/crate/cli/src/main.rs
@@ -43,7 +43,6 @@ enum CliCommands {
     Ec(EllipticCurveCommands),
     GetAttributes(GetAttributesAction),
     Locate(LocateObjectsAction),
-    Markdown(MarkdownAction),
     NewDatabase(NewDatabaseAction),
     ServerVersion(ServerVersionAction),
     #[command(subcommand)]
@@ -51,6 +50,7 @@ enum CliCommands {
     Verify(TeeAction),
     Login(LoginAction),
     Logout(LogoutAction),
+    Markdown(MarkdownAction),
 }
 
 #[tokio::main]


### PR DESCRIPTION
This PR adds a `markdown` command to the `ckms` CLI to automatically generate the CLI documentation.

Example output:  [output.md](https://github.com/Cosmian/kms/files/13502306/output.md)