### PR TITLE
Fix interpolation in error macros

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -17,7 +17,7 @@ jobs:
       archive-name: centos7_tests
       commands: |
         cargo build --bins
-        cargo test -- --nocapture
+        cargo test --workspace -- --nocapture
       artifacts: ''
 
   fips-centos7-test:
@@ -28,7 +28,7 @@ jobs:
       archive-name: fips_centos7_tests
       commands: |
         cargo build --bins --features fips
-        cargo test --features fips -- --nocapture
+        cargo test --workspace --features fips -- --nocapture
       artifacts: ''
 
   ubuntu-20-tests:
@@ -40,7 +40,7 @@ jobs:
       archive-name: ubuntu_20_04_tests
       commands: |
         cargo build --bins
-        cargo test -- --nocapture --skip test_mysql --skip test_pgsql --skip test_redis
+        cargo test --workspace -- --nocapture --skip test_mysql --skip test_pgsql --skip test_redis
       artifacts: ''
 
   fips-ubuntu-20-tests:
@@ -52,7 +52,7 @@ jobs:
       archive-name: fips_ubuntu_20_04_tests
       commands: |
         cargo build --bins --features fips
-        cargo test --features fips -- --nocapture --skip test_mysql --skip test_pgsql --skip test_redis
+        cargo test --workspace --features fips -- --nocapture --skip test_mysql --skip test_pgsql --skip test_redis
       artifacts: ''
 
   ubuntu-22-tests:
@@ -64,5 +64,5 @@ jobs:
       archive-name: ubuntu_22_04_tests
       commands: |
         cargo build --bins
-        cargo test -- --nocapture --skip test_mysql --skip test_pgsql --skip test_redis
+        cargo test --workspace -- --nocapture --skip test_mysql --skip test_pgsql --skip test_redis
       artifacts: ''

