### PR TITLE
Zeroizing key material byte arrays

### DIFF
--- a/crate/cli/src/actions/certificates/import_certificate.rs
+++ b/crate/cli/src/actions/certificates/import_certificate.rs
@@ -10,6 +10,7 @@ use cosmian_kms_client::KmsRestClient;
 use der::{Decode, DecodePem, Encode};
 use tracing::{debug, trace};
 use x509_cert::Certificate;
+use zeroize::Zeroizing;
 
 use crate::{
     actions::shared::{
@@ -243,7 +244,7 @@ impl ImportCertificateAction {
 
     /// Import the certificate, the chain and the associated private key
     async fn import_pkcs12(&self, kms_rest_client: &KmsRestClient) -> Result<String, CliError> {
-        let pkcs12_bytes = read_bytes_from_file(&self.get_certificate_file()?)?;
+        let pkcs12_bytes = Zeroizing::from(read_bytes_from_file(&self.get_certificate_file()?)?);
 
         // Create a KMIP private key from the PKCS12 private key
         let private_key = build_private_key_from_der_bytes(KeyFormatType::PKCS12, pkcs12_bytes);

--- a/crate/cli/src/actions/shared/utils/encodings.rs
+++ b/crate/cli/src/actions/shared/utils/encodings.rs
@@ -109,7 +109,9 @@ fn key_block(key_format_type: KeyFormatType, bytes: Vec<u8>) -> KeyBlock {
         key_format_type,
         key_compression_type: None,
         key_value: KeyValue {
-            key_material: KeyMaterial::ByteString(bytes),
+            // No need to specify zeroizing as parameter type for this function
+            // seems to only deal with public components.
+            key_material: KeyMaterial::ByteString(Zeroizing::from(bytes)),
             attributes: None,
         },
         // According to the KMIP spec, the cryptographic algorithm is not required

--- a/crate/kmip/src/kmip/kmip_data_structures.rs
+++ b/crate/kmip/src/kmip/kmip_data_structures.rs
@@ -1,4 +1,4 @@
-use std::{clone::Clone, ops::Deref};
+use std::clone::Clone;
 
 use num_bigint_dig::BigUint;
 use serde::{
@@ -439,12 +439,12 @@ impl Serialize for KeyMaterial {
         match self {
             Self::ByteString(bytes) => {
                 let mut st = serializer.serialize_struct("KeyMaterial", 1)?;
-                st.serialize_field("ByteString", bytes.deref())?;
+                st.serialize_field("ByteString", &**bytes)?;
                 st.end()
             }
             Self::TransparentSymmetricKey { key } => {
                 let mut st = serializer.serialize_struct("KeyMaterial", 1)?;
-                st.serialize_field("Key", key.deref())?;
+                st.serialize_field("Key", &**key)?;
                 st.end()
             }
             Self::TransparentDHPrivateKey { p, q, g, j, x } => {

--- a/crate/kmip/src/kmip/ttlv/tests/mod.rs
+++ b/crate/kmip/src/kmip/ttlv/tests/mod.rs
@@ -1,6 +1,7 @@
 use num_bigint_dig::BigUint;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use time::OffsetDateTime;
+use zeroize::Zeroizing;
 
 use crate::{
     error::KmipError,
@@ -27,7 +28,7 @@ use crate::{
 
 pub fn aes_key_material(key_value: &[u8]) -> KeyMaterial {
     KeyMaterial::TransparentSymmetricKey {
-        key: key_value.to_vec(),
+        key: Zeroizing::from(key_value.to_vec()),
     }
 }
 
@@ -224,7 +225,7 @@ fn test_serialization_deserialization() {
 
 #[test]
 fn test_ser_int() {
-    //log_init("info,hyper=info,reqwest=info");
+    log_init("info,hyper=info,reqwest=info");
     #[derive(Serialize)]
     #[serde(rename_all = "PascalCase")]
     struct Test {
@@ -244,7 +245,7 @@ fn test_ser_int() {
 
 #[test]
 fn test_ser_array() {
-    //log_init("info,hyper=info,reqwest=info");
+    log_init("info,hyper=info,reqwest=info");
     #[derive(Serialize)]
     #[serde(rename_all = "PascalCase")]
     struct Test {
@@ -262,7 +263,7 @@ fn test_ser_array() {
 
 #[test]
 fn test_ser_big_int() {
-    //log_init("info,hyper=info,reqwest=info");
+    log_init("info,hyper=info,reqwest=info");
     #[derive(Serialize)]
     #[serde(rename_all = "PascalCase")]
     struct Test {
@@ -399,14 +400,14 @@ fn test_des_enum() {
 #[test]
 fn test_key_material_vec_deserialization() {
     //log_init("info,hyper=info,reqwest=info");
-    let bytes = vec![
+    let bytes = Zeroizing::from(vec![
         116, 104, 105, 115, 95, 105, 115, 95, 97, 95, 116, 101, 115, 116,
     ];
     let ttlv = TTLV {
         tag: "KeyMaterial".to_string(),
         value: TTLValue::Structure(vec![TTLV {
             tag: "Key".to_string(),
-            value: TTLValue::ByteString(bytes.clone()),
+            value: TTLValue::ByteString(bytes.to_vec()),
         }]),
     };
     let km_: KeyMaterial = from_ttlv(&ttlv).unwrap();
@@ -636,7 +637,7 @@ fn test_byte_string_key_material() {
     //log_init("info");
     let key_bytes: &[u8] = b"this_is_a_test";
     let key_value = KeyValue {
-        key_material: KeyMaterial::ByteString(key_bytes.to_vec()),
+        key_material: KeyMaterial::ByteString(Zeroizing::from(key_bytes.to_vec())),
         attributes: Some(Attributes {
             object_type: Some(ObjectType::SymmetricKey),
             ..Attributes::default()
@@ -763,10 +764,12 @@ fn get_key_block() -> KeyBlock {
         key_compression_type: None,
         key_value: KeyValue {
             key_material: KeyMaterial::TransparentSymmetricKey {
-                key: hex::decode(
-                    b"EC189A82797F0AED1E5AEF9EB0D232E6079A1D3E5C00526DDEE59BCA16242604",
-                )
-                .unwrap(),
+                key: Zeroizing::from(
+                    hex::decode(
+                        b"EC189A82797F0AED1E5AEF9EB0D232E6079A1D3E5C00526DDEE59BCA16242604",
+                    )
+                    .unwrap(),
+                ),
             },
             //TODO:: Empty attributes used to cause a deserialization issue for `Object`; `None` works
             attributes: Some(Attributes::default()),

--- a/crate/kmip/src/kmip/ttlv/tests/mod.rs
+++ b/crate/kmip/src/kmip/ttlv/tests/mod.rs
@@ -225,7 +225,7 @@ fn test_serialization_deserialization() {
 
 #[test]
 fn test_ser_int() {
-    log_init("info,hyper=info,reqwest=info");
+    // log_init("info,hyper=info,reqwest=info");
     #[derive(Serialize)]
     #[serde(rename_all = "PascalCase")]
     struct Test {
@@ -245,7 +245,7 @@ fn test_ser_int() {
 
 #[test]
 fn test_ser_array() {
-    log_init("info,hyper=info,reqwest=info");
+    // log_init("info,hyper=info,reqwest=info");
     #[derive(Serialize)]
     #[serde(rename_all = "PascalCase")]
     struct Test {
@@ -263,7 +263,7 @@ fn test_ser_array() {
 
 #[test]
 fn test_ser_big_int() {
-    log_init("info,hyper=info,reqwest=info");
+    // log_init("info,hyper=info,reqwest=info");
     #[derive(Serialize)]
     #[serde(rename_all = "PascalCase")]
     struct Test {
@@ -402,7 +402,7 @@ fn test_key_material_vec_deserialization() {
     //log_init("info,hyper=info,reqwest=info");
     let bytes = Zeroizing::from(vec![
         116, 104, 105, 115, 95, 105, 115, 95, 97, 95, 116, 101, 115, 116,
-    ];
+    ]);
     let ttlv = TTLV {
         tag: "KeyMaterial".to_string(),
         value: TTLValue::Structure(vec![TTLV {

--- a/crate/server/src/core/operations/destroy.rs
+++ b/crate/server/src/core/operations/destroy.rs
@@ -12,6 +12,7 @@ use cosmian_kmip::kmip::{
 };
 use cosmian_kms_utils::access::{ExtraDatabaseParams, ObjectOperationType};
 use tracing::{debug, trace};
+use zeroize::Zeroizing;
 
 use crate::{
     core::{cover_crypt::destroy_user_decryption_keys, KMS},
@@ -177,7 +178,7 @@ async fn destroy_key_core(
     } else {
         let key_block = object.key_block_mut()?;
         key_block.key_value = KeyValue {
-            key_material: KeyMaterial::ByteString(vec![]),
+            key_material: KeyMaterial::ByteString(Zeroizing::from(vec![])),
             attributes: key_block.key_value.attributes.clone(),
         };
     }

--- a/crate/server/src/core/operations/export_utils.rs
+++ b/crate/server/src/core/operations/export_utils.rs
@@ -20,6 +20,7 @@ use openssl::{
     x509::X509,
 };
 use tracing::{debug, trace};
+use zeroize::Zeroizing;
 
 use crate::{
     core::{
@@ -69,7 +70,7 @@ pub async fn export_get(
             {
                 let key_block = owm.object.key_block_mut()?;
                 key_block.key_value = KeyValue {
-                    key_material: KeyMaterial::ByteString(vec![]),
+                    key_material: KeyMaterial::ByteString(Zeroizing::from(vec![])),
                     attributes: None,
                 };
                 key_block.key_format_type = KeyFormatType::Opaque;
@@ -115,7 +116,7 @@ pub async fn export_get(
             {
                 let key_block = owm.object.key_block_mut()?;
                 key_block.key_value = KeyValue {
-                    key_material: KeyMaterial::ByteString(vec![]),
+                    key_material: KeyMaterial::ByteString(Zeroizing::from(vec![])),
                     attributes: None,
                 };
                 key_block.key_format_type = KeyFormatType::Opaque;
@@ -143,7 +144,7 @@ pub async fn export_get(
             {
                 let key_block = owm.object.key_block_mut()?;
                 key_block.key_value = KeyValue {
-                    key_material: KeyMaterial::ByteString(vec![]),
+                    key_material: KeyMaterial::ByteString(Zeroizing::from(vec![])),
                     attributes: None,
                 };
                 key_block.key_format_type = KeyFormatType::Opaque;
@@ -614,7 +615,7 @@ async fn post_process_pkcs12_for_private_key(
             key_format_type: KeyFormatType::PKCS12,
             key_compression_type: None,
             key_value: KeyValue {
-                key_material: KeyMaterial::ByteString(pkcs12.to_der()?),
+                key_material: KeyMaterial::ByteString(Zeroizing::from(pkcs12.to_der()?)),
                 // attributes are added later
                 attributes: None,
             },

--- a/crate/server/src/core/operations/wrapping/wrap.rs
+++ b/crate/server/src/core/operations/wrapping/wrap.rs
@@ -7,7 +7,6 @@ use cosmian_kms_utils::{
     access::{ExtraDatabaseParams, ObjectOperationType},
     crypto::wrap::wrap_key_block,
 };
-use zeroize::Zeroizing;
 
 use crate::{
     core::KMS,

--- a/crate/server/src/core/operations/wrapping/wrap.rs
+++ b/crate/server/src/core/operations/wrapping/wrap.rs
@@ -7,6 +7,7 @@ use cosmian_kms_utils::{
     access::{ExtraDatabaseParams, ObjectOperationType},
     crypto::wrap::wrap_key_block,
 };
+use zeroize::Zeroizing;
 
 use crate::{
     core::KMS,

--- a/crate/server/src/tests/kmip_server_tests.rs
+++ b/crate/server/src/tests/kmip_server_tests.rs
@@ -21,6 +21,7 @@ use cosmian_kms_utils::crypto::{
 };
 use tracing::trace;
 use uuid::Uuid;
+use zeroize::Zeroizing;
 
 use crate::{
     config::ServerParams,
@@ -211,7 +212,7 @@ async fn test_import_wrapped_symmetric_key() -> KResult<()> {
     let wrapped_symmetric_key = [0_u8; 32];
     let aesgcm_nonce = [0_u8; 12];
 
-    let key_material = KeyMaterial::ByteString(wrapped_symmetric_key.to_vec());
+    let key_material = KeyMaterial::ByteString(Zeroizing::from(wrapped_symmetric_key.to_vec()));
 
     let symmetric_key = Object::SymmetricKey {
         key_block: KeyBlock {

--- a/crate/server/src/tests/ms_dke/mod.rs
+++ b/crate/server/src/tests/ms_dke/mod.rs
@@ -68,7 +68,7 @@ async fn decrypt_data_test() -> KResult<()> {
                 key_format_type: KeyFormatType::PKCS8,
                 key_compression_type: None,
                 key_value: KeyValue {
-                    key_material: KeyMaterial::ByteString(pem.contents().to_vec()),
+                    key_material: KeyMaterial::ByteString(pem.contents().to_vec().into()),
                     attributes: None,
                 },
                 cryptographic_algorithm: Some(CryptographicAlgorithm::RSA),

--- a/crate/utils/src/crypto/cover_crypt/decryption.rs
+++ b/crate/utils/src/crypto/cover_crypt/decryption.rs
@@ -11,6 +11,7 @@ use cosmian_kmip::{
     },
 };
 use tracing::{debug, trace};
+use zeroize::Zeroizing;
 
 use super::user_key::unwrap_user_decryption_key_object;
 use crate::{error::KmipUtilsError, DecryptionSystem};
@@ -20,7 +21,7 @@ use crate::{error::KmipUtilsError, DecryptionSystem};
 pub struct CovercryptDecryption {
     cover_crypt: Covercrypt,
     user_decryption_key_uid: String,
-    user_decryption_key_bytes: Vec<u8>,
+    user_decryption_key_bytes: Zeroizing<Vec<u8>>,
 }
 
 impl CovercryptDecryption {

--- a/crate/utils/src/crypto/cover_crypt/kmip_requests.rs
+++ b/crate/utils/src/crypto/cover_crypt/kmip_requests.rs
@@ -8,6 +8,7 @@ use cosmian_kmip::kmip::{
         LinkedObjectIdentifier, UniqueIdentifier, WrappingMethod,
     },
 };
+use zeroize::Zeroizing;
 
 use super::attributes::{
     access_policy_as_vendor_attribute, edit_policy_action_as_vendor_attribute,
@@ -95,11 +96,11 @@ pub fn build_import_decryption_private_key_request<T: IntoIterator<Item = impl A
     //  - to wrap (wrapping_password is some)
     //  - or not wrapped (otherwise)
     let is_wrapped = is_wrapped || wrapping_password.is_some();
-    let key = if let Some(wrapping_password) = wrapping_password {
+    let key = Zeroizing::from(if let Some(wrapping_password) = wrapping_password {
         wrap_key_bytes(private_key, &wrapping_password)?
     } else {
         private_key.to_vec()
-    };
+    });
 
     Ok(Import {
         unique_identifier: UniqueIdentifier::TextString(unique_identifier.unwrap_or_default()),
@@ -169,11 +170,11 @@ pub fn build_import_private_key_request<T: IntoIterator<Item = impl AsRef<str>>>
     //  - to wrapped (wrapping_password is some)
     //  - or not wrapped (otherwise)
     let is_wrapped = is_wrapped || wrapping_password.is_some();
-    let key = if let Some(wrapping_password) = wrapping_password {
+    let key = Zeroizing::from(if let Some(wrapping_password) = wrapping_password {
         wrap_key_bytes(private_key, &wrapping_password)?
     } else {
         private_key.to_vec()
-    };
+    });
 
     Ok(Import {
         unique_identifier: UniqueIdentifier::TextString(unique_identifier.unwrap_or_default()),
@@ -246,7 +247,7 @@ pub fn build_import_public_key_request<T: IntoIterator<Item = impl AsRef<str>>>(
                 key_format_type: KeyFormatType::CoverCryptPublicKey,
                 key_compression_type: None,
                 key_value: KeyValue {
-                    key_material: KeyMaterial::ByteString(public_key.to_vec()),
+                    key_material: KeyMaterial::ByteString(Zeroizing::from(public_key.to_vec())),
                     attributes: Some(attributes),
                 },
                 cryptographic_length: Some(public_key.len() as i32 * 8),

--- a/crate/utils/src/crypto/cover_crypt/master_keys.rs
+++ b/crate/utils/src/crypto/cover_crypt/master_keys.rs
@@ -14,6 +14,7 @@ use cosmian_kmip::{
         },
     },
 };
+use zeroize::Zeroizing;
 
 use crate::{
     crypto::cover_crypt::attributes::{policy_from_attributes, upsert_policy_in_attributes},
@@ -112,7 +113,7 @@ fn create_master_private_key_object(
             key_format_type: KeyFormatType::CoverCryptSecretKey,
             key_compression_type: None,
             key_value: KeyValue {
-                key_material: KeyMaterial::ByteString(key.to_vec()),
+                key_material: KeyMaterial::ByteString(Zeroizing::from(key.to_vec())),
                 attributes: Some(attributes),
             },
             cryptographic_length: Some(key.len() as i32 * 8),
@@ -149,7 +150,7 @@ fn create_master_public_key_object(
             key_format_type: KeyFormatType::CoverCryptPublicKey,
             key_compression_type: None,
             key_value: KeyValue {
-                key_material: KeyMaterial::ByteString(key.to_vec()),
+                key_material: KeyMaterial::ByteString(Zeroizing::from(key.to_vec())),
                 attributes: Some(attributes),
             },
             cryptographic_length: Some(key.len() as i32 * 8),

--- a/crate/utils/src/crypto/cover_crypt/secret_key.rs
+++ b/crate/utils/src/crypto/cover_crypt/secret_key.rs
@@ -15,6 +15,7 @@ use cosmian_kmip::{
 };
 use serde::{Deserialize, Serialize};
 use tracing::{debug, trace};
+use zeroize::Zeroizing;
 
 use crate::crypto::cover_crypt::attributes::{
     access_policy_as_vendor_attribute, policy_from_attributes,
@@ -49,7 +50,7 @@ pub fn wrapped_secret_key(
 
     let cryptographic_length = sk.encrypted_symmetric_key.len() as i32 * 8;
     let key_value = KeyValue {
-        key_material: KeyMaterial::ByteString(sk.encrypted_symmetric_key),
+        key_material: KeyMaterial::ByteString(Zeroizing::from(sk.encrypted_symmetric_key)),
         attributes: Some(wrapped_key_attributes),
     };
     let key_wrapping_data = KeyWrappingData {

--- a/crate/utils/src/crypto/cover_crypt/user_key.rs
+++ b/crate/utils/src/crypto/cover_crypt/user_key.rs
@@ -18,6 +18,7 @@ use cosmian_kmip::{
     },
 };
 use tracing::trace;
+use zeroize::Zeroizing;
 
 use crate::crypto::cover_crypt::attributes::{
     access_policy_from_attributes, policy_from_attributes, upsert_access_policy_in_attributes,
@@ -29,7 +30,7 @@ use crate::crypto::cover_crypt::attributes::{
 /// see `cover_crypt_create_user_decryption_key_object` for the reverse operation
 pub(crate) fn unwrap_user_decryption_key_object(
     user_decryption_key: &Object,
-) -> Result<(Vec<u8>, AccessPolicy, Attributes), KmipError> {
+) -> Result<(Zeroizing<Vec<u8>>, AccessPolicy, Attributes), KmipError> {
     let key_block = match &user_decryption_key {
         Object::PrivateKey { key_block } => key_block.clone(),
         _ => {
@@ -148,7 +149,7 @@ impl UserDecryptionKeysHandler {
                 key_format_type: KeyFormatType::CoverCryptSecretKey,
                 key_compression_type: None,
                 key_value: KeyValue {
-                    key_material: KeyMaterial::ByteString(user_decryption_key_bytes.to_vec()),
+                    key_material: KeyMaterial::ByteString(user_decryption_key_bytes),
                     attributes: Some(attributes),
                 },
                 cryptographic_length: Some(user_decryption_key_len as i32 * 8),
@@ -203,7 +204,7 @@ impl UserDecryptionKeysHandler {
                 key_format_type: KeyFormatType::CoverCryptSecretKey,
                 key_compression_type: None,
                 key_value: KeyValue {
-                    key_material: KeyMaterial::ByteString(user_decryption_key_bytes.to_vec()),
+                    key_material: KeyMaterial::ByteString(user_decryption_key_bytes),
                     attributes: Some(usk_attributes),
                 },
                 cryptographic_length: Some(user_decryption_key_len),

--- a/crate/utils/src/crypto/symmetric/symmetric_key.rs
+++ b/crate/utils/src/crypto/symmetric/symmetric_key.rs
@@ -4,6 +4,7 @@ use cosmian_kmip::kmip::{
     kmip_operations::Create,
     kmip_types::{Attributes, CryptographicAlgorithm, CryptographicUsageMask, KeyFormatType},
 };
+use zeroize::Zeroizing;
 
 use crate::{error::KmipUtilsError, tagging::set_tags};
 
@@ -43,7 +44,7 @@ pub fn create_symmetric_key_kmip_object(
             key_compression_type: None,
             key_value: KeyValue {
                 key_material: KeyMaterial::TransparentSymmetricKey {
-                    key: key_bytes.to_vec(),
+                    key: Zeroizing::from(key_bytes.to_vec()),
                 },
                 attributes: Some(attributes),
             },

--- a/crate/utils/src/crypto/wrap/unwrap_key.rs
+++ b/crate/utils/src/crypto/wrap/unwrap_key.rs
@@ -66,9 +66,9 @@ pub fn unwrap_key_block(
             let plain_text = unwrap(unwrapping_key, key_wrapping_data, &ciphertext)?;
             let key_material: KeyMaterial = match object_key_block.key_format_type {
                 KeyFormatType::TransparentSymmetricKey => KeyMaterial::TransparentSymmetricKey {
-                    key: plain_text.to_vec(),
+                    key: plain_text.to_vec().into(),
                 },
-                _ => KeyMaterial::ByteString(plain_text.to_vec()),
+                _ => KeyMaterial::ByteString(plain_text.to_vec().into()),
             };
             KeyValue {
                 key_material,

--- a/crate/utils/src/crypto/wrap/wrap_key.rs
+++ b/crate/utils/src/crypto/wrap/wrap_key.rs
@@ -85,7 +85,7 @@ pub fn wrap_key_block(
             let key_to_wrap = Zeroizing::from(serde_json::to_vec(&object_key_block.key_value)?);
             let ciphertext = wrap(wrapping_key, &key_wrapping_data, &key_to_wrap)?;
             object_key_block.key_value = KeyValue {
-                key_material: KeyMaterial::ByteString(ciphertext),
+                key_material: KeyMaterial::ByteString(ciphertext.into()),
                 // not clear whether this should be filled or not
                 attributes: object_key_block.key_value.attributes.clone(),
             };
@@ -93,7 +93,7 @@ pub fn wrap_key_block(
         EncodingOption::NoEncoding => {
             let key_to_wrap = object_key_block.key_bytes()?;
             let ciphertext = wrap(wrapping_key, &key_wrapping_data, &key_to_wrap)?;
-            object_key_block.key_value.key_material = KeyMaterial::ByteString(ciphertext);
+            object_key_block.key_value.key_material = KeyMaterial::ByteString(ciphertext.into());
         }
     };
 


### PR DESCRIPTION
This PR changes many files but only in surface as it changes kmip structure `KeyMaterial` bytes arrays into a zeroizing type.