### PR TITLE
ECIES implementation for Hybrid Encryption

### DIFF
--- a/crate/cli/src/tests/certificates/encrypt.rs
+++ b/crate/cli/src/tests/certificates/encrypt.rs
@@ -147,6 +147,7 @@ pub fn decrypt(
 //     Ok(())
 // }
 
+#[cfg(not(feature = "fips"))]
 async fn test_certificate_import_encrypt(
     ca_path: &str,
     subca_path: &str,
@@ -251,6 +252,7 @@ async fn test_certificate_import_encrypt(
 }
 
 #[tokio::test]
+#[cfg(not(feature = "fips"))]
 async fn test_certificate_import_ca_and_encrypt_using_x25519() -> Result<(), CliError> {
     test_certificate_import_encrypt(
         "p12/root.pem",

--- a/crate/cli/src/tests/elliptic_curve/mod.rs
+++ b/crate/cli/src/tests/elliptic_curve/mod.rs
@@ -1,4 +1,5 @@
 pub mod create_key_pair;
+#[cfg(not(feature = "fips"))]
 pub mod encrypt_decrypt;
 
 pub(crate) const SUB_COMMAND: &str = "ec";

--- a/crate/utils/src/crypto/curve_25519/operation.rs
+++ b/crate/utils/src/crypto/curve_25519/operation.rs
@@ -17,9 +17,9 @@ use openssl::{
 
 use crate::{error::KmipUtilsError, kmip_utils_bail, KeyPair};
 
-pub const X25519_SECRET_LENGTH: usize = 0x20;
+pub const X25519_PRIVATE_KEY_LENGTH: usize = 0x20;
 pub const X25519_PUBLIC_KEY_LENGTH: usize = 0x20;
-pub const ED25519_SECRET_LENGTH: usize = 0x20;
+pub const ED25519_PRIVATE_KEY_LENGTH: usize = 0x20;
 pub const ED25519_PUBLIC_KEY_LENGTH: usize = 0x20;
 pub const Q_LENGTH_BITS: i32 = 253;
 
@@ -269,14 +269,14 @@ mod tests {
     #[cfg(not(feature = "fips"))]
     use openssl::pkey::{Id, PKey};
 
+    #[cfg(not(feature = "fips"))]
+    use super::X25519_PRIVATE_KEY_LENGTH;
     use super::{
         create_ed25519_key_pair, create_p224_key_pair, create_p256_key_pair, create_p384_key_pair,
         create_p521_key_pair,
     };
     #[cfg(not(feature = "fips"))]
     use super::{create_p192_key_pair, create_x25519_key_pair};
-    #[cfg(not(feature = "fips"))]
-    const X25519_SECRET_LENGTH: usize = 0x20;
 
     #[test]
     fn test_ed25519_keypair_generation() {
@@ -467,7 +467,7 @@ mod tests {
             KeyMaterial::TransparentECPrivateKey { d, .. } => d.to_bytes_be(),
             _ => panic!("Not a transparent private key"),
         };
-        pad_be_bytes(&mut original_private_key_bytes, X25519_SECRET_LENGTH);
+        pad_be_bytes(&mut original_private_key_bytes, X25519_PRIVATE_KEY_LENGTH);
         // try to convert to openssl
         let p_key =
             PKey::private_key_from_raw_bytes(&original_private_key_bytes, Id::X25519).unwrap();

--- a/crate/utils/src/crypto/curve_25519/operation.rs
+++ b/crate/utils/src/crypto/curve_25519/operation.rs
@@ -17,6 +17,8 @@ use openssl::{
 
 use crate::{error::KmipUtilsError, kmip_utils_bail, KeyPair};
 
+pub const X25519_SECRET_LENGTH: usize = 0x20;
+pub const X25519_PUBLIC_KEY_LENGTH: usize = 0x20;
 pub const ED25519_SECRET_LENGTH: usize = 0x20;
 pub const ED25519_PUBLIC_KEY_LENGTH: usize = 0x20;
 pub const Q_LENGTH_BITS: i32 = 253;

--- a/crate/utils/src/crypto/hybrid_encryption/decryption.rs
+++ b/crate/utils/src/crypto/hybrid_encryption/decryption.rs
@@ -77,7 +77,6 @@ impl DecryptionSystem for HybridDecryptionSystem {
             }
             #[cfg(not(feature = "fips"))]
             Id::X25519 => {
-                // The raw public key happens to be the (compressed) value of the Montgomery point
                 let raw_bytes = self.private_key.raw_private_key()?;
                 let private_key_bytes: [u8; X25519_PRIVATE_KEY_LENGTH] = raw_bytes.try_into()?;
                 let private_key = X25519PrivateKey::try_from_bytes(private_key_bytes)?;

--- a/crate/utils/src/crypto/hybrid_encryption/decryption.rs
+++ b/crate/utils/src/crypto/hybrid_encryption/decryption.rs
@@ -12,7 +12,9 @@ use zeroize::Zeroizing;
 
 use super::{ecies::ecies_decrypt, rsa_oaep_aes_gcm::rsa_oaep_aes_gcm_decrypt};
 #[cfg(not(feature = "fips"))]
-use crate::crypto::curve_25519::operation::{ED25519_SECRET_LENGTH, X25519_SECRET_LENGTH};
+use crate::crypto::curve_25519::operation::{
+    ED25519_PRIVATE_KEY_LENGTH, X25519_PRIVATE_KEY_LENGTH,
+};
 use crate::{
     crypto::wrap::rsa_oaep_aes_kwp::ckm_rsa_aes_key_unwrap, error::KmipUtilsError, kmip_utils_bail,
     DecryptionSystem,
@@ -71,7 +73,7 @@ impl DecryptionSystem for HybridDecryptionSystem {
             #[cfg(not(feature = "fips"))]
             Id::ED25519 => {
                 let raw_bytes = self.private_key.raw_private_key()?;
-                let private_key_bytes: [u8; ED25519_SECRET_LENGTH] = raw_bytes.try_into()?;
+                let private_key_bytes: [u8; ED25519_PRIVATE_KEY_LENGTH] = raw_bytes.try_into()?;
                 let private_key = Ed25519PrivateKey::try_from_bytes(private_key_bytes)?;
                 let private_key = X25519PrivateKey::from_ed25519_private_key(&private_key);
                 Zeroizing::new(EciesSalsaSealBox::decrypt(&private_key, ciphertext, None)?)
@@ -80,7 +82,7 @@ impl DecryptionSystem for HybridDecryptionSystem {
             Id::X25519 => {
                 // The raw public key happens to be the (compressed) value of the Montgomery point
                 let raw_bytes = self.private_key.raw_private_key()?;
-                let private_key_bytes: [u8; X25519_SECRET_LENGTH] = raw_bytes.try_into()?;
+                let private_key_bytes: [u8; X25519_PRIVATE_KEY_LENGTH] = raw_bytes.try_into()?;
                 let private_key = X25519PrivateKey::try_from_bytes(private_key_bytes)?;
                 Zeroizing::new(EciesSalsaSealBox::decrypt(&private_key, ciphertext, None)?)
             }

--- a/crate/utils/src/crypto/hybrid_encryption/decryption.rs
+++ b/crate/utils/src/crypto/hybrid_encryption/decryption.rs
@@ -52,8 +52,7 @@ impl DecryptionSystem for HybridDecryptionSystem {
 
         // Convert the Pkey to a crypto_core curve and perform decryption
         // Note: All conversions below will go once we move to full openssl
-        let id = self.private_key.id();
-        let plaintext = match id {
+        let plaintext = match self.private_key.id() {
             Id::EC => Zeroizing::new(ecies_decrypt(&self.private_key, ciphertext)?),
             Id::RSA => {
                 if self.key_unwrapping {
@@ -85,8 +84,8 @@ impl DecryptionSystem for HybridDecryptionSystem {
                 let private_key = X25519PrivateKey::try_from_bytes(private_key_bytes)?;
                 Zeroizing::new(EciesSalsaSealBox::decrypt(&private_key, ciphertext, None)?)
             }
-            _ => {
-                kmip_utils_bail!("Public key id not supported yet: {:?}", id);
+            x => {
+                kmip_utils_bail!("private key id not supported yet: {:?}", x);
             }
         };
 

--- a/crate/utils/src/crypto/hybrid_encryption/decryption.rs
+++ b/crate/utils/src/crypto/hybrid_encryption/decryption.rs
@@ -58,13 +58,10 @@ impl DecryptionSystem for HybridDecryptionSystem {
             Id::EC => Zeroizing::new(ecies_decrypt(&self.private_key, ciphertext)?),
             Id::RSA => {
                 if self.key_unwrapping {
-                    Zeroizing::from(ckm_rsa_aes_key_unwrap(
-                        self.private_key.clone(),
-                        ciphertext,
-                    )?)
+                    Zeroizing::from(ckm_rsa_aes_key_unwrap(&self.private_key, ciphertext)?)
                 } else {
                     Zeroizing::from(rsa_oaep_aes_gcm_decrypt(
-                        self.private_key.clone(),
+                        &self.private_key,
                         ciphertext,
                         request.authenticated_encryption_additional_data.as_deref(),
                     )?)

--- a/crate/utils/src/crypto/hybrid_encryption/ecies.rs
+++ b/crate/utils/src/crypto/hybrid_encryption/ecies.rs
@@ -30,8 +30,8 @@ fn ecies_get_iv(
     let mut iv = vec![0; AES_256_GCM_IV_LENGTH];
 
     let mut hasher = Hasher::new(MessageDigest::shake_128())?;
-    hasher.update(&Q_bytes)?;
     hasher.update(&R_bytes)?;
+    hasher.update(&Q_bytes)?;
     hasher.finish_xof(&mut iv)?;
 
     Ok(iv)
@@ -72,7 +72,7 @@ pub fn ecies_encrypt(pubkey: &PKey<Public>, plaintext: &[u8]) -> Result<Vec<u8>,
 
     #[cfg(feature = "fips")]
     if curve.curve_name() == Some(Nid::X9_62_PRIME192V1) {
-        kmip_utils_bail!("Curve P-192 not allowed in FIPS mode.")
+        kmip_utils_bail!("ECIES: Curve P-192 not allowed in FIPS mode.")
     }
 
     // Generating random ephemeral private key `r` and associated public key
@@ -126,14 +126,14 @@ pub fn ecies_decrypt(
 
     #[cfg(feature = "fips")]
     if curve.curve_name() == Some(Nid::X9_62_PRIME192V1) {
-        kmip_utils_bail!("Curve P-192 not allowed in FIPS mode.")
+        kmip_utils_bail!("ECIES: Curve P-192 not allowed in FIPS mode.")
     }
 
     // OpenSSL stored compressed coordinates with one extra byte for some
     // reason hence the + 1 at the end.
     let pubkey_vec_size = idiv_ceil(curve.order_bits() as usize, 8) + 1;
     if ciphertext.len() <= pubkey_vec_size + AES_256_GCM_MAC_LENGTH {
-        kmip_utils_bail!("Decryption error: invalid ciphertext.")
+        kmip_utils_bail!("ECIES: Decryption error: invalid ciphertext.")
     }
 
     // Ciphertext received is a concatenation of `R | ct | tag` with `R`

--- a/crate/utils/src/crypto/hybrid_encryption/ecies.rs
+++ b/crate/utils/src/crypto/hybrid_encryption/ecies.rs
@@ -127,7 +127,6 @@ pub fn ecies_decrypt(
 ) -> Result<Vec<u8>, KmipUtilsError> {
     let mut ctx = BigNumContext::new_secure()?;
     let d = privkey.ec_key()?;
-    println!("after ec_key()");
     let curve = d.group();
 
     #[cfg(feature = "fips")]

--- a/crate/utils/src/crypto/hybrid_encryption/ecies.rs
+++ b/crate/utils/src/crypto/hybrid_encryption/ecies.rs
@@ -15,8 +15,8 @@ use crate::{
     kmip_utils_bail,
 };
 
-/// Derive initialization vector from recipient public key `Q` and ephemeral
-/// public key `R` using SHAKE128-128.
+/// Derive a 128-byte initialization vector from recipient public key `Q` and
+/// ephemeral public key `R` using SHAKE128.
 #[allow(non_snake_case)]
 fn ecies_get_iv(
     Q: &EcPointRef,
@@ -37,7 +37,7 @@ fn ecies_get_iv(
     Ok(iv)
 }
 
-/// Derive S into the symmetric secret key using SHAKE128-256.
+/// Derive S into the 256-bit symmetric secret key using SHAKE128.
 #[allow(non_snake_case)]
 fn ecies_get_key(S: &EcPointRef, curve: &EcGroupRef) -> Result<Vec<u8>, KmipUtilsError> {
     let mut ctx = BigNumContext::new_secure()?;

--- a/crate/utils/src/crypto/hybrid_encryption/ecies.rs
+++ b/crate/utils/src/crypto/hybrid_encryption/ecies.rs
@@ -9,11 +9,10 @@ use openssl::{
     symm::{decrypt_aead, encrypt_aead, Cipher},
 };
 
-#[cfg(feature = "fips")]
-use crate::kmip_utils_bail;
 use crate::{
     crypto::symmetric::{AES_256_GCM_IV_LENGTH, AES_256_GCM_KEY_LENGTH, AES_256_GCM_MAC_LENGTH},
     error::KmipUtilsError,
+    kmip_utils_bail,
 };
 
 /// Derive initialization vector from recipient public key `Q` and ephemeral

--- a/crate/utils/src/crypto/hybrid_encryption/ecies.rs
+++ b/crate/utils/src/crypto/hybrid_encryption/ecies.rs
@@ -52,8 +52,7 @@ fn ecies_get_key(S: &EcPointRef, curve: &EcGroupRef) -> Result<Vec<u8>, KmipUtil
     Ok(key)
 }
 
-/// Encrypt `plaintext` data using `pubkey` public key following the ECIES
-/// principle.
+/// Encrypt `plaintext` data using `pubkey` public key following ECIES.
 ///
 /// Generate a random `r` and compute `R = rG` with `G` the curve generator.
 /// Using target pubic key `pubkey` we will call `Q`, compute `S = rQ`. `S` is
@@ -108,8 +107,7 @@ pub fn ecies_encrypt(pubkey: &PKey<Public>, plaintext: &[u8]) -> Result<Vec<u8>,
     Ok([R_bytes, ct, tag].concat())
 }
 
-/// Decrypt `ciphertext` data using `privkey` private key following the ECIES
-/// principle.
+/// Decrypt `ciphertext` data using `privkey` private key following ECIES.
 ///
 /// `ciphertext` is a concatanation of `R | ct | tag` with `|` the concatenation
 /// operator, `R` the ephemeral public key on the curve, `ct` the encrypted data

--- a/crate/utils/src/crypto/hybrid_encryption/ecies.rs
+++ b/crate/utils/src/crypto/hybrid_encryption/ecies.rs
@@ -87,10 +87,8 @@ pub fn ecies_encrypt(pubkey: &PKey<Public>, plaintext: &[u8]) -> Result<Vec<u8>,
     let key = ecies_get_key(&S, curve)?;
     let iv = ecies_get_iv(Q.public_key(), R.public_key(), curve)?;
 
-    // Allocating memory for AES-GCM to write the tag at.
     let mut tag = vec![0; AES_256_GCM_MAC_LENGTH];
 
-    // Encryption using AES-256-GCM.
     let ct: Vec<u8> = encrypt_aead(
         Cipher::aes_256_gcm(),
         &key,
@@ -156,7 +154,6 @@ pub fn ecies_decrypt(
     let iv = ecies_get_iv(d.public_key(), &R, curve)?;
     let key = ecies_get_key(&S, curve)?;
 
-    // Decrypt data using AES-256-GCM with freshly computed key.
     let plaintext = decrypt_aead(Cipher::aes_256_gcm(), &key, Some(&iv), &[], ct, tag)?;
 
     Ok(plaintext)

--- a/crate/utils/src/crypto/hybrid_encryption/ecies.rs
+++ b/crate/utils/src/crypto/hybrid_encryption/ecies.rs
@@ -1,0 +1,203 @@
+use num_bigint_dig::algorithms::idiv_ceil;
+use openssl::{
+    bn::BigNumContext,
+    ec::{EcGroupRef, EcKey, EcPoint, EcPointRef, PointConversionForm},
+    hash::{Hasher, MessageDigest},
+    nid::Nid,
+    pkey::{PKey, Private, Public},
+    symm::{decrypt_aead, encrypt_aead, Cipher},
+};
+
+use crate::{
+    crypto::symmetric::{AES_256_GCM_IV_LENGTH, AES_256_GCM_KEY_LENGTH, AES_256_GCM_MAC_LENGTH},
+    error::KmipUtilsError,
+    kmip_utils_bail,
+};
+
+/// Derive initialization vector from recipient public key `Q` and ephemeral
+/// public key `R` using SHAKE128-128.
+#[allow(non_snake_case)]
+fn ecies_get_iv(
+    Q: &EcPointRef,
+    R: &EcPointRef,
+    curve: &EcGroupRef,
+) -> Result<Vec<u8>, KmipUtilsError> {
+    let mut ctx = BigNumContext::new_secure()?;
+    let Q_vec = Q.to_bytes(curve, PointConversionForm::COMPRESSED, &mut ctx)?;
+    let R_vec = R.to_bytes(curve, PointConversionForm::COMPRESSED, &mut ctx)?;
+
+    let mut iv = vec![0; AES_256_GCM_IV_LENGTH];
+
+    let mut hasher = Hasher::new(MessageDigest::shake_128())?;
+    hasher.update(&Q_vec)?;
+    hasher.update(&R_vec)?;
+    hasher.finish_xof(&mut iv)?;
+
+    Ok(iv)
+}
+
+/// Derive S into the symmetric secret key using SHAKE128-256.
+#[allow(non_snake_case)]
+fn ecies_get_key(S: &EcPointRef, curve: &EcGroupRef) -> Result<Vec<u8>, KmipUtilsError> {
+    let mut ctx = BigNumContext::new_secure()?;
+    let S_vec = S.to_bytes(curve, PointConversionForm::COMPRESSED, &mut ctx)?;
+
+    let mut key = vec![0; AES_256_GCM_KEY_LENGTH];
+
+    let mut hasher = Hasher::new(MessageDigest::shake_128())?;
+    hasher.update(&S_vec)?;
+    hasher.finish_xof(&mut key)?;
+
+    Ok(key)
+}
+
+/// Encrypt `plaintext` data using `pubkey` public key following the ECIES
+/// principle.
+///
+/// Generate a random `r` and compute `R = rG` with `G` the curve generator.
+/// Using target pubic key `pubkey` we will call `Q`, compute `S = rQ`. `S` is
+/// the shared key used to symmetrically encrypt data using AES-256-GCM.
+///
+/// Return `R | ct | tag` with `|` the concatenation operator, `R` the ephemeral
+/// public key on the curve, `ct` the encrypted data and `tag` the
+/// authentication tag forged during encryption.
+///
+/// Notice we don't send the IV since it is derived by hashing the public key as
+/// well as the ephemeral public key.
+#[allow(non_snake_case)]
+pub fn ecies_encrypt(pubkey: &PKey<Public>, plaintext: &[u8]) -> Result<Vec<u8>, KmipUtilsError> {
+    let mut ctx = BigNumContext::new_secure()?;
+    let Q = pubkey.ec_key()?;
+    let curve = Q.group();
+
+    #[cfg(feature = "fips")]
+    if curve.curve_name() == Some(Nid::X9_62_PRIME192V1) {
+        kmip_utils_bail!("Curve P-192 not allowed in FIPS mode.")
+    }
+
+    // Generating random ephemeral private key `r` and associated public key
+    // `R`.
+    let r = EcKey::generate(curve)?;
+    let R = EcKey::from_public_key(curve, r.public_key())?;
+
+    // Compute secret key from recipient public key `S = rQ`.
+    let mut S = EcPoint::new(curve)?;
+    S.mul(curve, Q.public_key(), r.private_key(), &ctx)?;
+
+    let key = ecies_get_key(&S, curve)?;
+    let iv = ecies_get_iv(Q.public_key(), R.public_key(), curve)?;
+
+    // Allocating memory for AES-GCM to write the tag at.
+    let mut tag = vec![0; AES_256_GCM_MAC_LENGTH];
+
+    // Encryption using AES-256-GCM.
+    let ct: Vec<u8> = encrypt_aead(
+        Cipher::aes_256_gcm(),
+        &key,
+        Some(&iv),
+        &[],
+        plaintext,
+        tag.as_mut(),
+    )?;
+
+    let R_vec = R
+        .public_key()
+        .to_bytes(curve, PointConversionForm::COMPRESSED, &mut ctx)?;
+
+    Ok([R_vec, ct, tag].concat())
+}
+
+/// Decrypt `ciphertext` data using `privkey` private key following the ECIES
+/// principle.
+///
+/// `ciphertext` is a concatanation of `R | ct | tag` with `|` the concatenation
+/// operator, `R` the ephemeral public key on the curve, `ct` the encrypted data
+/// and `tag` the authentication tag forged during encryption.
+///
+/// The IV for decryption is computed by taking the hash of the recipient public
+/// key and the ephemeral public key.
+///
+/// Return the plaintext.
+#[allow(non_snake_case)]
+pub fn ecies_decrypt(
+    privkey: &PKey<Private>,
+    ciphertext: &[u8],
+) -> Result<Vec<u8>, KmipUtilsError> {
+    let mut ctx = BigNumContext::new_secure()?;
+    let d = privkey.ec_key()?;
+    println!("after ec_key()");
+    let curve = d.group();
+
+    #[cfg(feature = "fips")]
+    if curve.curve_name() == Some(Nid::X9_62_PRIME192V1) {
+        kmip_utils_bail!("Curve P-192 not allowed in FIPS mode.")
+    }
+
+    // OpenSSL stored compressed coordinates with one extra byte for some
+    // reason hence the + 1 at the end.
+    let pubkey_vec_size = idiv_ceil(curve.order_bits() as usize, 8) + 1;
+
+    // Ciphertext received is a concatenation of `R | ct | tag` with `R`
+    // and `ct` of variable size and `tag` of size 128 bits.
+    let R_vec = &ciphertext[..pubkey_vec_size];
+
+    let ct_offset = ciphertext.len() - AES_256_GCM_MAC_LENGTH;
+    let ct = &ciphertext[pubkey_vec_size..ct_offset];
+
+    let tag = &ciphertext[ct_offset..];
+
+    let R = EcPoint::from_bytes(curve, R_vec, &mut ctx)?;
+
+    // Compute secret key from recipient public key `S = rQ = rdG = dR`.
+    let mut S = EcPoint::new(curve)?;
+    S.mul(curve, &R, d.private_key(), &ctx)?;
+
+    let iv = ecies_get_iv(d.public_key(), &R, curve)?;
+    let key = ecies_get_key(&S, curve)?;
+
+    // Decrypt data using AES-256-GCM with freshly computed key.
+    let plaintext = decrypt_aead(Cipher::aes_256_gcm(), &key, Some(&iv), &[], ct, tag)?;
+
+    Ok(plaintext)
+}
+
+#[cfg(test)]
+mod tests {
+    use openssl::{
+        ec::{EcGroup, EcKey},
+        nid::Nid,
+        pkey::PKey,
+    };
+
+    use super::{ecies_decrypt, ecies_encrypt};
+
+    fn test_ecies_encrypt_decrypt(nid: Nid) {
+        let curve = EcGroup::from_curve_name(nid).unwrap();
+        let ec_privkey = EcKey::generate(&curve).unwrap();
+        let ec_pubkey = EcKey::from_public_key(&curve, ec_privkey.public_key()).unwrap();
+
+        let pubkey = PKey::from_ec_key(ec_pubkey).unwrap();
+        let privkey = PKey::from_ec_key(ec_privkey).unwrap();
+
+        let plaintext = "i love pancakes".as_bytes();
+
+        let ct = ecies_encrypt(&pubkey, plaintext).unwrap();
+        let pt = ecies_decrypt(&privkey, &ct).unwrap();
+
+        assert_eq!(plaintext, &pt);
+    }
+
+    #[test]
+    fn test_ecies_encrypt_decrypt_p_curves() {
+        #[cfg(feature = "fips")]
+        // Load FIPS provider module from OpenSSL.
+        openssl::provider::Provider::load(None, "fips").unwrap();
+
+        #[cfg(not(feature = "fips"))]
+        test_ecies_encrypt_decrypt(Nid::X9_62_PRIME192V1);
+        test_ecies_encrypt_decrypt(Nid::SECP224R1);
+        test_ecies_encrypt_decrypt(Nid::X9_62_PRIME256V1);
+        test_ecies_encrypt_decrypt(Nid::SECP384R1);
+        test_ecies_encrypt_decrypt(Nid::SECP521R1);
+    }
+}

--- a/crate/utils/src/crypto/hybrid_encryption/ecies.rs
+++ b/crate/utils/src/crypto/hybrid_encryption/ecies.rs
@@ -1,17 +1,19 @@
 use num_bigint_dig::algorithms::idiv_ceil;
+#[cfg(feature = "fips")]
+use openssl::nid::Nid;
 use openssl::{
     bn::BigNumContext,
     ec::{EcGroupRef, EcKey, EcPoint, EcPointRef, PointConversionForm},
     hash::{Hasher, MessageDigest},
-    nid::Nid,
     pkey::{PKey, Private, Public},
     symm::{decrypt_aead, encrypt_aead, Cipher},
 };
 
+#[cfg(feature = "fips")]
+use crate::kmip_utils_bail;
 use crate::{
     crypto::symmetric::{AES_256_GCM_IV_LENGTH, AES_256_GCM_KEY_LENGTH, AES_256_GCM_MAC_LENGTH},
     error::KmipUtilsError,
-    kmip_utils_bail,
 };
 
 /// Derive initialization vector from recipient public key `Q` and ephemeral

--- a/crate/utils/src/crypto/hybrid_encryption/encryption.rs
+++ b/crate/utils/src/crypto/hybrid_encryption/encryption.rs
@@ -84,10 +84,10 @@ impl EncryptionSystem for HybridEncryptionSystem {
             Id::EC => ecies_encrypt(&self.public_key, &plaintext)?,
             Id::RSA => {
                 if self.key_wrapping {
-                    ckm_rsa_aes_key_wrap(self.public_key.clone(), &plaintext)?
+                    ckm_rsa_aes_key_wrap(&self.public_key, &plaintext)?
                 } else {
                     rsa_oaep_aes_gcm_encrypt(
-                        self.public_key.clone(),
+                        &self.public_key,
                         &plaintext,
                         request.authenticated_encryption_additional_data.as_deref(),
                     )?

--- a/crate/utils/src/crypto/hybrid_encryption/encryption.rs
+++ b/crate/utils/src/crypto/hybrid_encryption/encryption.rs
@@ -77,7 +77,7 @@ impl EncryptionSystem for HybridEncryptionSystem {
         #[cfg(not(feature = "fips"))]
         let mut rng = rng.lock().expect("RNG lock poisoned");
 
-        // Convert the Pkey to a crypto_core curve and perform emcryption
+        // Convert the Pkey to a crypto_core curve and perform encryption
         // Note: All conversions below will go once we move to full openssl
         let id = self.public_key.id();
         let ciphertext: Vec<u8> = match id {

--- a/crate/utils/src/crypto/hybrid_encryption/mod.rs
+++ b/crate/utils/src/crypto/hybrid_encryption/mod.rs
@@ -6,8 +6,8 @@
 //! These schemes do not support additional authenticated data.
 
 mod decryption;
+mod ecies;
 mod encryption;
 mod rsa_oaep_aes_gcm;
-
 pub use decryption::HybridDecryptionSystem;
 pub use encryption::HybridEncryptionSystem;

--- a/crate/utils/src/crypto/hybrid_encryption/rsa_oaep_aes_gcm.rs
+++ b/crate/utils/src/crypto/hybrid_encryption/rsa_oaep_aes_gcm.rs
@@ -29,7 +29,7 @@ const FIPS_MIN_RSA_MODULUS_LENGTH: u32 = 256;
 ///
 /// TODO - support OAEP for different hashes.
 pub fn rsa_oaep_aes_gcm_encrypt(
-    pubkey: PKey<Public>,
+    pubkey: &PKey<Public>,
     plaintext: &[u8],
     aad: Option<&[u8]>,
 ) -> Result<Vec<u8>, KmipUtilsError> {
@@ -86,7 +86,7 @@ pub fn rsa_oaep_aes_gcm_encrypt(
 ///
 /// TODO - support OAEP for different hashes.
 pub fn rsa_oaep_aes_gcm_decrypt(
-    p_key: PKey<Private>,
+    p_key: &PKey<Private>,
     ciphertext: &[u8],
     aad: Option<&[u8]>,
 ) -> Result<Vec<u8>, KmipUtilsError> {
@@ -164,9 +164,9 @@ fn test_rsa_oaep_encrypt_decrypt() -> Result<(), KmipUtilsError> {
 
     let privkey_to_wrap = openssl::rsa::Rsa::generate(2048)?.private_key_to_pem()?;
 
-    let ct = rsa_oaep_aes_gcm_encrypt(pubkey, &privkey_to_wrap, None)?;
+    let ct = rsa_oaep_aes_gcm_encrypt(&pubkey, &privkey_to_wrap, None)?;
 
-    let unwrapped_key = rsa_oaep_aes_gcm_decrypt(privkey, &ct, None)?;
+    let unwrapped_key = rsa_oaep_aes_gcm_decrypt(&privkey, &ct, None)?;
 
     assert_eq!(unwrapped_key, privkey_to_wrap);
 

--- a/crate/utils/src/crypto/wrap/rsa_oaep_aes_kwp.rs
+++ b/crate/utils/src/crypto/wrap/rsa_oaep_aes_kwp.rs
@@ -29,7 +29,7 @@ const FIPS_MIN_RSA_MODULUS_LENGTH: u32 = 256;
 ///
 /// TODO - support OAEP for different hashes.
 pub fn ckm_rsa_aes_key_wrap(
-    pubkey: PKey<Public>,
+    pubkey: &PKey<Public>,
     plaintext: &[u8],
 ) -> Result<Vec<u8>, KmipUtilsError> {
     let rsa_pubkey = pubkey.rsa()?;
@@ -77,7 +77,7 @@ pub fn ckm_rsa_aes_key_wrap(
 ///
 /// TODO - support OAEP for different hashes.
 pub fn ckm_rsa_aes_key_unwrap(
-    p_key: PKey<Private>,
+    p_key: &PKey<Private>,
     ciphertext: &[u8],
 ) -> Result<Vec<u8>, KmipUtilsError> {
     let rsa_privkey = p_key.rsa()?;
@@ -130,9 +130,9 @@ fn test_rsa_kem_wrap_unwrap() -> Result<(), KmipUtilsError> {
 
     let privkey_to_wrap = openssl::rsa::Rsa::generate(2048)?.private_key_to_pem()?;
 
-    let wrapped_key = ckm_rsa_aes_key_wrap(pubkey, &privkey_to_wrap)?;
+    let wrapped_key = ckm_rsa_aes_key_wrap(&pubkey, &privkey_to_wrap)?;
 
-    let unwrapped_key = ckm_rsa_aes_key_unwrap(privkey, &wrapped_key)?;
+    let unwrapped_key = ckm_rsa_aes_key_unwrap(&privkey, &wrapped_key)?;
 
     assert_eq!(unwrapped_key, privkey_to_wrap);
 


### PR DESCRIPTION
This change implements the ECIES Hybrid Encryption scheme fully supported by OpenSSL.

It only supports P-curves from NIST and not Ed/X25519 curves since they are not allowed for key agreement (if hybrid encryption is considered key agreement).

Thus is should make the hybrid encryption module from `crate/utils/crypto` fips compliant.