### PR TITLE
Allow multiple operations at once for access control requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+
+## [X.Y.Z] - 2024-xx-xx
+
+### Features
+
+- CLI: allow multiple operations to be supplied at once for access control [#155](https://github.com/Cosmian/kms/pull/155).
+
 ## [4.11.2] - 2024-01-23
 
 ### Ci

--- a/crate/cli/src/config.rs
+++ b/crate/cli/src/config.rs
@@ -34,10 +34,7 @@ fn get_home_folder() -> Option<PathBuf> {
     // Check for the existence of the HOMEDRIVE and HOMEPATH environment variables on Windows
     else if let (Some(hdrive), Some(hpath)) = (env::var_os("HOMEDRIVE"), env::var_os("HOMEPATH"))
     {
-        let mut path = PathBuf::new();
-        path.push(hdrive);
-        path.push(hpath);
-        return Some(path)
+        return Some(PathBuf::from(hdrive).join(hpath))
     }
     // If none of the above environment variables exist, the home folder cannot be determined
     None

--- a/crate/cli/src/tests/shared/locate.rs
+++ b/crate/cli/src/tests/shared/locate.rs
@@ -431,7 +431,7 @@ pub async fn test_locate_grant() -> Result<(), CliError> {
         &ctx.owner_cli_conf_path,
         &user_key_id,
         "user.client@acme.com",
-        "encrypt",
+        &["encrypt"],
     )?;
 
     // The user should be able to locate the user key and only that one
@@ -450,7 +450,7 @@ pub async fn test_locate_grant() -> Result<(), CliError> {
         &ctx.owner_cli_conf_path,
         &user_key_id,
         "user.client@acme.com",
-        "encrypt",
+        &["encrypt"],
     )?;
 
     // the user should no more be able to locate the key

--- a/crate/server/src/core/kms.rs
+++ b/crate/server/src/core/kms.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::{BTreeSet, HashSet},
     fs,
     sync::{Arc, Mutex},
 };
@@ -548,7 +549,12 @@ impl KMS {
         }
 
         self.db
-            .grant_access(uid, &access.user_id, access.operation_type, params)
+            .grant_access(
+                uid,
+                &access.user_id,
+                HashSet::from_iter(access.operation_types.clone()),
+                params,
+            )
             .await?;
         Ok(())
     }
@@ -585,7 +591,12 @@ impl KMS {
         }
 
         self.db
-            .remove_access(uid, &access.user_id, access.operation_type, params)
+            .remove_access(
+                uid,
+                &access.user_id,
+                HashSet::from_iter(access.operation_types.clone()),
+                params,
+            )
             .await?;
         Ok(())
     }
