### PR TITLE
Zeroize crypto

### DIFF
--- a/crate/cli/src/actions/shared/wrap_key.rs
+++ b/crate/cli/src/actions/shared/wrap_key.rs
@@ -82,7 +82,7 @@ impl WrapKeyAction {
                 derive_key_from_password::<SYMMETRIC_WRAPPING_KEY_SIZE>(password.as_bytes())?;
 
             let symmetric_key_object =
-                create_symmetric_key_kmip_object(&key_bytes, CryptographicAlgorithm::AES);
+                create_symmetric_key_kmip_object(key_bytes.as_ref(), CryptographicAlgorithm::AES);
 
             // Print the wrapping key for user. This is the only time that this wrapping key will be printed
             println!(

--- a/crate/server/src/database/redis/redis_with_findex.rs
+++ b/crate/server/src/database/redis/redis_with_findex.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
+    ops::Deref,
     path::PathBuf,
     sync::Arc,
 };
@@ -103,7 +104,7 @@ impl RedisWithFindex {
         )?;
 
         let master_secret_key: SymmetricKey<REDIS_WITH_FINDEX_MASTER_KEY_LENGTH> =
-            SymmetricKey::try_from_bytes(output_key_material)?;
+            SymmetricKey::try_from_bytes(*output_key_material.deref())?;
 
         Ok(master_secret_key)
     }

--- a/crate/server/src/database/redis/redis_with_findex.rs
+++ b/crate/server/src/database/redis/redis_with_findex.rs
@@ -104,7 +104,13 @@ impl RedisWithFindex {
         )?;
 
         let master_secret_key: SymmetricKey<REDIS_WITH_FINDEX_MASTER_KEY_LENGTH> =
-            SymmetricKey::try_from_bytes(*output_key_material.deref())?;
+            SymmetricKey::try_from_bytes(
+                output_key_material
+                    .deref()
+                    .as_slice()
+                    .try_into()
+                    .expect("Derived key has invalid length."),
+            )?;
 
         Ok(master_secret_key)
     }

--- a/crate/server/src/main.rs
+++ b/crate/server/src/main.rs
@@ -8,6 +8,7 @@ use cosmian_kms_server::{
     result::KResult,
 };
 use dotenvy::dotenv;
+#[cfg(feature = "fips")]
 use openssl::provider::Provider;
 #[cfg(feature = "timeout")]
 use tracing::warn;

--- a/crate/server/src/tests/kmip_server_tests.rs
+++ b/crate/server/src/tests/kmip_server_tests.rs
@@ -9,7 +9,6 @@ use cosmian_kmip::kmip::{
         Attributes, CryptographicAlgorithm, KeyFormatType, KeyWrapType, LinkType,
         LinkedObjectIdentifier, RecommendedCurve, UniqueIdentifier, WrappingMethod,
     },