--- a/crate/kmip/src/crypto/password_derivation.rs
+++ b/crate/kmip/src/crypto/password_derivation.rs
@@ -33,10 +33,7 @@ pub fn derive_key_from_password<const LENGTH: usize>(
 ) -> Result<Secret<LENGTH>, KmipError> {
     // Check requested key length is in the authorized bounds.
     if LENGTH < FIPS_MIN_KLEN || LENGTH * 8 > FIPS_MAX_KLEN {
-        kmip_bail!(
-            "Password derivation error: wrong output length argument, got {}",
-            LENGTH,
-        )
+        kmip_bail!("Password derivation error: wrong output length argument, got {LENGTH}")
     }
 
     let mut output_key_material = Secret::<LENGTH>::new();
@@ -56,9 +53,9 @@ pub fn derive_key_from_password<const LENGTH: usize>(
     Ok(output_key_material)
 }
 
-#[cfg(not(feature = "fips"))]
 /// Derive a key into a LENGTH bytes key using Argon 2 by default, and PBKDF2
 /// with SHA512 in FIPS mode.
+#[cfg(not(feature = "fips"))]
 pub fn derive_key_from_password<const LENGTH: usize>(
     password: &[u8],
 ) -> Result<Secret<LENGTH>, KmipError> {
@@ -90,7 +87,6 @@ fn test_password_derivation() {
 #[test]
 #[cfg(feature = "fips")]
 fn test_password_derivation_bad_size() {
-    #[cfg(feature = "fips")]
     // Load FIPS provider module from OpenSSL.
     openssl::provider::Provider::load(None, "fips").unwrap();
 

--- a/crate/kmip/src/crypto/rsa/ckm_rsa_pkcs_oaep.rs
+++ b/crate/kmip/src/crypto/rsa/ckm_rsa_pkcs_oaep.rs
@@ -75,11 +75,11 @@ fn init_ckm_rsa_pkcs_oaep_encryption_context(
 ) -> Result<(PkeyCtx<Public>, Vec<u8>), KmipError> {
     let rsa_pub_key = pub_key.rsa()?;
     #[cfg(feature = "fips")]
-    if pub_key.bits() < FIPS_MIN_RSA_MODULUS_LENGTH {
+    if pub_key.bits() < (FIPS_MIN_RSA_MODULUS_LENGTH * 8) {
         kmip_bail!(
             "CKM_RSA_OAEP encryption error: RSA key has insufficient size: expected >= {} bits \
              and got {} bits",
-            FIPS_MIN_RSA_MODULUS_LENGTH,
+            (FIPS_MIN_RSA_MODULUS_LENGTH * 8),
             pub_key.bits()
         )
     }
@@ -146,11 +146,11 @@ fn init_ckm_rsa_pkcs_oaep_decryption_context(
 ) -> Result<(PkeyCtx<Private>, Zeroizing<Vec<u8>>), KmipError> {
     let rsa_priv_key = priv_key.rsa()?;
     #[cfg(feature = "fips")]
-    if priv_key.bits() < FIPS_MIN_RSA_MODULUS_LENGTH {
+    if priv_key.bits() < (FIPS_MIN_RSA_MODULUS_LENGTH * 8) {
         kmip_bail!(
             "CKM_RSA_OAEP decryption error: RSA key has insufficient size: expected >= {} bits \
              and got {} bits",
-            FIPS_MIN_RSA_MODULUS_LENGTH,
+            (FIPS_MIN_RSA_MODULUS_LENGTH * 8),
             priv_key.bits()
         )
     }

--- a/crate/kmip/src/crypto/secret.rs
+++ b/crate/kmip/src/crypto/secret.rs
@@ -58,7 +58,12 @@ impl<const LENGTH: usize> Secret<LENGTH> {
     #[inline(always)]
     #[must_use]
     pub fn new() -> Self {
-        Self(Box::pin([0; LENGTH]))
+        // heap-allocate and turn into `Box` but looses `LENGTH`-constraint  in type
+        let data = vec![0u8; LENGTH].into_boxed_slice();
+        // cast the raw pointer back to our fixed-length type
+        // it is considered safe because `data` is initialized in the previous line
+        let data = unsafe { Box::from_raw(Box::into_raw(data) as *mut [u8; LENGTH]) };
+        Self(Pin::new(data))
     }
 
     /// Creates a new random secret.

--- a/crate/kmip/src/crypto/secret.rs
+++ b/crate/kmip/src/crypto/secret.rs
@@ -58,7 +58,7 @@ impl<const LENGTH: usize> Secret<LENGTH> {
     #[inline(always)]
     #[must_use]
     pub fn new() -> Self {
-        // heap-allocate and turn into `Box` but looses `LENGTH`-constraint  in type
+        // heap-allocate and turn into `Box` but looses `LENGTH`-constraint in type
         let data = vec![0u8; LENGTH].into_boxed_slice();
         // cast the raw pointer back to our fixed-length type
         // it is considered safe because `data` is initialized in the previous line

--- a/crate/kmip/src/crypto/wrap/wrap_key.rs
+++ b/crate/kmip/src/crypto/wrap/wrap_key.rs
@@ -28,7 +28,7 @@ use crate::{
             CryptographicAlgorithm, EncodingOption, KeyFormatType, PaddingMethod, WrappingMethod,
         },
     },
-    kmip_bail,
+    kmip_bail, kmip_error,
     openssl::kmip_public_key_to_openssl,
 };
 
@@ -64,10 +64,7 @@ pub fn wrap_key_block(
             // ok
         }
         x => {
-            kmip_bail!(
-                "Unable to wrap the key: wrapping method is not supported: {:?}",
-                x
-            )
+            kmip_bail!("Unable to wrap the key: wrapping method is not supported: {x:?}")
         }
     }
 
@@ -88,7 +85,6 @@ pub fn wrap_key_block(
         ..KeyWrappingData::default()
     };
 
-    // wrap the key based on the encoding
     // wrap the key based on the encoding
     match encoding {
         EncodingOption::TTLVEncoding => {
@@ -151,7 +147,7 @@ pub(crate) fn wrap(
                     Ok(ciphertext)
                 }
                 KeyFormatType::TransparentECPublicKey | KeyFormatType::TransparentRSAPublicKey => {
-                    //convert to transparent key and wrap
+                    // convert to transparent key and wrap
                     // note: when moving to full openssl this double conversion will be unnecessary
                     let p_key = kmip_public_key_to_openssl(wrapping_key)?;
                     wrap_with_public_key(p_key, key_wrapping_data, key_to_wrap)
@@ -164,8 +160,7 @@ pub(crate) fn wrap(
                 x => {
                     kmip_bail!(
                         "Unable to wrap key: wrapping key: key format not supported for wrapping: \
-                         {:?}",
-                        x
+                         {x:?}"
                     )
                 }
             }?;
@@ -187,12 +182,9 @@ fn wrap_with_public_key(
         Id::RSA => wrap_with_rsa(public_key, key_wrapping_data, key_to_wrap),
         #[cfg(not(feature = "fips"))]
         Id::EC | Id::X25519 | Id::ED25519 => ecies_encrypt(&public_key, key_to_wrap),
-        other => {
-            kmip_bail!(
-                "Unable to wrap key: wrapping public key type not supported: {:?}",
-                other
-            )
-        }
+        other => Err(kmip_error!(
+            "Unable to wrap key: wrapping public key type not supported: {other:?}"
+        )),
     }
 }
 
@@ -203,21 +195,15 @@ fn wrap_with_rsa(
 ) -> Result<Vec<u8>, KmipError> {
     let (algorithm, padding, hashing_fn) = rsa_parameters(key_wrapping_data);
     if padding != PaddingMethod::OAEP {
-        kmip_bail!(
-            "Unable to wrap key with RSA: padding method not supported: {:?}",
-            padding
-        )
+        kmip_bail!("Unable to wrap key with RSA: padding method not supported: {padding:?}")
     }
     match algorithm {
         CryptographicAlgorithm::AES => ckm_rsa_aes_key_wrap(&pub_key, hashing_fn, key_to_wrap),
         CryptographicAlgorithm::RSA => {
             ckm_rsa_pkcs_oaep_key_wrap(&pub_key, hashing_fn, key_to_wrap)
         }
-        x => {
-            kmip_bail!(
-                "Unable to wrap key with RSA: algorithm not supported for wrapping: {:?}",
-                x
-            )
-        }
+        x => Err(kmip_error!(
+            "Unable to wrap key with RSA: algorithm not supported for wrapping: {x:?}"
+        )),
     }
 }

--- a/crate/kmip/src/lib.rs
+++ b/crate/kmip/src/lib.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::upper_case_acronyms)]
-//required to detect generic type in Serializer
+// required to detect generic type in Serializer
 #![feature(min_specialization)]
 // To parse a slice
 #![feature(slice_take)]

--- a/crate/kmip/src/openssl/public_key.rs
+++ b/crate/kmip/src/openssl/public_key.rs
@@ -138,8 +138,7 @@ pub fn kmip_public_key_to_openssl(public_key: &Object) -> Result<PKey<Public>, K
             ),
         },
         f => kmip_bail!(
-            "Unsupported key format type: {:?}, for tr transforming a {} to openssl",
-            f,
+            "Unsupported key format type: {f:?}, for tr transforming a {} to openssl",
             public_key.object_type()
         ),
     };
@@ -423,16 +422,10 @@ pub fn openssl_public_key_to_kmip(
                         key_compression_type: None,
                     }
                 }
-                x => kmip_bail!(
-                    "Unsupported curve key id: {:?} for a Transparent EC Public Key",
-                    x
-                ),
+                x => kmip_bail!("Unsupported curve key id: {x:?} for a Transparent EC Public Key"),
             }
         }
-        kft => kmip_bail!(
-            "Unsupported target key format type: {:?}, for an openssl public key",
-            kft
-        ),
+        kft => kmip_bail!("Unsupported target key format type: {kft:?}, for an openssl public key"),
     };
 
     Ok(Object::PublicKey { key_block })

--- a/crate/server/src/core/implementation.rs
+++ b/crate/server/src/core/implementation.rs
@@ -42,7 +42,7 @@ use crate::{
         Database,
     },
     error::KmsError,
-    kms_bail, kms_not_supported,
+    kms_bail,
     result::KResult,
 };
 
