### PR TITLE
bugfix: fixed trailing null byte bug for biguint/bytes conversions

### DIFF
--- a/crate/kmip/src/crypto/elliptic_curves/ecies/mod.rs
+++ b/crate/kmip/src/crypto/elliptic_curves/ecies/mod.rs
@@ -62,7 +62,6 @@ pub fn ecies_decrypt(
 ) -> Result<Zeroizing<Vec<u8>>, KmipError> {
     let plaintext = match private_key.id() {
         Id::EC => standard_curves::ecies_decrypt(private_key, ciphertext)?,
-        #[cfg(not(feature = "fips"))]
         Id::ED25519 | Id::X25519 => salsa_sealbox::sealbox_decrypt(private_key, ciphertext)?,
         x => {
             kmip_bail!("private key id not supported yet: {:?}", x);

--- a/crate/kmip/src/crypto/elliptic_curves/ecies/standard_curves.rs
+++ b/crate/kmip/src/crypto/elliptic_curves/ecies/standard_curves.rs
@@ -24,7 +24,7 @@ fn ecies_get_iv(
     iv_size: usize,
     message_digest: MessageDigest,
 ) -> Result<Vec<u8>, KmipError> {
-    let mut ctx = BigNumContext::new_secure()?;
+    let mut ctx = BigNumContext::new()?;
     let Q_bytes = Q.to_bytes(curve, PointConversionForm::COMPRESSED, &mut ctx)?;
     let R_bytes = R.to_bytes(curve, PointConversionForm::COMPRESSED, &mut ctx)?;
 
@@ -190,12 +190,8 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "fips"))]
     fn test_ecies_encrypt_decrypt_p_curves() {
-        #[cfg(feature = "fips")]
-        // Load FIPS provider module from OpenSSL.
-        openssl::provider::Provider::load(None, "fips").unwrap();
-
-        #[cfg(not(feature = "fips"))]
         test_ecies_encrypt_decrypt(Nid::X9_62_PRIME192V1);
         test_ecies_encrypt_decrypt(Nid::SECP224R1);
         test_ecies_encrypt_decrypt(Nid::X9_62_PRIME256V1);

--- a/crate/kmip/src/crypto/elliptic_curves/operation.rs
+++ b/crate/kmip/src/crypto/elliptic_curves/operation.rs
@@ -449,7 +449,7 @@ pub fn create_approved_ecc_key_pair(
     let public_key = to_ec_public_key(
         &ec_private_key
             .public_key()
-            .to_bytes(&group, PointConversionForm::HYBRID, &mut ctx)?,
+            .to_bytes(&group, PointConversionForm::COMPRESSED, &mut ctx)?,
         ec_private_key.private_key().num_bits() as u32,
         private_key_uid,
         curve,

--- a/crate/kmip/src/kmip/ttlv/mod.rs
+++ b/crate/kmip/src/kmip/ttlv/mod.rs
@@ -469,14 +469,17 @@ pub fn to_u32_digits(big_int: &BigUint) -> Vec<u32> {
     // In this case, using this to convert a BigUint to a Vec<u32> will not lose
     // leading null bytes information which might be the case when an EC private
     // key is legally generated with leading null bytes.
-    big_int
-        .to_bytes_be()
+    let mut bytes_be = big_int.to_bytes_be();
+    bytes_be.reverse();
+
+    bytes_be
         .chunks(4)
         .map(|group_of_4_bytes| {
-            group_of_4_bytes
-                .iter()
-                .rev()
-                .fold(0, |acc, byte| (acc << 8) + u32::from(*byte))
+            let mut acc = 0;
+            for (k, elt) in group_of_4_bytes.iter().enumerate() {
+                acc += *elt as u32 * 2_u32.pow(k as u32 * 8);
+            }
+            acc
         })
         .collect::<Vec<_>>()
 }

--- a/crate/kmip/src/openssl/private_key.rs
+++ b/crate/kmip/src/openssl/private_key.rs
@@ -193,7 +193,7 @@ fn ec_private_key_from_scalar(
 
     let mut scalar_vec = scalar.to_bytes_be();
     pad_be_bytes(&mut scalar_vec, privkey_size);
-    let scalar = BigNum::from_slice(scalar.to_bytes_be().as_slice())?;
+    let scalar = BigNum::from_slice(&scalar_vec)?;
 
     let ec_group = EcGroup::from_curve_name(nid)?;
     let mut ec_public_key = EcPoint::new(&ec_group)?;

--- a/crate/server/src/core/operations/decrypt.rs
+++ b/crate/server/src/core/operations/decrypt.rs
@@ -193,7 +193,7 @@ fn decrypt_with_private_key(
         | KeyFormatType::PKCS1
         | KeyFormatType::PKCS8 => {
             let ciphertext = request.data.as_ref().ok_or_else(|| {
-                KmsError::InvalidRequest("Encrypt: data to decrypt must be provided".to_owned())
+                KmsError::InvalidRequest("Decrypt: data to decrypt must be provided".to_owned())
             })?;
             trace!(
                 "get_decryption_system: matching on key format type: {:?}",


### PR DESCRIPTION
EC keys with a trailing null byte were being wrongfully processed during BigUint-bytes conversions resulting in loss of information on the private key and different encryption values.

This was due to a wrong implementation of the method converting big-endian encoded BigUint to u32 words.
This PR aims at fixing this bug.

Took the opportunity to remove irrelevant `#[cfg]`.