### PR TITLE
Fixing inconsistent crypto consts

### DIFF
--- a/crate/kmip/src/crypto/elliptic_curves/operation.rs
+++ b/crate/kmip/src/crypto/elliptic_curves/operation.rs
@@ -465,6 +465,9 @@ pub fn create_approved_ecc_key_pair(
 mod tests {
     #[cfg(not(feature = "fips"))]
     use openssl::pkey::{Id, PKey};
+    // Load FIPS provider module from OpenSSL.
+    #[cfg(feature = "fips")]
+    use openssl::provider::Provider;
 
     #[cfg(feature = "fips")]
     use super::{check_ecc_mask_against_flags, check_ecc_mask_algorithm_compliance};
@@ -495,7 +498,7 @@ mod tests {
     fn test_ed25519_keypair_generation() {
         #[cfg(feature = "fips")]
         // Load FIPS provider module from OpenSSL.
-        openssl::provider::Provider::load(None, "fips").unwrap();
+        Provider::load(None, "fips").unwrap();
 
         let algorithm = Some(CryptographicAlgorithm::Ed25519);
         let private_key_mask = Some(CryptographicUsageMask::Sign);
@@ -538,10 +541,6 @@ mod tests {
     #[test]
     #[cfg(not(feature = "fips"))]
     fn test_x25519_conversions() {
-        #[cfg(feature = "fips")]
-        // Load FIPS provider module from OpenSSL.
-        openssl::provider::Provider::load(None, "fips").unwrap();
-
         // Create a Key pair
         // - the private key is a TransparentEcPrivateKey where the key value is the bytes of the scalar
         // - the public key is a TransparentEcPublicKey where the key value is the bytes of the Montgomery point
@@ -643,7 +642,7 @@ mod tests {
     fn test_approved_ecc_keypair_generation() {
         #[cfg(feature = "fips")]
         // Load FIPS provider module from OpenSSL.
-        openssl::provider::Provider::load(None, "fips").unwrap();
+        Provider::load(None, "fips").unwrap();
 
         // P-CURVES
         keypair_generation(RecommendedCurve::P224);
@@ -655,10 +654,6 @@ mod tests {
     #[test]
     #[cfg(not(feature = "fips"))]
     fn test_x448_conversions() {
-        #[cfg(feature = "fips")]
-        // Load FIPS provider module from OpenSSL.
-        openssl::provider::Provider::load(None, "fips").unwrap();
-
         // Create a Key pair
         // - the private key is a TransparentEcPrivateKey where the key value is the bytes of the scalar
         // - the public key is a TransparentEcPublicKey where the key value is the bytes of the Montgomery point
@@ -712,6 +707,9 @@ mod tests {
     #[test]
     #[cfg(feature = "fips")]
     fn test_mask_flags_exact() {
+        // Load FIPS provider module from OpenSSL.
+        Provider::load(None, "fips").unwrap();
+
         let mask = CryptographicUsageMask::Sign
             | CryptographicUsageMask::Verify
             | CryptographicUsageMask::Encrypt
@@ -730,6 +728,9 @@ mod tests {
     #[test]
     #[cfg(feature = "fips")]
     fn test_mask_flags_correct() {
+        // Load FIPS provider module from OpenSSL.
+        Provider::load(None, "fips").unwrap();
+
         let mask = CryptographicUsageMask::Authenticate;
 
         let flags = CryptographicUsageMask::Sign
@@ -746,6 +747,9 @@ mod tests {
     #[test]
     #[cfg(feature = "fips")]
     fn test_mask_flags_none() {
+        // Load FIPS provider module from OpenSSL.
+        Provider::load(None, "fips").unwrap();
+
         let flags = CryptographicUsageMask::Unrestricted;
 
         let res = check_ecc_mask_against_flags(None, flags);
@@ -756,6 +760,9 @@ mod tests {
     #[test]
     #[cfg(feature = "fips")]
     fn test_mask_flags_all() {
+        // Load FIPS provider module from OpenSSL.
+        Provider::load(None, "fips").unwrap();
+
         let mask = FIPS_PRIVATE_ECC_MASK_SIGN;
 
         let flags = CryptographicUsageMask::Sign
@@ -780,6 +787,9 @@ mod tests {
     #[test]
     #[cfg(feature = "fips")]
     fn test_mask_flags_fips_sign() {
+        // Load FIPS provider module from OpenSSL.
+        Provider::load(None, "fips").unwrap();
+
         let mask = CryptographicUsageMask::Sign;
         let res = check_ecc_mask_against_flags(Some(mask), FIPS_PRIVATE_ECC_MASK_SIGN);
 
@@ -794,6 +804,9 @@ mod tests {
     #[test]
     #[cfg(feature = "fips")]
     fn test_mask_flags_fips_dh() {
+        // Load FIPS provider module from OpenSSL.
+        Provider::load(None, "fips").unwrap();
+
         let mask = CryptographicUsageMask::KeyAgreement;
         let res = check_ecc_mask_against_flags(Some(mask), FIPS_PRIVATE_ECC_MASK_ECDH);
 
@@ -821,6 +834,9 @@ mod tests {
     #[cfg(feature = "fips")]
     /// This test should fail for unrestricted should not happen in FIPS mode.
     fn test_mask_flags_unrestricted1() {
+        // Load FIPS provider module from OpenSSL.
+        Provider::load(None, "fips").unwrap();
+
         let mask = CryptographicUsageMask::Unrestricted;
         let flags = CryptographicUsageMask::Unrestricted;
 
@@ -833,6 +849,9 @@ mod tests {
     #[cfg(feature = "fips")]
     /// This test should fail for unrestricted should not happen in FIPS mode.
     fn test_mask_flags_unrestricted2() {
+        // Load FIPS provider module from OpenSSL.
+        Provider::load(None, "fips").unwrap();
+
         let mask = CryptographicUsageMask::Sign
             | CryptographicUsageMask::Verify
             | CryptographicUsageMask::Encrypt
@@ -848,6 +867,9 @@ mod tests {
     #[cfg(feature = "fips")]
     /// This test should fail for unrestricted should not happen in FIPS mode.
     fn test_mask_flags_incorrect1() {
+        // Load FIPS provider module from OpenSSL.
+        Provider::load(None, "fips").unwrap();
+
         let mask = CryptographicUsageMask::Encrypt | CryptographicUsageMask::Decrypt;
         let flags = CryptographicUsageMask::Encrypt;
 
@@ -860,6 +882,9 @@ mod tests {
     #[cfg(feature = "fips")]
     /// This test should fail for unrestricted should not happen in FIPS mode.
     fn test_mask_flags_incorrect2() {
+        // Load FIPS provider module from OpenSSL.
+        Provider::load(None, "fips").unwrap();
+
         let mask = CryptographicUsageMask::WrapKey;
         let flags = CryptographicUsageMask::UnwrapKey;
 
@@ -872,6 +897,9 @@ mod tests {
     #[cfg(feature = "fips")]
     /// This test should fail for unrestricted should not happen in FIPS mode.
     fn test_mask_flags_incorrect3() {
+        // Load FIPS provider module from OpenSSL.
+        Provider::load(None, "fips").unwrap();
+
         let mask = CryptographicUsageMask::Sign
             | CryptographicUsageMask::Verify
             | CryptographicUsageMask::Encrypt
@@ -889,6 +917,9 @@ mod tests {
     #[test]
     #[cfg(feature = "fips")]
     fn test_check_ecc_algo_none() {
+        // Load FIPS provider module from OpenSSL.
+        Provider::load(None, "fips").unwrap();
+
         let private_key_mask = CryptographicUsageMask::Sign;
         let public_key_mask = CryptographicUsageMask::Verify;
 
@@ -906,6 +937,9 @@ mod tests {
     #[test]
     #[cfg(feature = "fips")]
     fn test_check_ecc_algo_contains() {
+        // Load FIPS provider module from OpenSSL.
+        Provider::load(None, "fips").unwrap();
+
         let private_key_mask = CryptographicUsageMask::KeyAgreement;
         let public_key_mask = CryptographicUsageMask::KeyAgreement;
 
@@ -928,6 +962,9 @@ mod tests {
     #[test]
     #[cfg(feature = "fips")]
     fn test_check_ecc_algo_not_contains() {
+        // Load FIPS provider module from OpenSSL.
+        Provider::load(None, "fips").unwrap();
+
         let private_key_mask = CryptographicUsageMask::KeyAgreement;
         let public_key_mask = CryptographicUsageMask::KeyAgreement;
 
@@ -946,6 +983,9 @@ mod tests {
     #[test]
     #[cfg(feature = "fips")]
     fn test_create_ecc_keys_bad_mask() {
+        // Load FIPS provider module from OpenSSL.
+        Provider::load(None, "fips").unwrap();
+
         let algorithm = CryptographicAlgorithm::EC;
         let private_key_mask = CryptographicUsageMask::Decrypt;
         let public_key_mask = CryptographicUsageMask::Encrypt;
@@ -1017,6 +1057,9 @@ mod tests {
     #[test]
     #[cfg(feature = "fips")]
     fn test_create_ecc_keys_bad_algorithm() {
+        // Load FIPS provider module from OpenSSL.
+        Provider::load(None, "fips").unwrap();
+
         let algorithm = CryptographicAlgorithm::Ed25519;
         let private_key_mask = CryptographicUsageMask::Sign;
         let public_key_mask = CryptographicUsageMask::Verify;
@@ -1062,6 +1105,9 @@ mod tests {
     #[test]
     #[cfg(feature = "fips")]
     fn test_create_ecc_keys_incorrect_mask_and_algorithm_ecdh() {
+        // Load FIPS provider module from OpenSSL.
+        Provider::load(None, "fips").unwrap();
+
         // ECDH algorithm should not have Sign and Verify masks;
         let algorithm = CryptographicAlgorithm::ECDH;
         let private_key_mask = CryptographicUsageMask::Sign
@@ -1085,6 +1131,9 @@ mod tests {
     #[test]
     #[cfg(feature = "fips")]
     fn test_create_ecc_keys_incorrect_mask_and_algorithm_ecdsa() {
+        // Load FIPS provider module from OpenSSL.
+        Provider::load(None, "fips").unwrap();
+
         // ECDSA algorithm should not have KeyAgreement mask;
         let algorithm = CryptographicAlgorithm::ECDSA;
         let private_key_mask = CryptographicUsageMask::Sign;
@@ -1104,6 +1153,9 @@ mod tests {
     #[test]
     #[cfg(feature = "fips")]
     fn test_create_ecc_keys_incorrect_private_mask() {
+        // Load FIPS provider module from OpenSSL.
+        Provider::load(None, "fips").unwrap();
+
         let algorithm = CryptographicAlgorithm::ECDSA;
         let private_key_mask = CryptographicUsageMask::Sign | CryptographicUsageMask::Verify;
         let public_key_mask = CryptographicUsageMask::Verify;
@@ -1122,6 +1174,9 @@ mod tests {
     #[test]
     #[cfg(feature = "fips")]
     fn test_create_ecc_keys_incorrect_public_mask() {
+        // Load FIPS provider module from OpenSSL.
+        Provider::load(None, "fips").unwrap();
+
         let algorithm = CryptographicAlgorithm::ECDSA;
         let private_key_mask = CryptographicUsageMask::Sign;
         let public_key_mask = CryptographicUsageMask::Sign;

--- a/crate/kmip/src/crypto/password_derivation.rs
+++ b/crate/kmip/src/crypto/password_derivation.rs
@@ -14,14 +14,14 @@ use crate::kmip_bail;
 const FIPS_MIN_SALT_SIZE: usize = 16;
 #[cfg(feature = "fips")]
 /// Output size in bits of the hash function used in PBKDF2.
-const FIPS_HLEN_BITS: usize = 512;
+const FIPS_HLEN: usize = 512;
 #[cfg(feature = "fips")]
 /// Minimum key length in bits to be derived in FIPS mode.
 const FIPS_MIN_KLEN: usize = 112;
 #[cfg(feature = "fips")]
 /// Max key length in bits authorized is (2^32 - 1) x hLen.
 /// Source: NIST.FIPS.800-132 - Section 5.3.
-const FIPS_MAX_KLEN: usize = ((1 << 32) - 1) * FIPS_HLEN_BITS;
+const FIPS_MAX_KLEN: usize = ((1 << 32) - 1) * FIPS_HLEN;
 
 #[cfg(feature = "fips")]
 /// OWASP recommended parameter for SHA-512 chosen following NIST.FIPS.800-132

--- a/crate/kmip/src/crypto/password_derivation.rs
+++ b/crate/kmip/src/crypto/password_derivation.rs
@@ -10,13 +10,16 @@ use crate::error::KmipError;
 #[cfg(feature = "fips")]
 use crate::kmip_bail;
 
+/// Minimum random salt size in bytes to use when deriving keys.
 const FIPS_MIN_SALT_SIZE: usize = 16;
 #[cfg(feature = "fips")]
+/// Output size in bits of the hash function used in PBKDF2.
 const FIPS_HLEN_BITS: usize = 512;
 #[cfg(feature = "fips")]
-const FIPS_MIN_KLEN: usize = 14;
+/// Minimum key length in bits to be derived in FIPS mode.
+const FIPS_MIN_KLEN: usize = 112;
 #[cfg(feature = "fips")]
-/// Max key length authorized is (2^32 - 1) x hLen.
+/// Max key length in bits authorized is (2^32 - 1) x hLen.
 /// Source: NIST.FIPS.800-132 - Section 5.3.
 const FIPS_MAX_KLEN: usize = ((1 << 32) - 1) * FIPS_HLEN_BITS;
 
@@ -31,8 +34,8 @@ const FIPS_MIN_ITER: usize = 210_000;
 pub fn derive_key_from_password<const LENGTH: usize>(
     password: &[u8],
 ) -> Result<Secret<LENGTH>, KmipError> {
-    // Check requested key length is in the authorized bounds.
-    if LENGTH < FIPS_MIN_KLEN || LENGTH * 8 > FIPS_MAX_KLEN {
+    // Check requested key length converted in bits is in the authorized bounds.
+    if LENGTH * 8 < FIPS_MIN_KLEN || LENGTH * 8 > FIPS_MAX_KLEN {
         kmip_bail!("Password derivation error: wrong output length argument, got {LENGTH}")
     }
 

--- a/crate/kmip/src/crypto/rsa/ckm_rsa_aes_key_wrap.rs
+++ b/crate/kmip/src/crypto/rsa/ckm_rsa_aes_key_wrap.rs
@@ -75,7 +75,7 @@ pub fn ckm_rsa_aes_key_unwrap(
     let rsa_privkey = p_key.rsa()?;
 
     #[cfg(feature = "fips")]
-    if rsa_privkey.size() < FIPS_MIN_RSA_MODULUS_LENGTH {
+    if p_key.bits() < FIPS_MIN_RSA_MODULUS_LENGTH {
         kmip_bail!(
             "CKM_RSA_OAEP decryption error: RSA key has insufficient size: expected >= {} bytes \
              and got {} bytes",

--- a/crate/kmip/src/crypto/rsa/ckm_rsa_pkcs_oaep.rs
+++ b/crate/kmip/src/crypto/rsa/ckm_rsa_pkcs_oaep.rs
@@ -75,11 +75,11 @@ fn init_ckm_rsa_pkcs_oaep_encryption_context(
 ) -> Result<(PkeyCtx<Public>, Vec<u8>), KmipError> {
     let rsa_pub_key = pub_key.rsa()?;
     #[cfg(feature = "fips")]
-    if pub_key.bits() < (FIPS_MIN_RSA_MODULUS_LENGTH * 8) {
+    if pub_key.bits() < FIPS_MIN_RSA_MODULUS_LENGTH {
         kmip_bail!(
             "CKM_RSA_OAEP encryption error: RSA key has insufficient size: expected >= {} bits \
              and got {} bits",
-            (FIPS_MIN_RSA_MODULUS_LENGTH * 8),
+            FIPS_MIN_RSA_MODULUS_LENGTH,
             pub_key.bits()
         )
     }
@@ -146,11 +146,11 @@ fn init_ckm_rsa_pkcs_oaep_decryption_context(
 ) -> Result<(PkeyCtx<Private>, Zeroizing<Vec<u8>>), KmipError> {
     let rsa_priv_key = priv_key.rsa()?;
     #[cfg(feature = "fips")]
-    if priv_key.bits() < (FIPS_MIN_RSA_MODULUS_LENGTH * 8) {
+    if priv_key.bits() < FIPS_MIN_RSA_MODULUS_LENGTH {
         kmip_bail!(
             "CKM_RSA_OAEP decryption error: RSA key has insufficient size: expected >= {} bits \
              and got {} bits",
-            (FIPS_MIN_RSA_MODULUS_LENGTH * 8),
+            FIPS_MIN_RSA_MODULUS_LENGTH,
             priv_key.bits()
         )
     }

--- a/crate/kmip/src/crypto/rsa/mod.rs
+++ b/crate/kmip/src/crypto/rsa/mod.rs
@@ -12,7 +12,8 @@ pub mod operation;
 pub mod rsa_oaep_aes_gcm;
 
 #[cfg(feature = "fips")]
-pub const FIPS_MIN_RSA_MODULUS_LENGTH: u32 = 256;
+/// FIPS minimum modulus length in bits.
+pub const FIPS_MIN_RSA_MODULUS_LENGTH: u32 = 2048;
 
 #[cfg(feature = "fips")]
 /// RSA private key mask usage for FIPS mode: signing, auth and encryption.

--- a/crate/kmip/src/crypto/rsa/operation.rs
+++ b/crate/kmip/src/crypto/rsa/operation.rs
@@ -230,6 +230,9 @@ pub fn create_rsa_key_pair(
 #[test]
 #[cfg(feature = "fips")]
 fn test_create_rsa_incorrect_mask() {
+    // Load FIPS provider module from OpenSSL.
+    openssl::provider::Provider::load(None, "fips").unwrap();
+
     let private_key_mask = Some(CryptographicUsageMask::Sign);
     let public_key_mask = Some(CryptographicUsageMask::Sign | CryptographicUsageMask::Verify);
 
@@ -262,6 +265,9 @@ fn test_create_rsa_incorrect_mask() {
 #[test]
 #[cfg(feature = "fips")]
 fn test_create_rsa_incorrect_mask_unrestricted() {
+    // Load FIPS provider module from OpenSSL.
+    openssl::provider::Provider::load(None, "fips").unwrap();
+
     let private_key_mask = Some(CryptographicUsageMask::Unrestricted);
     let public_key_mask = Some(CryptographicUsageMask::Verify);
 
@@ -294,6 +300,9 @@ fn test_create_rsa_incorrect_mask_unrestricted() {
 #[test]
 #[cfg(feature = "fips")]
 fn test_create_rsa_fips_mask() {
+    // Load FIPS provider module from OpenSSL.
+    openssl::provider::Provider::load(None, "fips").unwrap();
+
     let algorithm = Some(CryptographicAlgorithm::RSA);
 
     let res = create_rsa_key_pair(
@@ -311,6 +320,9 @@ fn test_create_rsa_fips_mask() {
 #[test]
 #[cfg(feature = "fips")]
 fn test_create_rsa_incorrect_algorithm() {
+    // Load FIPS provider module from OpenSSL.
+    openssl::provider::Provider::load(None, "fips").unwrap();
+
     let private_key_mask = Some(CryptographicUsageMask::Sign);
     let public_key_mask = Some(CryptographicUsageMask::Verify);
 

--- a/crate/kmip/src/crypto/rsa/operation.rs
+++ b/crate/kmip/src/crypto/rsa/operation.rs
@@ -196,10 +196,10 @@ pub fn create_rsa_key_pair(
     public_key_mask: Option<CryptographicUsageMask>,
 ) -> Result<KeyPair, KmipError> {
     #[cfg(feature = "fips")]
-    if key_size_in_bits < FIPS_MIN_RSA_MODULUS_LENGTH * 8 {
+    if key_size_in_bits < FIPS_MIN_RSA_MODULUS_LENGTH {
         kmip_bail!(
             "FIPS 140 mode requires a minimum key length of {} bits",
-            FIPS_MIN_RSA_MODULUS_LENGTH * 8
+            FIPS_MIN_RSA_MODULUS_LENGTH
         )
     }
 

--- a/crate/kmip/src/crypto/wrap/tests.rs
+++ b/crate/kmip/src/crypto/wrap/tests.rs
@@ -7,8 +7,9 @@ use openssl::{pkey::PKey, rand::rand_bytes, rsa::Rsa};
 
 #[cfg(not(feature = "fips"))]
 use crate::kmip::{
-    kmip_data_structures::KeyWrappingSpecification, kmip_objects::Object,
-    kmip_types::EncodingOption,
+    kmip_data_structures::KeyWrappingSpecification,
+    kmip_objects::Object,
+    kmip_types::{CryptographicUsageMask, EncodingOption},
 };
 #[cfg(not(feature = "fips"))]
 use crate::{
@@ -35,7 +36,6 @@ use crate::{
 fn test_wrap_unwrap() -> Result<(), KmipError> {
     // the symmetric wrapping key
 
-    use crate::kmip::kmip_types::CryptographicUsageMask;
     let mut sym_wrapping_key_bytes = vec![0; 32];
     rand_bytes(&mut sym_wrapping_key_bytes).unwrap();
     let sym_wrapping_key = create_symmetric_key_kmip_object(
@@ -173,8 +173,6 @@ fn test_encrypt_decrypt_rfc_5649() {
 #[test]
 #[cfg(not(feature = "fips"))]
 fn test_encrypt_decrypt_rfc_ecies_x25519() {
-    use crate::kmip::kmip_types::CryptographicUsageMask;
-
     let algorithm = Some(CryptographicAlgorithm::EC);
     let private_key_mask = Some(CryptographicUsageMask::Unrestricted);
     let public_key_mask = Some(CryptographicUsageMask::Unrestricted);

--- a/crate/server/src/core/implementation.rs
+++ b/crate/server/src/core/implementation.rs
@@ -260,7 +260,7 @@ impl KMS {
         })?;
 
         let key_pair = match cryptographic_algorithm {
-            // EC, ECDSA and ECDH posses the same FIPS restrictions for curves.
+            // EC, ECDSA and ECDH possess the same FIPS restrictions for curves.
             CryptographicAlgorithm::EC
             | CryptographicAlgorithm::ECDH
             | CryptographicAlgorithm::ECDSA => {


### PR DESCRIPTION
Declared crypto consts were describing sizes in both bits and bytes resulting in inconsistent comparisons and harder to read code.