@@ -617,7 +628,7 @@ impl KMS {
             .into_iter()
             .map(|(user_id, operations)| UserAccessResponse {
                 user_id,
-                operations,
+                operations: operations.into_iter().collect::<BTreeSet<_>>(),
             })
             .collect();
 

--- a/crate/server/src/database/cached_sqlcipher.rs
+++ b/crate/server/src/database/cached_sqlcipher.rs
@@ -372,12 +372,12 @@ impl Database for CachedSqlCipher {
         &self,
         uid: &str,
         userid: &str,
-        operation_type: ObjectOperationType,
+        operation_types: HashSet<ObjectOperationType>,
         params: Option<&ExtraDatabaseParams>,
     ) -> KResult<()> {
         if let Some(params) = params {
             let pool = self.pre_query(params.group_id, &params.key).await?;
-            let ret = insert_access_(uid, userid, operation_type, &*pool).await;
+            let ret = insert_access_(uid, userid, operation_types, &*pool).await;
             self.post_query(params.group_id)?;
             return ret
         }
@@ -389,12 +389,12 @@ impl Database for CachedSqlCipher {
         &self,
         uid: &str,
         userid: &str,
-        operation_type: ObjectOperationType,
+        operation_types: HashSet<ObjectOperationType>,
         params: Option<&ExtraDatabaseParams>,
     ) -> KResult<()> {
         if let Some(params) = params {
             let pool = self.pre_query(params.group_id, &params.key).await?;
-            let ret = remove_access_(uid, userid, operation_type, &*pool).await;
+            let ret = remove_access_(uid, userid, operation_types, &*pool).await;
             self.post_query(params.group_id)?;
             return ret
         }

--- a/crate/server/src/database/database_trait.rs
+++ b/crate/server/src/database/database_trait.rs
@@ -137,7 +137,7 @@ pub trait Database {
         &self,
         uid: &str,
         user: &str,
-        operation_type: ObjectOperationType,
+        operation_types: HashSet<ObjectOperationType>,
         params: Option<&ExtraDatabaseParams>,
     ) -> KResult<()>;
 
@@ -147,7 +147,7 @@ pub trait Database {
         &self,
         uid: &str,
         user: &str,
-        operation_type: ObjectOperationType,
+        operation_types: HashSet<ObjectOperationType>,
         params: Option<&ExtraDatabaseParams>,
     ) -> KResult<()>;
 

--- a/crate/server/src/database/pgsql.rs
+++ b/crate/server/src/database/pgsql.rs
@@ -244,20 +244,20 @@ impl Database for PgPool {
         &self,
         uid: &str,
         userid: &str,
-        operation_type: ObjectOperationType,
+        operation_types: HashSet<ObjectOperationType>,
         _params: Option<&ExtraDatabaseParams>,
     ) -> KResult<()> {
-        insert_access_(uid, userid, operation_type, &self.pool).await
+        insert_access_(uid, userid, operation_types, &self.pool).await
     }
 
     async fn remove_access(
         &self,
         uid: &str,
         userid: &str,
-        operation_type: ObjectOperationType,
+        operation_types: HashSet<ObjectOperationType>,
         _params: Option<&ExtraDatabaseParams>,
     ) -> KResult<()> {
-        remove_access_(uid, userid, operation_type, &self.pool).await
+        remove_access_(uid, userid, operation_types, &self.pool).await
     }
 
     async fn is_object_owned_by(
@@ -732,7 +732,7 @@ where
 pub(crate) async fn insert_access_<'e, E>(
     uid: &str,
     userid: &str,
-    operation_type: ObjectOperationType,
+    operation_types: HashSet<ObjectOperationType>,
     executor: E,
 ) -> KResult<()>
 where
@@ -740,11 +740,11 @@ where
 {
     // Retrieve existing permissions if any
     let mut perms = list_user_access_rights_on_object_(uid, userid, false, executor).await?;
-    if perms.contains(&operation_type) {
-        // permission is already setup
+    if operation_types.is_subset(&perms) {
+        // permissions are already setup
         return Ok(())
     }
-    perms.insert(operation_type);
+    perms.extend(operation_types.iter());
 
     // Serialize permissions
     let json = serde_json::to_value(&perms)
@@ -769,15 +769,18 @@ where
 pub(crate) async fn remove_access_<'e, E>(
     uid: &str,
     userid: &str,
-    operation_type: ObjectOperationType,
+    operation_types: HashSet<ObjectOperationType>,
     executor: E,
 ) -> KResult<()>
 where
     E: Executor<'e, Database = Postgres> + Copy,
 {
     // Retrieve existing permissions if any
-    let mut perms = list_user_access_rights_on_object_(uid, userid, true, executor).await?;
-    perms.retain(|p| *p != operation_type);
+    let perms = list_user_access_rights_on_object_(uid, userid, true, executor)
+        .await?
+        .difference(&operation_types)
+        .cloned()
+        .collect::<HashSet<_>>();
 
     // No remaining permissions, delete the row
     if perms.is_empty() {

--- a/crate/server/src/database/redis/redis_with_findex.rs
+++ b/crate/server/src/database/redis/redis_with_findex.rs
@@ -485,12 +485,14 @@ impl Database for RedisWithFindex {
         &self,
         uid: &str,
         user: &str,
-        operation_type: ObjectOperationType,
+        operation_types: HashSet<ObjectOperationType>,
         _params: Option<&ExtraDatabaseParams>,
     ) -> KResult<()> {
-        self.permissions_db
-            .add(&self.findex_key, uid, user, operation_type)
-            .await?;
+        for operation in &operation_types {
+            self.permissions_db
+                .add(&self.findex_key, uid, user, *operation)
+                .await?;
+        }
         Ok(())
     }
 
@@ -500,12 +502,14 @@ impl Database for RedisWithFindex {
         &self,
         uid: &str,
         user: &str,
-        operation_type: ObjectOperationType,
+        operation_types: HashSet<ObjectOperationType>,
         _params: Option<&ExtraDatabaseParams>,
     ) -> KResult<()> {
-        self.permissions_db
-            .remove(&self.findex_key, uid, user, operation_type)
-            .await?;
+        for operation in &operation_types {
+            self.permissions_db
+                .remove(&self.findex_key, uid, user, *operation)
+                .await?;
+        }
         Ok(())
     }
 

--- a/crate/server/src/database/tests/owner_test.rs
+++ b/crate/server/src/database/tests/owner_test.rs
@@ -74,8 +74,13 @@ pub async fn owner<DB: Database>(db_and_params: &(DB, Option<ExtraDatabaseParams
 
     // Add authorized `userid` to `read_access` table
 
-    db.grant_access(&uid, user_id_1, ObjectOperationType::Get, db_params)
-        .await?;
+    db.grant_access(
+        &uid,
+        user_id_1,
+        HashSet::from([ObjectOperationType::Get]),
+        db_params,
+    )
+    .await?;
 
     // Retrieve object with authorized `user_id_1` with `Create` operation type - ko
 
@@ -104,12 +109,22 @@ pub async fn owner<DB: Database>(db_and_params: &(DB, Option<ExtraDatabaseParams
     }
 
     // Add authorized `userid2` to `read_access` table
-    db.grant_access(&uid, user_id_2, ObjectOperationType::Get, db_params)
-        .await?;
+    db.grant_access(
+        &uid,
+        user_id_2,
+        HashSet::from([ObjectOperationType::Get]),
+        db_params,
+    )
+    .await?;
 
     // Try to add same access again - OK
-    db.grant_access(&uid, user_id_2, ObjectOperationType::Get, db_params)
-        .await?;
+    db.grant_access(
+        &uid,
+        user_id_2,
+        HashSet::from([ObjectOperationType::Get]),
+        db_params,
+    )
+    .await?;
 
     // We should still be able to find the object by its owner
     let objects = db.find(None, None, owner, true, db_params).await?;
@@ -176,8 +191,13 @@ pub async fn owner<DB: Database>(db_and_params: &(DB, Option<ExtraDatabaseParams
     }
 
     // Remove `userid2` authorization
-    db.remove_access(&uid, user_id_2, ObjectOperationType::Get, db_params)
-        .await?;
+    db.remove_access(
+        &uid,
+        user_id_2,
+        HashSet::from([ObjectOperationType::Get]),
+        db_params,
+    )
+    .await?;
 
     // Retrieve object with `userid2` with `Get` operation type - ko
     if !db

--- a/crate/server/src/database/tests/permissions_test.rs
+++ b/crate/server/src/database/tests/permissions_test.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use cosmian_kms_utils::access::{ExtraDatabaseParams, ObjectOperationType};
 use cosmian_logger::log_utils::log_init;
 use uuid::Uuid;
@@ -25,8 +27,13 @@ async fn permissions_users<DB: Database>(
     let uid = Uuid::new_v4().to_string();
 
     // simple insert
-    db.grant_access(&uid, &user_id_1, ObjectOperationType::Get, db_params)
-        .await?;
+    db.grant_access(
+        &uid,
+        &user_id_1,
+        HashSet::from([ObjectOperationType::Get]),
+        db_params,
+    )
+    .await?;
 
     let perms = db
         .list_user_access_rights_on_object(&uid, &user_id_1, false, db_params)
@@ -35,8 +42,13 @@ async fn permissions_users<DB: Database>(
     assert!(perms.contains(&ObjectOperationType::Get));
 
     // double insert, expect no duplicate
-    db.grant_access(&uid, &user_id_1, ObjectOperationType::Get, db_params)
-        .await?;
+    db.grant_access(
+        &uid,
+        &user_id_1,
+        HashSet::from([ObjectOperationType::Get]),
+        db_params,
+    )
+    .await?;
 
     let perms = db
         .list_user_access_rights_on_object(&uid, &user_id_1, false, db_params)
@@ -45,8 +57,13 @@ async fn permissions_users<DB: Database>(
     assert!(perms.contains(&ObjectOperationType::Get));
 
     // insert other operation type
-    db.grant_access(&uid, &user_id_1, ObjectOperationType::Encrypt, db_params)
-        .await?;
+    db.grant_access(
+        &uid,
+        &user_id_1,
+        HashSet::from([ObjectOperationType::Encrypt]),
+        db_params,
+    )
+    .await?;
 
     let perms = db
         .list_user_access_rights_on_object(&uid, &user_id_1, false, db_params)
@@ -56,8 +73,13 @@ async fn permissions_users<DB: Database>(
     assert!(perms.contains(&ObjectOperationType::Get));
 
     // insert other `userid2`, check it is ok and it didn't change anything for `userid`
-    db.grant_access(&uid, &user_id_2, ObjectOperationType::Get, db_params)
-        .await?;
+    db.grant_access(
+        &uid,
+        &user_id_2,
+        HashSet::from([ObjectOperationType::Get]),
+        db_params,
+    )
+    .await?;
 
     let perms = db
         .list_user_access_rights_on_object(&uid, &user_id_2, false, db_params)
@@ -84,8 +106,13 @@ async fn permissions_users<DB: Database>(
     assert!(accesses[&user_id_2].contains(&ObjectOperationType::Get));
 
     // remove `Get` access for `userid`
-    db.remove_access(&uid, &user_id_1, ObjectOperationType::Get, db_params)
-        .await?;
+    db.remove_access(
+        &uid,
+        &user_id_1,
+        HashSet::from([ObjectOperationType::Get]),
+        db_params,
+    )
+    .await?;
 
     let perms = db
         .list_user_access_rights_on_object(&uid, &user_id_2, false, db_params)
@@ -112,8 +139,13 @@ async fn permissions_wildcard<DB: Database>(
     let uid = Uuid::new_v4().to_string();
 
     // simple insert
-    db.grant_access(&uid, &user_id, ObjectOperationType::Get, db_params)
-        .await?;
+    db.grant_access(
+        &uid,
+        &user_id,
+        HashSet::from([ObjectOperationType::Get]),
+        db_params,
+    )
+    .await?;
 
     let perms = db
         .list_user_access_rights_on_object(&uid, &user_id, false, db_params)
@@ -122,8 +154,13 @@ async fn permissions_wildcard<DB: Database>(
     assert!(perms.contains(&ObjectOperationType::Get));
 
     // insert other operation type using wildcard user
-    db.grant_access(&uid, "*", ObjectOperationType::Encrypt, db_params)
-        .await?;
+    db.grant_access(
+        &uid,
+        "*",
+        HashSet::from([ObjectOperationType::Encrypt]),
+        db_params,
+    )
+    .await?;
 
     let perms = db
         .list_user_access_rights_on_object(&uid, &user_id, false, db_params)
@@ -147,8 +184,13 @@ async fn permissions_wildcard<DB: Database>(
     assert!(perms.contains(&ObjectOperationType::Encrypt));
 
     // double insert, expect no duplicate
-    db.grant_access(&uid, "*", ObjectOperationType::Encrypt, db_params)
-        .await?;
+    db.grant_access(
+        &uid,
+        "*",
+        HashSet::from([ObjectOperationType::Encrypt]),
+        db_params,
+    )
+    .await?;
 
     let perms = db
         .list_user_access_rights_on_object(&uid, &user_id, false, db_params)
@@ -158,8 +200,13 @@ async fn permissions_wildcard<DB: Database>(
     assert!(perms.contains(&ObjectOperationType::Get));
 
     // grant access to Get via the wildcard user - expect no duplicates
-    db.grant_access(&uid, "*", ObjectOperationType::Get, db_params)
-        .await?;
+    db.grant_access(
+        &uid,
+        "*",
+        HashSet::from([ObjectOperationType::Get]),
+        db_params,
+    )
+    .await?;
 
     let perms = db
         .list_user_access_rights_on_object(&uid, &user_id, false, db_params)
@@ -169,8 +216,13 @@ async fn permissions_wildcard<DB: Database>(
     assert!(perms.contains(&ObjectOperationType::Get));
 
     // Remove Get access to user: it should still have access via the wildcard user
-    db.remove_access(&uid, &user_id, ObjectOperationType::Get, db_params)
-        .await?;
+    db.remove_access(
+        &uid,
+        &user_id,
+        HashSet::from([ObjectOperationType::Get]),
+        db_params,
+    )
+    .await?;
 
     let perms = db
         .list_user_access_rights_on_object(&uid, &user_id, false, db_params)
@@ -180,12 +232,22 @@ async fn permissions_wildcard<DB: Database>(
     assert!(perms.contains(&ObjectOperationType::Get));
 
     // remove Encrypt access for the  wildcard user: user1 should only be left with Get access
-    db.remove_access(&uid, "*", ObjectOperationType::Encrypt, db_params)
-        .await?;
+    db.remove_access(
+        &uid,
+        "*",
+        HashSet::from([ObjectOperationType::Encrypt]),
+        db_params,
+    )
+    .await?;
 
     // remove Get from user 3
-    db.remove_access(&uid, &user_id, ObjectOperationType::Get, db_params)
-        .await?;
+    db.remove_access(
+        &uid,
+        &user_id,
+        HashSet::from([ObjectOperationType::Get]),
+        db_params,
+    )
+    .await?;
 
     // permissions of the wildcard user should be Get
     let perms = db

--- a/crate/server/src/database/tests/tagging_tests.rs
+++ b/crate/server/src/database/tests/tagging_tests.rs
@@ -151,13 +151,23 @@ pub async fn tags<DB: Database>(db_and_params: &(DB, Option<ExtraDatabaseParams>
 
     // grant the Get access right to USER_GET
     const USER_GET: &str = "user_get";
-    db.grant_access(&uid, USER_GET, ObjectOperationType::Get, db_params)
-        .await?;
+    db.grant_access(
+        &uid,
+        USER_GET,
+        HashSet::from([ObjectOperationType::Get]),
+        db_params,
+    )
+    .await?;
 
     // grant the Decrypt access right to USER_DECRYPT
     const USER_DECRYPT: &str = "user_decrypt";
-    db.grant_access(&uid, USER_DECRYPT, ObjectOperationType::Decrypt, db_params)
-        .await?;
+    db.grant_access(
+        &uid,
+        USER_DECRYPT,
+        HashSet::from([ObjectOperationType::Decrypt]),
+        db_params,
+    )
+    .await?;
 
     // find this object from tags as USER_GET using tag1
     let res = db

--- a/crate/server/src/routes/access.rs
+++ b/crate/server/src/routes/access.rs
@@ -84,7 +84,7 @@ pub async fn grant_access(
         .await?;
     debug!(
         "Access granted on {:?} for {:?} to {}",
-        &access.unique_identifier, &access.operation_type, &access.user_id
+        access.unique_identifier, access.operation_types, access.user_id
     );
 
     Ok(Json(SuccessResponse {
@@ -108,7 +108,7 @@ pub async fn revoke_access(
         .await?;
     debug!(
         "Access revoke on {:?} for {:?} to {}",
-        &access.unique_identifier, &access.operation_type, &access.user_id
+        access.unique_identifier, access.operation_types, access.user_id
     );
 
     Ok(Json(SuccessResponse {

--- a/crate/utils/src/access.rs
+++ b/crate/utils/src/access.rs
@@ -1,3 +1,9 @@
+use std::{
+    collections::{BTreeSet, HashSet},
+    fmt,
+    str::FromStr,
+};
+
 use cloudproof::reexport::crypto_core::{FixedSizeCBytes, RandomFixedSizeCBytes, SymmetricKey};
 use cosmian_kmip::kmip::kmip_types::{Attributes, StateEnumeration, UniqueIdentifier};
 use serde::{Deserialize, Serialize};
@@ -10,13 +16,13 @@ pub struct Access {
     pub unique_identifier: Option<UniqueIdentifier>,
     /// User identifier, beneficiary of the access
     pub user_id: String,
-    /// Operation type for the access
-    pub operation_type: ObjectOperationType,
+    /// Operation types for the access
+    pub operation_types: Vec<ObjectOperationType>,
 }
 
 /// Operation types that can get or create objects
 /// These operations use `retrieve` or `get` methods.
-#[derive(Eq, PartialEq, Serialize, Deserialize, Copy, Clone, Hash)]
+#[derive(Eq, PartialEq, Serialize, Deserialize, Copy, Clone, Hash, PartialOrd, Ord)]
 #[serde(rename_all = "lowercase")]
 pub enum ObjectOperationType {
     Create,
@@ -99,8 +105,6 @@ impl<'de> Deserialize<'de> for ExtraDatabaseParams {
     }
 }
 
-use std::{collections::HashSet, fmt, str::FromStr};
-
 // any error type implementing Display is acceptable.
 type ParseError = &'static str;
 
@@ -128,7 +132,8 @@ impl FromStr for ObjectOperationType {
 #[derive(Deserialize, Serialize, Debug)] // Debug is required by ok_json()
 pub struct UserAccessResponse {
     pub user_id: String,
-    pub operations: HashSet<ObjectOperationType>,
+    /// A `BTreeSet` is used to keep results sorted
+    pub operations: BTreeSet<ObjectOperationType>,
 }
 
 pub type IsWrapped = bool;

--- a/documentation/docs/cli/main_commands.md
+++ b/documentation/docs/cli/main_commands.md
@@ -46,9 +46,9 @@ Manage the users' access rights to the cryptographic objects
 
 ### Subcommands
 
-**`grant`** [[1.1]](#11-ckms-access-rights-grant)  Grant another user an access right to an object
+**`grant`** [[1.1]](#11-ckms-access-rights-grant)  Grant another user one or multiple access rights to an object
 
-**`revoke`** [[1.2]](#12-ckms-access-rights-revoke)  Revoke another user access right to an object
+**`revoke`** [[1.2]](#12-ckms-access-rights-revoke)  Revoke another user one or multiple access rights to an object
 
 **`list`** [[1.3]](#13-ckms-access-rights-list)  List the access rights granted on an object to other users
 
@@ -60,19 +60,19 @@ Manage the users' access rights to the cryptographic objects
 
 ## 1.1 ckms access-rights grant
 
-Grant another user an access right to an object
+Grant another user one or multiple access rights to an object
 
 ### Usage
 `ckms access-rights grant [options] <USER>
  <OBJECT_UID>
- <OPERATION>
+ <OPERATIONS>...
 `
 ### Arguments
 ` <USER>` The user identifier to allow
 
 ` <OBJECT_UID>` The object unique identifier stored in the KMS
 
-` <OPERATION>` The KMIP operation to allow
+` <OPERATIONS>` The operations to grant (`create`, `get`, `encrypt`, `decrypt`, `import`, `revoke`, `locate`, `rekey`, `destroy`)
 
 
 
@@ -80,19 +80,19 @@ Grant another user an access right to an object
 
 ## 1.2 ckms access-rights revoke
 
-Revoke another user access right to an object
+Revoke another user one or multiple access rights to an object
 
 ### Usage
 `ckms access-rights revoke [options] <USER>
  <OBJECT_UID>
- <OPERATION>
+ <OPERATIONS>...
 `
 ### Arguments
 ` <USER>` The user to revoke access to
 
 ` <OBJECT_UID>` The object unique identifier stored in the KMS
 
-` <OPERATION>` The operation to revoke (create, get, encrypt, decrypt, import, revoke, locate, rekey, destroy)
+` <OPERATIONS>` The operations to revoke (`create`, `get`, `encrypt`, `decrypt`, `import`, `revoke`, `locate`, `rekey`, `destroy`)
 
 
 
@@ -1612,3 +1612,7 @@ Generate the CLI documentation as markdown
 `
 ### Arguments
 ` <MARKDOWN_FILE>` The file to export the markdown to
+
+
+
+


### PR DESCRIPTION
Allow to use the CLI this way:
```console
ckms -- access-rights grant '*' google_cse create encrypt decrypt
```
instead of
```console
ckms -- access-rights grant '*' google_cse create
ckms -- access-rights grant '*' google_cse encrypt
ckms -- access-rights grant '*' google_cse decrypt
```