### PR TITLE
use closures in CC keys update

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -16,8 +16,8 @@ jobs:
       toolchain: ${{ inputs.toolchain }}
       archive-name: centos7_tests
       commands: |
-        cargo build --bins
-        cargo test --workspace -- --nocapture
+        cargo build --release --bins
+        cargo test --release --workspace -- --nocapture
       artifacts: ''
 
   fips-centos7-test:
@@ -27,8 +27,8 @@ jobs:
       toolchain: ${{ inputs.toolchain }}
       archive-name: fips_centos7_tests
       commands: |
-        cargo build --bins --features fips
-        cargo test --workspace --features fips -- --nocapture
+        cargo build --release --bins --features fips
+        cargo test --release --workspace --features fips -- --nocapture
       artifacts: ''
 
   ubuntu-20-tests:
@@ -39,8 +39,8 @@ jobs:
       distribution: ubuntu-20.04
       archive-name: ubuntu_20_04_tests
       commands: |
-        cargo build --bins
-        cargo test --workspace -- --nocapture --skip test_mysql --skip test_pgsql --skip test_redis
+        cargo build --release --bins
+        cargo test --release --workspace -- --nocapture --skip test_mysql --skip test_pgsql --skip test_redis
       artifacts: ''
 
   fips-ubuntu-20-tests:
@@ -51,8 +51,8 @@ jobs:
       distribution: ubuntu-20.04
       archive-name: fips_ubuntu_20_04_tests
       commands: |
-        cargo build --bins --features fips
-        cargo test --workspace --features fips -- --nocapture --skip test_mysql --skip test_pgsql --skip test_redis
+        cargo build --release --bins --features fips
+        cargo test --release --workspace --features fips -- --nocapture --skip test_mysql --skip test_pgsql --skip test_redis
       artifacts: ''
 
   ubuntu-22-tests:
@@ -63,6 +63,6 @@ jobs:
       distribution: ubuntu-22.04
       archive-name: ubuntu_22_04_tests
       commands: |
-        cargo build --bins
-        cargo test --workspace -- --nocapture --skip test_mysql --skip test_pgsql --skip test_redis
+        cargo build --release --bins
+        cargo test --release --workspace -- --nocapture --skip test_mysql --skip test_pgsql --skip test_redis
       artifacts: ''

--- a/crate/kmip/src/crypto/cover_crypt/attributes.rs
+++ b/crate/kmip/src/crypto/cover_crypt/attributes.rs
@@ -172,17 +172,6 @@ pub enum RekeyEditAction {
     RenameAttribute(Vec<(abe_policy::Attribute, String)>),
 }
 
-impl RekeyEditAction {
-    pub fn induce_user_keys_refreshing(&self) -> bool {
-        match self {
-            Self::RekeyAccessPolicy(_) | Self::PruneAccessPolicy(_) | Self::RemoveAttribute(_) => {
-                true
-            }
-            Self::DisableAttribute(_) | Self::AddAttribute(_) | Self::RenameAttribute(_) => false,
-        }
-    }
-}
-
 /// Convert an edit action to a vendor attribute
 pub fn rekey_edit_action_as_vendor_attribute(
     action: RekeyEditAction,

--- a/crate/kmip/src/crypto/cover_crypt/master_keys.rs
+++ b/crate/kmip/src/crypto/cover_crypt/master_keys.rs
@@ -6,13 +6,7 @@ use zeroize::Zeroizing;
 
 use crate::{
     crypto::{
-        cover_crypt::attributes::{
-            deserialize_access_policy, policy_from_attributes, upsert_policy_in_attributes,
-            RekeyEditAction::{
-                self, AddAttribute, DisableAttribute, PruneAccessPolicy, RekeyAccessPolicy,
-                RemoveAttribute, RenameAttribute,
-            },
-        },
+        cover_crypt::attributes::{policy_from_attributes, upsert_policy_in_attributes},
         KeyPair,
     },
     error::KmipError,
@@ -26,6 +20,7 @@ use crate::{
         },
     },
 };
+
 /// Generate a `KeyPair` `(PrivateKey, MasterPublicKey)` from the attributes
 /// of a `CreateKeyPair` operation
 pub fn create_master_keypair(
@@ -164,85 +159,7 @@ fn create_master_public_key_object(
     })
 }
 