@@ -126,9 +126,9 @@ impl KMS {
             | CryptographicAlgorithm::SHA3512
             | CryptographicAlgorithm::SHAKE128
             | CryptographicAlgorithm::SHAKE256 => match attributes.key_format_type {
-                None => kms_bail!(KmsError::InvalidRequest(
+                None => Err(KmsError::InvalidRequest(
                     "Unable to create a symmetric key, the format type is not specified"
-                        .to_string()
+                        .to_string(),
                 )),
                 Some(KeyFormatType::TransparentSymmetricKey) => {
                     // create the key
@@ -143,13 +143,13 @@ impl KMS {
                     //return the object and the tags
                     Ok((object, tags))
                 }
-                Some(other) => kms_bail!(KmsError::InvalidRequest(format!(
+                Some(other) => Err(KmsError::InvalidRequest(format!(
                     "unable to generate a symmetric key for format: {other}"
                 ))),
             },
-            other => kms_not_supported!(
+            other => Err(KmsError::NotSupported(format!(
                 "the creation of secret key for algorithm: {other:?} is not supported"
-            ),
+            ))),
         }
     }
 
@@ -194,9 +194,9 @@ impl KMS {
                 .await?;
                 Ok((object, tags))
             }
-            other => kms_not_supported!(
+            other => Err(KmsError::NotSupported(format!(
                 "the creation of a private key for algorithm: {other:?} is not supported"
-            ),
+            ))),
         }
     }
 
@@ -309,10 +309,11 @@ impl KMS {
                     // Ed25519 not allowed for ECDH.
                     // see NIST.SP.800-186 - Section 3.1.2 table 2.
                     RecommendedCurve::CURVEED25519 => {
-                        kms_not_supported!(
+                        kms_bail!(KmsError::NotSupported(
                             "An Edwards Keypair on curve 25519 should not be requested to perform \
                              ECDH in FIPS mode."
-                        )
+                                .to_string()
+                        ))
                     }
                     #[cfg(not(feature = "fips"))]
                     RecommendedCurve::CURVEED448 => {
@@ -326,14 +327,15 @@ impl KMS {
                     // Ed448 not allowed for ECDH.
                     // see NIST.SP.800-186 - Section 3.1.2 table 2.
                     RecommendedCurve::CURVEED448 => {
-                        kms_not_supported!(
+                        kms_bail!(KmsError::NotSupported(
                             "An Edwards Keypair on curve 448 should not be requested to perform \
                              ECDH in FIPS mode."
-                        )
+                                .to_string()
+                        ))
                     }
-                    other => kms_not_supported!(
+                    other => kms_bail!(KmsError::NotSupported(format!(
                         "Generation of Key Pair for curve: {other:?}, is not supported"
-                    ),
+                    ))),
                 }
             }
             CryptographicAlgorithm::RSA => {
@@ -341,10 +343,7 @@ impl KMS {
                     .cryptographic_length
                     .ok_or_else(|| KmsError::InvalidRequest("RSA key size: error".to_string()))?
                     as u32;
-                trace!(
-                    "RSA key pair generation: size in bits: {}",
-                    key_size_in_bits
-                );
+                trace!("RSA key pair generation: size in bits: {key_size_in_bits}");
 
                 create_rsa_key_pair(key_size_in_bits, public_key_uid, private_key_uid)
             }
@@ -361,9 +360,9 @@ impl KMS {
                 request.public_key_attributes,
             )
             .map_err(Into::into),
-            other => kms_not_supported!(
+            other => kms_bail!(KmsError::NotSupported(format!(
                 "The creation of a key pair for algorithm: {other:?} is not supported"
-            ),
+            ))),
         }?;
         Ok((key_pair, sk_tags, pk_tags))
     }

--- a/crate/server/src/error.rs
+++ b/crate/server/src/error.rs
@@ -83,6 +83,16 @@ pub enum KmsError {
     RatlsError(String),
 }
 
+impl KmsError {
+    #[must_use]
+    pub fn reason(&self, reason: ErrorReason) -> Self {
+        match self {
+            Self::KmipError(_r, e) => Self::KmipError(reason, e.clone()),
+            e => Self::KmipError(reason, e.to_string()),
+        }
+    }
+}
+
 impl From<TtlvError> for KmsError {
     fn from(e: TtlvError) -> Self {
         Self::KmipError(ErrorReason::Codec_Error, e.to_string())
@@ -221,16 +231,6 @@ impl From<base64::DecodeError> for KmsError {
     }
 }
 
-impl KmsError {
-    #[must_use]
-    pub fn reason(&self, reason: ErrorReason) -> Self {
-        match self {
-            Self::KmipError(_r, e) => Self::KmipError(reason, e.clone()),
-            e => Self::KmipError(reason, e.to_string()),
-        }
-    }
-}
-
 /// Return early with an error if a condition is not satisfied.
 ///
 /// This macro is equivalent to `if !$cond { return Err(From::from($err)); }`.
@@ -238,7 +238,7 @@ impl KmsError {
 macro_rules! kms_ensure {
     ($cond:expr, $msg:literal $(,)?) => {
         if !$cond {
-            return ::core::result::Result::Err($crate::error::KmsError::ServerError($msg.to_owned()));
+            return ::core::result::Result::Err($crate::kms_error!($msg));
         }
     };
     ($cond:expr, $err:expr $(,)?) => {
@@ -248,7 +248,7 @@ macro_rules! kms_ensure {
     };
     ($cond:expr, $fmt:expr, $($arg:tt)*) => {
         if !$cond {
-            return ::core::result::Result::Err($crate::error::KmsError::ServerError(format!($fmt, $($arg)*)));
+            return ::core::result::Result::Err($crate::kms_error!($fmt, $($arg)*));
         }
     };
 }
@@ -257,13 +257,13 @@ macro_rules! kms_ensure {
 #[macro_export]
 macro_rules! kms_error {
     ($msg:literal) => {
-        $crate::error::KmsError::ServerError(format!($msg))
+        $crate::error::KmsError::ServerError(::core::format_args!($msg).to_string())
     };
     ($err:expr $(,)?) => ({
         $crate::error::KmsError::ServerError($err.to_string())
     });
     ($fmt:expr, $($arg:tt)*) => {
-        $crate::error::KmsError::ServerError(format!($fmt, $($arg)*))
+        $crate::error::KmsError::ServerError(::core::format_args!($fmt, $($arg)*).to_string())
     };
 }
 
@@ -271,23 +271,50 @@ macro_rules! kms_error {
 #[macro_export]
 macro_rules! kms_bail {
     ($msg:literal) => {
-        return ::core::result::Result::Err($crate::error::KmsError::ServerError(format!($msg)))
+        return ::core::result::Result::Err($crate::kms_error!($msg))
     };
     ($err:expr $(,)?) => {
         return ::core::result::Result::Err($err)
     };
     ($fmt:expr, $($arg:tt)*) => {
-        return ::core::result::Result::Err($crate::error::KmsError::ServerError(format!($fmt, $($arg)*)))
+        return ::core::result::Result::Err($crate::kms_error!($fmt, $($arg)*))
     };
 }
 
-/// Return early with an Unsupported error
-#[macro_export]
-macro_rules! kms_not_supported {
-    ($msg:literal) => {
-        return ::core::result::Result::Err($crate::error::KmsError::NotSupported(format!($msg)))
-    };
-    ($fmt:expr, $($arg:tt)*) => {
-        return ::core::result::Result::Err($crate::error::KmsError::NotSupported(format!($fmt, $($arg)*)))
-    };
+#[cfg(test)]
+mod tests {
+    use super::KmsError;
+
+    #[test]
+    fn test_kms_error_interpolation() {
+        let var = 42;
+        let err = kms_error!("interpolate {var}");
+        assert_eq!("Unexpected server error: interpolate 42", err.to_string());
+
+        let err = bail();
+        assert_eq!(
+            "Unexpected server error: interpolate 43",
+            err.unwrap_err().to_string()
+        );
+
+        let err = ensure();
+        assert_eq!(
+            "Unexpected server error: interpolate 44",
+            err.unwrap_err().to_string()
+        );
+    }
+
+    fn bail() -> Result<(), KmsError> {
+        let var = 43;
+        if true {
+            kms_bail!("interpolate {var}");
+        }
+        Ok(())
+    }
+
+    fn ensure() -> Result<(), KmsError> {
+        let var = 44;
+        kms_ensure!(false, "interpolate {var}");
+        Ok(())
+    }
 }


### PR DESCRIPTION
This PR fixes string interpolation.

Before, a code like:
```rust
let var = 42;
let err = kms_error!("interpolate {var}");
```
was rendering
```
"interpolate {var}"
```
with this PR it is rendering

```
"interpolate 42"
```

Also, this PR [fixes](https://github.com/Cosmian/kms/pull/184/commits/5b24cf2d0d5a77abf17b8ea308fe6af42f823abb#diff-460ab4609eec2aef5e10adf4fe17629e6cdf5a3cfd952de5a7256022006d4da5R61) the `Secret` instantiation by turning data init from stack to heap