-    ttlv::{deserializer::from_ttlv, TTLV},
 };
 use cosmian_kms_utils::crypto::{
     elliptic_curves::{
@@ -21,7 +20,7 @@ use cosmian_kms_utils::crypto::{
     symmetric::symmetric_key_create_request,
 };
 use cosmian_logger::log_utils::log_init;
-use tracing::{info, trace};
+use tracing::trace;
 use uuid::Uuid;
 
 use crate::{

--- a/crate/utils/src/crypto/elliptic_curves/operation.rs
+++ b/crate/utils/src/crypto/elliptic_curves/operation.rs
@@ -25,8 +25,15 @@ pub const ED25519_PRIVATE_KEY_LENGTH: usize = 0x20;
 pub const ED25519_PUBLIC_KEY_LENGTH: usize = 0x20;
 pub const Q_LENGTH_BITS: i32 = 253;
 
-/// convert to a X25519 256 bits KMIP Public Key
-/// no check performed
+/// Convert to an Elliptic Curve KMIP Public Key.
+/// Supported curves are:
+/// X25519, Ed25519, X448, Ed448, P-192, P-224, P-256, P-384, P-521.
+///
+/// `pkey_bits_number` is passed independently from `len(bytes)` since some key
+/// sizes are not multiple of 8 thus it cannot be computes by taking the byte
+/// array length.
+///
+/// No check performed.
 pub fn to_ec_public_key(
     bytes: &[u8],
     pkey_bits_number: u32,
@@ -80,8 +87,15 @@ pub fn to_ec_public_key(
     }
 }
 
-/// convert to a curve 25519 256 bits KMIP Private Key
-/// no check performed
+/// Convert to an Elliptic Curve KMIP Private Key.
+/// Supported curves are:
+/// X25519, Ed25519, X448, Ed448, P-192, P-224, P-256, P-384, P-521.
+///
+/// `pkey_bits_number` is passed independently from `len(bytes)` since some key
+/// sizes are not multiple of 8 thus it cannot be computes by taking the byte
+/// array length.
+///
+/// No check performed.
 pub fn to_ec_private_key(
     bytes: &[u8],
     pkey_bits_number: u32,

--- a/crate/utils/src/crypto/elliptic_curves/operation.rs
+++ b/crate/utils/src/crypto/elliptic_curves/operation.rs
@@ -30,7 +30,7 @@ pub const Q_LENGTH_BITS: i32 = 253;
 /// X25519, Ed25519, X448, Ed448, P-192, P-224, P-256, P-384, P-521.
 ///
 /// `pkey_bits_number` is passed independently from `len(bytes)` since some key
-/// sizes are not multiple of 8 thus it cannot be computes by taking the byte
+/// sizes are not multiple of 8 thus it cannot be computed by taking the byte
 /// array length.
 ///
 /// No check performed.
@@ -92,7 +92,7 @@ pub fn to_ec_public_key(
 /// X25519, Ed25519, X448, Ed448, P-192, P-224, P-256, P-384, P-521.
 ///
 /// `pkey_bits_number` is passed independently from `len(bytes)` since some key
-/// sizes are not multiple of 8 thus it cannot be computes by taking the byte
+/// sizes are not multiple of 8 thus it cannot be computed by taking the byte
 /// array length.
 ///
 /// No check performed.

--- a/crate/utils/src/crypto/elliptic_curves/operation.rs
+++ b/crate/utils/src/crypto/elliptic_curves/operation.rs
@@ -280,11 +280,9 @@ pub fn create_approved_ecc_key_pair(
 
     let mut ctx = BigNumContext::new()?;
     let public_key = to_ec_public_key(
-        &Zeroizing::from(ec_private_key.public_key().to_bytes(
-            &curve,
-            PointConversionForm::HYBRID,
-            &mut ctx,
-        )?),
+        &ec_private_key
+            .public_key()
+            .to_bytes(&curve, PointConversionForm::HYBRID, &mut ctx)?,
         ec_private_key.private_key().num_bits() as u32,
         private_key_uid,
         kmip_curve,

--- a/crate/utils/src/crypto/rsa/operation.rs
+++ b/crate/utils/src/crypto/rsa/operation.rs
@@ -9,6 +9,7 @@ use cosmian_kmip::kmip::{
 use num_bigint_dig::BigUint;
 use openssl::{pkey::Private, rsa::Rsa};
 use tracing::trace;
+use zeroize::Zeroizing;
 
 #[cfg(feature = "fips")]
 use crate::{crypto::wrap::rsa_oaep_aes_kwp::FIPS_MIN_RSA_MODULUS_LENGTH, kmip_utils_bail};
@@ -89,19 +90,25 @@ pub fn to_rsa_private_key(
             key_value: KeyValue {
                 key_material: KeyMaterial::TransparentRSAPrivateKey {
                     modulus: BigUint::from_bytes_be(&private_key.n().to_vec()),
-                    private_exponent: Some(BigUint::from_bytes_be(&private_key.d().to_vec())),
+                    private_exponent: Some(BigUint::from_bytes_be(&Zeroizing::from(
+                        private_key.d().to_vec(),
+                    ))),
                     public_exponent: Some(BigUint::from_bytes_be(&private_key.e().to_vec())),
-                    p: private_key.p().map(|p| BigUint::from_bytes_be(&p.to_vec())),
-                    q: private_key.q().map(|q| BigUint::from_bytes_be(&q.to_vec())),
+                    p: private_key
+                        .p()
+                        .map(|p| BigUint::from_bytes_be(&Zeroizing::from(p.to_vec()))),
+                    q: private_key
+                        .q()
+                        .map(|q| BigUint::from_bytes_be(&Zeroizing::from(q.to_vec()))),
                     prime_exponent_p: private_key
                         .dmp1()
-                        .map(|dmp1| BigUint::from_bytes_be(&dmp1.to_vec())),
+                        .map(|dmp1| BigUint::from_bytes_be(&Zeroizing::from(dmp1.to_vec()))),
                     prime_exponent_q: private_key
                         .dmq1()
-                        .map(|dmq1| BigUint::from_bytes_be(&dmq1.to_vec())),
+                        .map(|dmq1| BigUint::from_bytes_be(&Zeroizing::from(dmq1.to_vec()))),
                     crt_coefficient: private_key
                         .iqmp()
-                        .map(|iqmp| BigUint::from_bytes_be(&iqmp.to_vec())),
+                        .map(|iqmp| BigUint::from_bytes_be(&Zeroizing::from(iqmp.to_vec()))),
                 },
                 attributes: Some(Attributes {
                     object_type: Some(ObjectType::PrivateKey),

--- a/crate/utils/src/crypto/wrap/rfc5649.rs
+++ b/crate/utils/src/crypto/wrap/rfc5649.rs
@@ -231,7 +231,7 @@ fn _unwrap_64(ciphertext: &[u8], kek: &[u8]) -> Result<(u64, Zeroizing<Vec<u8>>)
     // Number of 64-bit blocks minus 1
     let n = n / 8 - 1;
 
-    let mut blocks = Vec::with_capacity(n + 1);
+    let mut blocks = Zeroizing::from(Vec::with_capacity(n + 1));
     for chunk in ciphertext.chunks(AES_WRAP_PAD_BLOCK_SIZE) {
         blocks.push(u64::from_be_bytes(chunk.try_into()?));
     }
@@ -265,7 +265,7 @@ fn _unwrap_64(ciphertext: &[u8], kek: &[u8]) -> Result<(u64, Zeroizing<Vec<u8>>)
             let big_i = (u128::from(icr ^ t) << 64 | u128::from(*block)).to_be_bytes();
             let big_b = big_i.as_slice();
 
-            let mut plaintext = vec![0; big_b.len() + AES_BLOCK_SIZE];
+            let mut plaintext = Zeroizing::from(vec![0; big_b.len() + AES_BLOCK_SIZE]);
             let mut dec_len = decrypt_cipher.update(big_b, &mut plaintext)?;
             dec_len += decrypt_cipher.finalize(&mut plaintext)?;
             plaintext.truncate(dec_len);
@@ -280,7 +280,7 @@ fn _unwrap_64(ciphertext: &[u8], kek: &[u8]) -> Result<(u64, Zeroizing<Vec<u8>>)
         }
     }
 
-    let mut unwrapped_key = Zeroizing::from(Vec::with_capacity(blocks.len() - 1));
+    let mut unwrapped_key = Zeroizing::from(Vec::with_capacity((blocks.len() - 1) * 8));
     for block in &blocks[1..] {
         unwrapped_key.extend(block.to_be_bytes());
     }

--- a/crate/utils/src/crypto/wrap/rfc5649.rs
+++ b/crate/utils/src/crypto/wrap/rfc5649.rs
@@ -10,6 +10,7 @@
  */
 
 use openssl::symm::{encrypt, Cipher, Crypter, Mode};
+use zeroize::Zeroizing;
 
 use crate::error::KmipUtilsError;
 
@@ -92,7 +93,7 @@ pub fn key_wrap(plain: &[u8], kek: &[u8]) -> Result<Vec<u8>, KmipUtilsError> {
 ///
 /// The function name matches the one used in the RFC and has no link to the
 /// unwrap function in Rust.
-pub fn key_unwrap(ciphertext: &[u8], kek: &[u8]) -> Result<Vec<u8>, KmipUtilsError> {
+pub fn key_unwrap(ciphertext: &[u8], kek: &[u8]) -> Result<Zeroizing<Vec<u8>>, KmipUtilsError> {
     let n = ciphertext.len();
 
     if n % AES_WRAP_PAD_BLOCK_SIZE != 0 || n < AES_BLOCK_SIZE {
@@ -112,7 +113,7 @@ pub fn key_unwrap(ciphertext: &[u8], kek: &[u8]) -> Result<Vec<u8>, KmipUtilsErr
         }
 
         let unpadded_size = u32::from_le(iv as u32) as usize;
-        Ok(padded_plain[0..unpadded_size].to_vec())
+        Ok(Zeroizing::from(padded_plain[0..unpadded_size].to_vec()))
     } else {
         /*
          * Encrypt block using AES with ECB mode i.e. raw AES as specified in
@@ -133,7 +134,7 @@ pub fn key_unwrap(ciphertext: &[u8], kek: &[u8]) -> Result<Vec<u8>, KmipUtilsErr
         decrypt_cipher.pad(false);
 
         //// A | P[1] = DEC(K, C[0] | C[1])
-        let mut plaintext = vec![0; ciphertext.len() + AES_BLOCK_SIZE];
+        let mut plaintext = Zeroizing::from(vec![0; ciphertext.len() + AES_BLOCK_SIZE]);
         let mut dec_len = decrypt_cipher.update(ciphertext, &mut plaintext)?;
         dec_len += decrypt_cipher.finalize(&mut plaintext)?;
         plaintext.truncate(dec_len);
@@ -150,7 +151,9 @@ pub fn key_unwrap(ciphertext: &[u8], kek: &[u8]) -> Result<Vec<u8>, KmipUtilsErr
 
         let unpadded_size = u32::from_be_bytes(plaintext[4..8].try_into()?) as usize;
 
-        Ok(plaintext[AES_WRAP_PAD_BLOCK_SIZE..(AES_WRAP_PAD_BLOCK_SIZE + unpadded_size)].to_vec())
+        Ok(Zeroizing::from(
+            plaintext[AES_WRAP_PAD_BLOCK_SIZE..(AES_WRAP_PAD_BLOCK_SIZE + unpadded_size)].to_vec(),
+        ))
     }
 }
 
@@ -216,7 +219,7 @@ fn _wrap_64(plain: &[u8], kek: &[u8], iv: Option<u64>) -> Result<Vec<u8>, KmipUt
     Ok(wrapped_key)
 }
 
-fn _unwrap_64(ciphertext: &[u8], kek: &[u8]) -> Result<(u64, Vec<u8>), KmipUtilsError> {
+fn _unwrap_64(ciphertext: &[u8], kek: &[u8]) -> Result<(u64, Zeroizing<Vec<u8>>), KmipUtilsError> {
     let n = ciphertext.len();
 
     if n % AES_WRAP_PAD_BLOCK_SIZE != 0 || n < AES_BLOCK_SIZE {
@@ -277,7 +280,7 @@ fn _unwrap_64(ciphertext: &[u8], kek: &[u8]) -> Result<(u64, Vec<u8>), KmipUtils
         }
     }
 
-    let mut unwrapped_key = Vec::with_capacity(blocks.len() - 1);
+    let mut unwrapped_key = Zeroizing::from(Vec::with_capacity(blocks.len() - 1));
     for block in &blocks[1..] {
         unwrapped_key.extend(block.to_be_bytes());
     }
@@ -287,6 +290,8 @@ fn _unwrap_64(ciphertext: &[u8], kek: &[u8]) -> Result<(u64, Vec<u8>), KmipUtils
 
 #[cfg(test)]
 mod tests {
+    use zeroize::Zeroizing;
+
     use crate::crypto::wrap::rfc5649::{key_unwrap, key_wrap};
 
     #[test]
@@ -310,7 +315,7 @@ mod tests {
         );
         assert_eq!(
             key_unwrap(&wrapped_key, kek).expect("Fail to unwrap"),
-            key_to_wrap
+            Zeroizing::from(key_to_wrap.to_vec())
         );
 
         const TEST_SIZE_LIMIT: usize = 100;
@@ -319,7 +324,7 @@ mod tests {
             let ciphertext = key_wrap(key_to_wrap, kek).expect("Fail to wrap");
             assert_eq!(
                 key_unwrap(&ciphertext, kek).expect("Fail to unwrap"),
-                key_to_wrap
+                Zeroizing::from(key_to_wrap.to_vec())
             );
         }
     }
@@ -345,7 +350,7 @@ mod tests {
         );
         assert_eq!(
             key_unwrap(&wrapped_key, kek).expect("Fail to unwrap"),
-            key_to_wrap
+            Zeroizing::from(key_to_wrap.to_vec())
         );
     }
 
@@ -368,7 +373,7 @@ mod tests {
         );
         assert_eq!(
             key_unwrap(&wrapped_key, kek).expect("Fail to unwrap"),
-            key_to_wrap
+            Zeroizing::from(key_to_wrap.to_vec())
         );
     }
 

--- a/crate/utils/src/crypto/wrap/rsa_oaep_aes_kwp.rs
+++ b/crate/utils/src/crypto/wrap/rsa_oaep_aes_kwp.rs
@@ -79,7 +79,7 @@ pub fn ckm_rsa_aes_key_wrap(
 pub fn ckm_rsa_aes_key_unwrap(
     p_key: &PKey<Private>,
     ciphertext: &[u8],
-) -> Result<Vec<u8>, KmipUtilsError> {
+) -> Result<Zeroizing<Vec<u8>>, KmipUtilsError> {
     let rsa_privkey = p_key.rsa()?;
 
     #[cfg(feature = "fips")]
@@ -128,7 +128,7 @@ fn test_rsa_kem_wrap_unwrap() -> Result<(), KmipUtilsError> {
     let privkey = PKey::from_rsa(openssl::rsa::Rsa::generate(2048)?)?;
     let pubkey = PKey::public_key_from_pem(&privkey.public_key_to_pem()?)?;
 
-    let privkey_to_wrap = openssl::rsa::Rsa::generate(2048)?.private_key_to_pem()?;
+    let privkey_to_wrap = Zeroizing::from(openssl::rsa::Rsa::generate(2048)?.private_key_to_pem()?);
 
     let wrapped_key = ckm_rsa_aes_key_wrap(&pubkey, &privkey_to_wrap)?;
 

--- a/crate/utils/src/crypto/wrap/wrap_unwrap_key.rs
+++ b/crate/utils/src/crypto/wrap/wrap_unwrap_key.rs
@@ -105,10 +105,10 @@ pub fn unwrap_key_block(
             let (ciphertext, attributes) = object_key_block.key_bytes_and_attributes()?;
             let plain_text = decrypt_bytes(unwrapping_key, &ciphertext)?;
             let key_material: KeyMaterial = match object_key_block.key_format_type {
-                KeyFormatType::TransparentSymmetricKey => {
-                    KeyMaterial::TransparentSymmetricKey { key: plain_text }
-                }
-                _ => KeyMaterial::ByteString(plain_text),
+                KeyFormatType::TransparentSymmetricKey => KeyMaterial::TransparentSymmetricKey {
+                    key: plain_text.to_vec(), // XXX keep zeroizing
+                },
+                _ => KeyMaterial::ByteString(plain_text.to_vec()), // XXX keep zeroizing
             };
             KeyValue {
                 key_material,

--- a/crate/utils/src/kmip_utils.rs
+++ b/crate/utils/src/kmip_utils.rs
@@ -14,7 +14,7 @@ const WRAPPING_SECRET_LENGTH: usize = 32;
 pub fn wrap_key_bytes(key: &[u8], wrapping_password: &str) -> Result<Vec<u8>, KmipUtilsError> {
     let wrapping_secret =
         derive_key_from_password::<WRAPPING_SECRET_LENGTH>(wrapping_password.as_bytes())?;
-    key_wrap(key, &wrapping_secret).map_err(|e| KmipUtilsError::Default(e.to_string()))
+    key_wrap(key, wrapping_secret.as_ref()).map_err(|e| KmipUtilsError::Default(e.to_string()))
 }
 
 /// Unwrap a key using a password
@@ -24,5 +24,5 @@ pub fn unwrap_key_bytes(
 ) -> Result<Zeroizing<Vec<u8>>, KmipUtilsError> {
     let wrapping_secret =
         derive_key_from_password::<WRAPPING_SECRET_LENGTH>(wrapping_password.as_bytes())?;
-    key_unwrap(key, &wrapping_secret).map_err(|e| KmipUtilsError::Default(e.to_string()))
+    key_unwrap(key, wrapping_secret.as_ref()).map_err(|e| KmipUtilsError::Default(e.to_string()))
 }

--- a/crate/utils/src/kmip_utils.rs
+++ b/crate/utils/src/kmip_utils.rs
@@ -1,3 +1,5 @@
+use zeroize::Zeroizing;
+
 use crate::{
     crypto::{
         password_derivation::derive_key_from_password,
@@ -16,7 +18,10 @@ pub fn wrap_key_bytes(key: &[u8], wrapping_password: &str) -> Result<Vec<u8>, Km
 }
 
 /// Unwrap a key using a password
-pub fn unwrap_key_bytes(key: &[u8], wrapping_password: &str) -> Result<Vec<u8>, KmipUtilsError> {
+pub fn unwrap_key_bytes(
+    key: &[u8],
+    wrapping_password: &str,
+) -> Result<Zeroizing<Vec<u8>>, KmipUtilsError> {
     let wrapping_secret =
         derive_key_from_password::<WRAPPING_SECRET_LENGTH>(wrapping_password.as_bytes())?;
     key_unwrap(key, &wrapping_secret).map_err(|e| KmipUtilsError::Default(e.to_string()))

--- a/documentation/docs/zeroization.md
+++ b/documentation/docs/zeroization.md
@@ -1,0 +1,12 @@
+Secret keys and plaintexts are considered highly sensitive information and to securely erase from memory or storage Cosmian KMS implements data `zeroization`. The term `zeroization` originates from the process of setting all relevant bits to zero, effectively rendering the data unreadable and unrecoverable. This practice is essential to prevent unwanted memory residue of critical data, especially in scenarios where the confidentiality and integrity of data are paramount.
+
+This is particularly crucial in environments where multiple users or processes access the same resources but this does not prevent in any way an attacker reading from live memory as the latter may not be encrypted.
+
+It is good to notice that in the source code, only keys and plaintexts represented as byte arrays are being *zeroized* using the [zeroize](https://docs.rs/zeroize/latest/zeroize/) crate. Regarding OpenSSL `PKey` types, they are being zeroized by OpenSSL itself which is triggered on drop by rust.
+
+> EVP_PKEYs are dropped with EVP_PKEY_free which should use the appropriate cipher-internal freeing function which in turn should cleanse all private data unless there is a a bug in the underlying OpenSSL library [...].
+> [source](https://github.com/sfackler/rust-openssl/issues/2147)
+
+
+# Regulatory Compliance
+Cosmian KMS thus adheres to relevant industry standards and regulatory requirements concerning data security and privacy such as the [rust guidelines from ANSSI](https://cyber.gouv.fr/publications/regles-de-programmation-pour-le-developpement-dapplications-securisees-en-rust). The use of zeroization aligns with this standard, demonstrating our commitment to safeguarding sensitive information and meeting the necessary compliance obligations.

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -80,3 +80,4 @@ nav:
       - Getting started with Google Workspace CSE: google_cse/google_cse.md
       - Setting up a well-known file web server: google_cse/configuring-the-well-known-server.md
       - Configuring the well-known file: google_cse/configuring-the-well-known-file.md
+  - Zeroization: zeroization.md


### PR DESCRIPTION
A first pass at better zeroization for cryptographic primitives.

Still unzeroized parts are serialized keys and plaintext because `serde` does not support `Zeroizing<>`  and I think it could be discussed.