### PR TITLE
Temporarily ignore rustsec from pqc-kyber

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -16,6 +16,7 @@ ignore = [
   "RUSTSEC-2023-0018", # openssl-src
   "RUSTSEC-2023-0034", # openssl-src
   "RUSTSEC-2023-0071", # rsa
+  "RUSTSEC-2023-0079", # pqc-kyber
 ]
 # informational_warnings = ["unmaintained"] # warn for categories of informational advisories
 # severity_threshold = "low" # CVSS severity ("none", "low", "medium", "high", "critical")


### PR DESCRIPTION
Temporarily ignore RUSTSEC-2023-0079 from `pqc-kyber`.