-/// Update a Covercrypt policy associated to a master key.
-pub fn update_policy(policy: &mut Policy, action: &RekeyEditAction) -> Result<(), KmipError> {
-    match action {
-        RekeyAccessPolicy(_) | PruneAccessPolicy(_) => Ok(()),
-        RemoveAttribute(attrs) => attrs
-            .iter()
-            .try_for_each(|attr| policy.remove_attribute(attr)), // TODO: tests revoking of existing keys with deleted attribute?
-        DisableAttribute(attrs) => attrs
-            .iter()
-            .try_for_each(|attr| policy.disable_attribute(attr)),
-        RenameAttribute(pairs_attr_name) => pairs_attr_name
-            .iter()
-            .try_for_each(|(attr, new_name)| policy.rename_attribute(attr, new_name.clone())),
-        AddAttribute(attrs_properties) => {
-            attrs_properties
-                .iter()
-                .try_for_each(|(attr, encryption_hint)| {
-                    policy.add_attribute(attr.clone(), *encryption_hint)
-                })
-        }
-    }
-    .map_err(|e| {
-        KmipError::KmipError(
-            ErrorReason::Unsupported_Cryptographic_Parameters,
-            e.to_string(),
-        )
-    })?;
-
-    Ok(())
-}
-
-/// Update the master key with a new Policy
-/// (after editing the policy typically)
-pub fn update_master_keys(
-    cover_crypt: &Covercrypt,
-    policy: &Policy,
-    action: &RekeyEditAction,
-    master_private_key: &Object,
-    master_private_key_uid: &str,
-    master_public_key: &Object,
-    master_public_key_uid: &str,
-) -> Result<(Object, Object), KmipError> {
-    let (mut msk, mut mpk) =
-        covercrypt_keys_from_kmip_objects(master_private_key, master_public_key)?;
-
-    // Update the keys
-    match action {
-        RenameAttribute(_) => Ok(()),
-        RemoveAttribute(_) | DisableAttribute(_) | AddAttribute(_) => {
-            cover_crypt.update_master_keys(policy, &mut msk, &mut mpk)
-        }
-        RekeyAccessPolicy(ap) => cover_crypt.rekey_master_keys(
-            &deserialize_access_policy(ap)?,
-            policy,
-            &mut msk,
-            &mut mpk,
-        ),
-        PruneAccessPolicy(ap) => {
-            cover_crypt.prune_master_secret_key(&deserialize_access_policy(ap)?, policy, &mut msk)
-        }
-    }
-    .map_err(|e| {
-        KmipError::KmipError(
-            ErrorReason::Cryptographic_Failure,
-            format!("Failed updating the CoverCrypt Master Keys: {e}"),
-        )
-    })?;
-
-    kmip_objects_from_covercrypt_keys(
-        policy,
-        &msk,
-        master_private_key,
-        master_public_key_uid,
-        &mpk,
-        master_private_key_uid,
-    )
-}
-
-fn covercrypt_keys_from_kmip_objects(
+pub fn covercrypt_keys_from_kmip_objects(
     master_private_key: &Object,
     master_public_key: &Object,
 ) -> Result<(MasterSecretKey, MasterPublicKey), KmipError> {
@@ -268,7 +185,8 @@ fn covercrypt_keys_from_kmip_objects(
 
     Ok((msk, mpk))
 }
-fn kmip_objects_from_covercrypt_keys(
+
+pub fn kmip_objects_from_covercrypt_keys(
     policy: &Policy,
     msk: &MasterSecretKey,
     master_private_key: &Object,

--- a/crate/kmip/src/crypto/cover_crypt/master_keys.rs
+++ b/crate/kmip/src/crypto/cover_crypt/master_keys.rs
@@ -189,11 +189,10 @@ pub fn covercrypt_keys_from_kmip_objects(
 pub fn kmip_objects_from_covercrypt_keys(
     policy: &Policy,
     msk: &MasterSecretKey,
-    master_private_key: &Object,
-    master_public_key_uid: &str,
     mpk: &MasterPublicKey,
-    master_private_key_uid: &str,
-) -> Result<(Object, Object), KmipError> {
+    msk_obj: (String, Object),
+    mpk_obj: (String, Object),
+) -> Result<((String, Object), (String, Object)), KmipError> {
     let updated_master_private_key_bytes = &msk.serialize().map_err(|e| {
         KmipError::KmipError(
             ErrorReason::Cryptographic_Failure,
@@ -203,8 +202,8 @@ pub fn kmip_objects_from_covercrypt_keys(
     let updated_master_private_key = create_master_private_key_object(
         updated_master_private_key_bytes,
         policy,
-        Some(master_private_key.attributes()?),
-        master_public_key_uid,
+        Some(msk_obj.1.attributes()?),
+        &mpk_obj.0,
     )?;
     let updated_master_public_key_bytes = &mpk.serialize().map_err(|e| {
         KmipError::KmipError(
@@ -215,9 +214,12 @@ pub fn kmip_objects_from_covercrypt_keys(
     let updated_master_public_key = create_master_public_key_object(
         updated_master_public_key_bytes,
         policy,
-        Some(master_private_key.attributes()?),
-        master_private_key_uid,
+        Some(msk_obj.1.attributes()?),
+        &msk_obj.0,
     )?;
 
-    Ok((updated_master_private_key, updated_master_public_key))
+    Ok((
+        (msk_obj.0, updated_master_private_key),
+        (mpk_obj.0, updated_master_public_key),
+    ))
 }

--- a/crate/kmip/src/crypto/cover_crypt/master_keys.rs
+++ b/crate/kmip/src/crypto/cover_crypt/master_keys.rs
@@ -21,6 +21,9 @@ use crate::{
     },
 };
 
+/// Group a key UID with its KMIP Object
+pub type KmipKeyUidObject = (String, Object);
+
 /// Generate a `KeyPair` `(PrivateKey, MasterPublicKey)` from the attributes
 /// of a `CreateKeyPair` operation
 pub fn create_master_keypair(
@@ -190,9 +193,9 @@ pub fn kmip_objects_from_covercrypt_keys(
     policy: &Policy,
     msk: &MasterSecretKey,
     mpk: &MasterPublicKey,
-    msk_obj: (String, Object),
-    mpk_obj: (String, Object),
-) -> Result<((String, Object), (String, Object)), KmipError> {
+    msk_obj: KmipKeyUidObject,
+    mpk_obj: KmipKeyUidObject,
+) -> Result<(KmipKeyUidObject, KmipKeyUidObject), KmipError> {
     let updated_master_private_key_bytes = &msk.serialize().map_err(|e| {
         KmipError::KmipError(
             ErrorReason::Cryptographic_Failure,
@@ -214,7 +217,7 @@ pub fn kmip_objects_from_covercrypt_keys(
     let updated_master_public_key = create_master_public_key_object(
         updated_master_public_key_bytes,
         policy,
-        Some(msk_obj.1.attributes()?),
+        Some(mpk_obj.1.attributes()?),
         &msk_obj.0,
     )?;
 

--- a/crate/server/src/core/cover_crypt/rekey_keys.rs
+++ b/crate/server/src/core/cover_crypt/rekey_keys.rs
@@ -131,8 +131,8 @@ pub async fn rekey_keypair_cover_crypt(
     })
 }
 
-/// Update the master key with a new Policy
-/// (after editing the policy typically)
+/// Updates the key-pair associated to the MSK which ID is given using the given mutator, and
+/// replaces the stored key-pair with the mutated one.
 pub async fn update_master_keys(
     server: &KMS,
     owner: &str,

--- a/crate/server/src/core/cover_crypt/rekey_keys.rs
+++ b/crate/server/src/core/cover_crypt/rekey_keys.rs
@@ -4,7 +4,9 @@ use cloudproof::reexport::cover_crypt::{
 use cosmian_kmip::{
     crypto::cover_crypt::{
         attributes::{deserialize_access_policy, policy_from_attributes, RekeyEditAction},
-        master_keys::{covercrypt_keys_from_kmip_objects, kmip_objects_from_covercrypt_keys},
+        master_keys::{
+            covercrypt_keys_from_kmip_objects, kmip_objects_from_covercrypt_keys, KmipKeyUidObject,
+        },
         user_key::UserDecryptionKeysHandler,
     },
     kmip::{
@@ -158,7 +160,7 @@ async fn get_master_keys_and_policy(
     msk_uid: String,
     owner: &str,
     params: Option<&ExtraDatabaseParams>,
-) -> KResult<((String, Object), (String, Object), Policy)> {
+) -> KResult<(KmipKeyUidObject, KmipKeyUidObject, Policy)> {
     // Recover the master private key
     let msk = kmip_server
         .get(Get::from(&msk_uid), owner, params)
@@ -207,8 +209,8 @@ async fn import_rekeyed_master_keys(
     kmip_server: &KMS,
     owner: &str,
     params: Option<&ExtraDatabaseParams>,
-    msk: (String, Object),
-    mpk: (String, Object),
+    msk: KmipKeyUidObject,
+    mpk: KmipKeyUidObject,
 ) -> KResult<()> {
     // re_import it
     let import_request = Import {
@@ -240,7 +242,7 @@ async fn import_rekeyed_master_keys(
 async fn update_user_secret_keys(
     kmip_server: &KMS,
     cover_crypt: Covercrypt,
-    msk_obj: &(String, Object),
+    msk_obj: &KmipKeyUidObject,
     owner: &str,
     params: Option<&ExtraDatabaseParams>,
 ) -> KResult<()> {

--- a/crate/server/src/core/operations/rekey_keypair.rs
+++ b/crate/server/src/core/operations/rekey_keypair.rs
@@ -81,7 +81,7 @@ pub async fn rekey_keypair(
 
     if Some(CryptographicAlgorithm::CoverCrypt) == attributes.cryptographic_algorithm {
         let action = rekey_edit_action_from_attributes(attributes)?;
-        rekey_keypair_cover_crypt(kms, Covercrypt::default(), &owm.id, user, action, params).await
+        rekey_keypair_cover_crypt(kms, Covercrypt::default(), owm.id, user, action, params).await
     } else if let Some(other) = attributes.cryptographic_algorithm {
         kms_bail!(KmsError::NotSupported(format!(
             "The rekey of a key pair for algorithm: {other:?} is not yet supported"


### PR DESCRIPTION
This PR:
- merges the three `match` blocks into one. This leads to a slightly too big function, but it is mainly doing control flow. All actions are performed in dedicated procedures.
- master keys and user keys update procedures both grossly follow the scheme "fetch, mutate, then send".