### PR TITLE
Compile optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,16 @@ lto = true
 strip = true
 
 [profile.dev]
+strip = "debuginfo"
 incremental = false
 
-[profile.dev.package."*"] # external dependencies
+# proc-macros and build-scripts
+[profile.dev.build-override]
+strip = "debuginfo"
+incremental = false
+
+# external dependencies
+[profile.dev.package."*"]
 opt-level = 0
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+default-members = ["crate/cli", "crate/server"]
 members = [
   "crate/cli",
   "crate/client",
@@ -8,7 +9,9 @@ members = [
   "crate/pyo3",
   "crate/logger",
 ]
-# Do that if you don't want to enable `dev` feature by default due to the `dev-dependencies` of the cli. For more details, read: https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2
+# Do that if you don't want to enable `dev` feature by default due to the `dev-dependencies` of the cli.
+# For more details, read: https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2
+# note: resolver defaults to 2 in 2021 edition crate, but defaults to 1 in virtual workspace
 resolver = "2"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,7 @@ lto = true
 strip = true
 
 [profile.dev]
-strip = false
-opt-level = 0
-debug = true
-overflow-checks = true
-lto = false
-panic = 'unwind'
 incremental = false
-codegen-units = 256
-rpath = false
 
 [profile.dev.package."*"] # external dependencies
 opt-level = 0

--- a/crate/cli/Cargo.toml
+++ b/crate/cli/Cargo.toml
@@ -8,6 +8,12 @@ description = "CLI used to manage the Cosmian KMS."
 [[bin]]
 name = "ckms"
 path = "src/main.rs"
+test = false
+
+[lib]
+# doc test linking as a separate binary is extremely slow
+# and is not needed for internal lib
+doctest = false
 
 [features]
 # Staging is used to run tests with the remote kms test server. Otherwise, the test runs a local kms server.

--- a/crate/client/Cargo.toml
+++ b/crate/client/Cargo.toml
@@ -5,6 +5,11 @@ authors = ["Bruno Grieder <bruno.grieder@cosmian.com>"]
 edition = "2021"
 license-file = "../../LICENSE.md"
 
+[lib]
+# doc test linking as a separate binary is extremely slow
+# and is not needed for internal lib
+doctest = false
+
 [dependencies]
 base64 = { workspace = true }
 cosmian_kmip = { path = "../kmip" }

--- a/crate/kmip/Cargo.toml
+++ b/crate/kmip/Cargo.toml
@@ -4,6 +4,11 @@ version = "4.11.3"
 edition = "2021"
 license-file = "../../LICENSE.md"
 
+[lib]
+# doc test linking as a separate binary is extremely slow
+# and is not needed for internal lib
+doctest = false
+
 [features]
 default = []
 openssl = ["dep:openssl"]

--- a/crate/server/Cargo.toml
+++ b/crate/server/Cargo.toml
@@ -6,6 +6,16 @@ edition = "2021"
 license-file = "../../LICENSE.md"
 description = "Cosmian Key Management Service"
 
+[[bin]]
+name = "cosmian_kms_server"
+path = "src/main.rs"
+test = false
+
+[lib]
+# doc test linking as a separate binary is extremely slow
+# and is not needed for internal lib
+doctest = false
+
 [features]
 # Do not verify auth0 token expiration date and https ssl is auto-signed (to avoid to be banned by letsencrypt)
 insecure = []
@@ -77,11 +87,3 @@ cosmian_logger = { path = "../logger" }
 
 [build-dependencies]
 time = { workspace = true, features = ["local-offset", "formatting"] }
-
-[[bin]]
-name = "cosmian_kms_server"
-path = "src/main.rs"
-
-[lib]
-name = "cosmian_kms_server"
-path = "src/lib.rs"

--- a/crate/utils/Cargo.toml
+++ b/crate/utils/Cargo.toml
@@ -5,6 +5,11 @@ authors = ["Bruno Grieder <bruno.grieder@cosmian.com>"]
 edition = "2021"
 license-file = "../../LICENSE.md"
 
+[lib]
+# doc test linking as a separate binary is extremely slow
+# and is not needed for internal lib
+doctest = false
+
 [features]
 fips = []
 curve25519 = []


### PR DESCRIPTION
- compiler optimizations
  - build time: 1mn -> 37 secs (-38%)
  - resident memory: 1,92 GB -> 920 MB (-52%)
  - storage size on disk: 5 GB -> 3,2 GB (-36%)

<details>
  <summary>Details</summary>

  ```sh
  develop (target: 5 GB)
	  Maximum resident set size (kbytes): 1917432
      Finished dev [unoptimized + debuginfo] target(s) in 1m 03s
      Finished dev [unoptimized + debuginfo] target(s) in 1m 04s
  default-members
      Finished dev [unoptimized + debuginfo] target(s) in 49.87s
      Finished dev [unoptimized + debuginfo] target(s) in 51.96s
  strip debug-info
      Finished dev [unoptimized + debuginfo] target(s) in 40.25s
      Finished dev [unoptimized + debuginfo] target(s) in 41.86s
      Finished dev [unoptimized + debuginfo] target(s) in 42.83s
  build-override
      Finished dev [unoptimized + debuginfo] target(s) in 40.89s
      Finished dev [unoptimized + debuginfo] target(s) in 40.93s
      Finished dev [unoptimized + debuginfo] target(s) in 40.74s
  disable bin test and doctest in lib  (target: 3.2 GB)
	  Maximum resident set size (kbytes): 922168
      Finished dev [unoptimized + debuginfo] target(s) in 37.13s
      Finished dev [unoptimized + debuginfo] target(s) in 37.65s
      Finished dev [unoptimized + debuginfo] target(s) in 37.10s
  ```
</details>