### PR TITLE
Check usagemask crypto operations

### DIFF
--- a/crate/cli/src/actions/certificates/import_certificate.rs
+++ b/crate/cli/src/actions/certificates/import_certificate.rs
@@ -256,13 +256,11 @@ impl ImportCertificateAction {
         let pkcs12_bytes = Zeroizing::from(read_bytes_from_file(&self.get_certificate_file()?)?);
 
         // Create a KMIP private key from the PKCS12 private key
-        let private_key = build_private_key_from_der_bytes(
-            KeyFormatType::PKCS12,
-            pkcs12_bytes,
-            cryptographic_usage_mask,
-        );
+        let private_key = build_private_key_from_der_bytes(KeyFormatType::PKCS12, pkcs12_bytes);
 
         let mut attributes = private_key.attributes().cloned().unwrap_or_default();
+        attributes.set_cryptographic_usage_mask(cryptographic_usage_mask);
+
         if let Some(password) = &self.pkcs12_password {
             attributes.add_link(
                 LinkType::PKCS12PasswordLink,

--- a/crate/cli/src/actions/certificates/import_certificate.rs
+++ b/crate/cli/src/actions/certificates/import_certificate.rs
@@ -252,7 +252,10 @@ impl ImportCertificateAction {
 
     /// Import the certificate, the chain and the associated private key
     async fn import_pkcs12(&self, kms_rest_client: &KmsClient) -> Result<String, CliError> {
-        let cryptographic_usage_mask = build_usage_mask_from_key_usage(&self.key_usage);
+        let cryptographic_usage_mask = self
+            .key_usage
+            .as_deref()
+            .and_then(build_usage_mask_from_key_usage);
         let pkcs12_bytes = Zeroizing::from(read_bytes_from_file(&self.get_certificate_file()?)?);
 
         // Create a KMIP private key from the PKCS12 private key

--- a/crate/cli/src/actions/shared/import_key.rs
+++ b/crate/cli/src/actions/shared/import_key.rs
@@ -116,9 +116,8 @@ impl ImportKeyAction {
         let object = match &self.key_format {
             ImportKeyFormat::JsonTtlv => {
                 let mut obj = read_object_from_json_ttlv_bytes(&bytes)?;
-                if let Ok(attr) = obj.attributes_mut() {
-                    attr.set_cryptographic_usage_mask(cryptographic_usage_mask);
-                }
+                obj.attributes_mut()?
+                    .set_cryptographic_usage_mask(cryptographic_usage_mask);
                 obj
             }
             ImportKeyFormat::Pem => read_key_from_pem(&bytes, cryptographic_usage_mask)?,

--- a/crate/cli/src/actions/shared/import_key.rs
+++ b/crate/cli/src/actions/shared/import_key.rs
@@ -109,7 +109,10 @@ pub struct ImportKeyAction {
 
 impl ImportKeyAction {
     pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
-        let cryptographic_usage_mask = build_usage_mask_from_key_usage(&self.key_usage);
+        let cryptographic_usage_mask = self
+            .key_usage
+            .as_deref()
+            .and_then(build_usage_mask_from_key_usage);
         // read the key file
         let bytes = Zeroizing::from(read_bytes_from_file(&self.key_file)?);
         let mut object = match &self.key_format {

--- a/crate/cli/src/actions/shared/import_key.rs
+++ b/crate/cli/src/actions/shared/import_key.rs
@@ -160,31 +160,30 @@ impl ImportKeyAction {
         let object_type = object.object_type();
 
         // Generate the import attributes if links are specified.
-        let mut import_attributes = object.attributes().ok().cloned();
-        if import_attributes.is_none() {
-            import_attributes = Some(Attributes {
+        let mut import_attributes = object
+            .attributes()
+            .unwrap_or(&Attributes {
                 cryptographic_usage_mask,
                 ..Default::default()
             })
-        }
+            .clone();
 
         if let Some(issuer_certificate_id) = &self.certificate_id {
-            let attributes = import_attributes.get_or_insert(Attributes::default());
-            attributes.add_link(
+            //let attributes = import_attributes.get_or_insert(Attributes::default());
+            import_attributes.add_link(
                 LinkType::CertificateLink,
                 LinkedObjectIdentifier::TextString(issuer_certificate_id.clone()),
             );
         };
         if let Some(private_key_id) = &self.private_key_id {
-            let attributes = import_attributes.get_or_insert(Attributes::default());
-            attributes.add_link(
+            //let attributes = import_attributes.get_or_insert(Attributes::default());
+            import_attributes.add_link(
                 LinkType::PrivateKeyLink,
                 LinkedObjectIdentifier::TextString(private_key_id.clone()),
             );
         };
         if let Some(public_key_id) = &self.public_key_id {
-            let attributes = import_attributes.get_or_insert(Attributes::default());
-            attributes.add_link(
+            import_attributes.add_link(
                 LinkType::PublicKeyLink,
                 LinkedObjectIdentifier::TextString(public_key_id.clone()),
             );
@@ -195,7 +194,7 @@ impl ImportKeyAction {
             kms_rest_client,
             self.key_id.clone(),
             object,
-            import_attributes,
+            Some(import_attributes),
             self.unwrap,
             self.replace_existing,
             &self.tags,

--- a/crate/cli/src/actions/shared/utils/key_usage.rs
+++ b/crate/cli/src/actions/shared/utils/key_usage.rs
@@ -18,6 +18,28 @@ pub enum KeyUsage {
     Unrestricted,
 }
 
+impl From<KeyUsage> for String {
+    fn from(key_usage: KeyUsage) -> Self {
+        match key_usage {
+            KeyUsage::Sign => "sign",
+            KeyUsage::Verify => "verify",
+            KeyUsage::Encrypt => "encrypt",
+            KeyUsage::Decrypt => "decrypt",
+            KeyUsage::WrapKey => "wrap-key",
+            KeyUsage::UnwrapKey => "unwrap-key",
+            KeyUsage::MACGenerate => "mac-generate",
+            KeyUsage::MACVerify => "mac-verify",
+            KeyUsage::DeriveKey => "derive-key",
+            KeyUsage::KeyAgreement => "key-agreement",
+            KeyUsage::CertificateSign => "certificate-sign",
+            KeyUsage::CRLSign => "crl-sign",
+            KeyUsage::Authenticate => "authenticate",
+            KeyUsage::Unrestricted => "unrestricted",
+        }
+        .to_string()
+    }
+}
+
 pub fn build_usage_mask_from_key_usage(
     key_usage_vec: &Option<Vec<KeyUsage>>,
 ) -> Option<CryptographicUsageMask> {

--- a/crate/cli/src/actions/shared/utils/key_usage.rs
+++ b/crate/cli/src/actions/shared/utils/key_usage.rs
@@ -1,0 +1,51 @@
+use cosmian_kms_client::kmip::kmip_types::CryptographicUsageMask;
+
+#[derive(clap::ValueEnum, Debug, Clone)]
+pub enum KeyUsage {
+    Sign,
+    Verify,
+    Encrypt,
+    Decrypt,
+    WrapKey,
+    UnwrapKey,
+    MACGenerate,
+    MACVerify,
+    DeriveKey,
+    KeyAgreement,
+    CertificateSign,
+    CRLSign,
+    Authenticate,
+    Unrestricted,
+}
+
+pub fn build_usage_mask_from_key_usage(
+    key_usage_vec: &Option<Vec<KeyUsage>>,
+) -> Option<CryptographicUsageMask> {
+    match key_usage_vec {
+        None => None,
+        Some(key_usage_vec) => {
+            let mut flags = 0;
+
+            for key_usage in key_usage_vec {
+                flags |= match key_usage {
+                    KeyUsage::Sign => CryptographicUsageMask::Sign,
+                    KeyUsage::Verify => CryptographicUsageMask::Verify,
+                    KeyUsage::Encrypt => CryptographicUsageMask::Encrypt,
+                    KeyUsage::Decrypt => CryptographicUsageMask::Decrypt,
+                    KeyUsage::WrapKey => CryptographicUsageMask::WrapKey,
+                    KeyUsage::UnwrapKey => CryptographicUsageMask::UnwrapKey,
+                    KeyUsage::MACGenerate => CryptographicUsageMask::MACGenerate,
+                    KeyUsage::MACVerify => CryptographicUsageMask::MACVerify,
+                    KeyUsage::DeriveKey => CryptographicUsageMask::DeriveKey,
+                    KeyUsage::KeyAgreement => CryptographicUsageMask::KeyAgreement,
+                    KeyUsage::CertificateSign => CryptographicUsageMask::CertificateSign,
+                    KeyUsage::CRLSign => CryptographicUsageMask::CRLSign,
+                    KeyUsage::Authenticate => CryptographicUsageMask::Authenticate,
+                    KeyUsage::Unrestricted => CryptographicUsageMask::Unrestricted,
+                }
+                .bits();
+            }
+            CryptographicUsageMask::from_bits(flags)
+        }
+    }
+}

--- a/crate/cli/src/actions/shared/utils/key_usage.rs
+++ b/crate/cli/src/actions/shared/utils/key_usage.rs
@@ -41,33 +41,27 @@ impl From<KeyUsage> for String {
 }
 
 pub fn build_usage_mask_from_key_usage(
-    key_usage_vec: &Option<Vec<KeyUsage>>,
+    key_usage_vec: &[KeyUsage],
 ) -> Option<CryptographicUsageMask> {
-    match key_usage_vec {
-        None => None,
-        Some(key_usage_vec) => {
-            let mut flags = 0;
-
-            for key_usage in key_usage_vec {
-                flags |= match key_usage {
-                    KeyUsage::Sign => CryptographicUsageMask::Sign,
-                    KeyUsage::Verify => CryptographicUsageMask::Verify,
-                    KeyUsage::Encrypt => CryptographicUsageMask::Encrypt,
-                    KeyUsage::Decrypt => CryptographicUsageMask::Decrypt,
-                    KeyUsage::WrapKey => CryptographicUsageMask::WrapKey,
-                    KeyUsage::UnwrapKey => CryptographicUsageMask::UnwrapKey,
-                    KeyUsage::MACGenerate => CryptographicUsageMask::MACGenerate,
-                    KeyUsage::MACVerify => CryptographicUsageMask::MACVerify,
-                    KeyUsage::DeriveKey => CryptographicUsageMask::DeriveKey,
-                    KeyUsage::KeyAgreement => CryptographicUsageMask::KeyAgreement,
-                    KeyUsage::CertificateSign => CryptographicUsageMask::CertificateSign,
-                    KeyUsage::CRLSign => CryptographicUsageMask::CRLSign,
-                    KeyUsage::Authenticate => CryptographicUsageMask::Authenticate,
-                    KeyUsage::Unrestricted => CryptographicUsageMask::Unrestricted,
-                }
-                .bits();
-            }
-            CryptographicUsageMask::from_bits(flags)
+    let mut flags = 0;
+    for key_usage in key_usage_vec {
+        flags |= match key_usage {
+            KeyUsage::Sign => CryptographicUsageMask::Sign,
+            KeyUsage::Verify => CryptographicUsageMask::Verify,
+            KeyUsage::Encrypt => CryptographicUsageMask::Encrypt,
+            KeyUsage::Decrypt => CryptographicUsageMask::Decrypt,
+            KeyUsage::WrapKey => CryptographicUsageMask::WrapKey,
+            KeyUsage::UnwrapKey => CryptographicUsageMask::UnwrapKey,
+            KeyUsage::MACGenerate => CryptographicUsageMask::MACGenerate,
+            KeyUsage::MACVerify => CryptographicUsageMask::MACVerify,
+            KeyUsage::DeriveKey => CryptographicUsageMask::DeriveKey,
+            KeyUsage::KeyAgreement => CryptographicUsageMask::KeyAgreement,
+            KeyUsage::CertificateSign => CryptographicUsageMask::CertificateSign,
+            KeyUsage::CRLSign => CryptographicUsageMask::CRLSign,
+            KeyUsage::Authenticate => CryptographicUsageMask::Authenticate,
+            KeyUsage::Unrestricted => CryptographicUsageMask::Unrestricted,
         }
+        .bits();
     }
+    CryptographicUsageMask::from_bits(flags)
 }

--- a/crate/cli/src/actions/shared/utils/mod.rs
+++ b/crate/cli/src/actions/shared/utils/mod.rs
@@ -1,5 +1,7 @@
 pub(crate) use destroy_utils::destroy;
+pub(crate) use key_usage::{build_usage_mask_from_key_usage, KeyUsage};
 pub(crate) use revoke_utils::revoke;
 
 mod destroy_utils;
+mod key_usage;
 mod revoke_utils;

--- a/crate/cli/src/tests/certificates/certify.rs
+++ b/crate/cli/src/tests/certificates/certify.rs
@@ -119,6 +119,7 @@ async fn test_certify_a_csr() -> Result<(), CliError> {
         None,
         None,
         Some(&["root_ca"]),
+        None,
         false,
         true,
     )?;
@@ -134,6 +135,7 @@ async fn test_certify_a_csr() -> Result<(), CliError> {
         None,
         None,
         Some(&["intermediate_ca"]),
+        None,
         false,
         true,
     )?;
@@ -227,6 +229,7 @@ async fn test_certify_a_csr_with_extensions() -> Result<(), CliError> {
         None,
         None,
         Some(&["root_ca"]),
+        None,
         false,
         true,
     )?;
@@ -242,6 +245,7 @@ async fn test_certify_a_csr_with_extensions() -> Result<(), CliError> {
         None,
         None,
         Some(&["intermediate_ca"]),
+        None,
         false,
         true,
     )?;

--- a/crate/cli/src/tests/certificates/certify.rs
+++ b/crate/cli/src/tests/certificates/certify.rs
@@ -392,6 +392,7 @@ async fn certify_a_public_key_test() -> Result<(), CliError> {
         None,
         None,
         Some(&["root_ca"]),
+        None,
         false,
         true,
     )?;
@@ -407,6 +408,7 @@ async fn certify_a_public_key_test() -> Result<(), CliError> {
         None,
         None,
         Some(&["intermediate_ca"]),
+        None,
         false,
         true,
     )?;

--- a/crate/cli/src/tests/certificates/encrypt.rs
+++ b/crate/cli/src/tests/certificates/encrypt.rs
@@ -11,7 +11,7 @@ use super::SUB_COMMAND;
 use crate::{
     actions::{
         certificates::CertificateInputFormat,
-        shared::{import_key::ImportKeyFormat, ExportKeyFormat},
+        shared::{import_key::ImportKeyFormat, utils::KeyUsage, ExportKeyFormat},
     },
     error::CliError,
     tests::{
@@ -293,6 +293,7 @@ async fn import_encrypt_decrypt(filename: &str) -> Result<(), CliError> {
             .map(|&s| s.to_string())
             .collect::<Vec<String>>()
             .as_slice(),
+        Some(vec![KeyUsage::Decrypt, KeyUsage::UnwrapKey]),
         false,
         true,
     )?;
@@ -308,6 +309,7 @@ async fn import_encrypt_decrypt(filename: &str) -> Result<(), CliError> {
         Some(private_key_id.clone()),
         None,
         Some(tags),
+        Some(vec![KeyUsage::Encrypt]),
         false,
         true,
     )?;
@@ -338,6 +340,7 @@ async fn import_encrypt_decrypt(filename: &str) -> Result<(), CliError> {
         false,
     )?;
 
+    println!("import private key with unwrap");
     debug!("\n\nImport a wrapped Private key but unwrap it into server");
     import_key(
         &ctx.owner_client_conf_path,
@@ -346,9 +349,11 @@ async fn import_encrypt_decrypt(filename: &str) -> Result<(), CliError> {
         Some(ImportKeyFormat::JsonTtlv),
         Some(Uuid::new_v4().to_string()),
         &[],
+        Some(vec![KeyUsage::Decrypt]),
         true,
         true,
     )?;
+    println!("import private key with unwrap OK");
 
     debug!("\n\nImport a wrapped Private key but let is save it `as registered` into server");
     let wrapped_private_key_uid = import_key(
@@ -358,6 +363,7 @@ async fn import_encrypt_decrypt(filename: &str) -> Result<(), CliError> {
         Some(ImportKeyFormat::JsonTtlv),
         Some(Uuid::new_v4().to_string()),
         &[],
+        Some(vec![KeyUsage::Decrypt]),
         false,
         true,
     )?;

--- a/crate/cli/src/tests/certificates/encrypt.rs
+++ b/crate/cli/src/tests/certificates/encrypt.rs
@@ -178,6 +178,7 @@ async fn test_certificate_import_encrypt(
             .map(|&s| s.to_string())
             .collect::<Vec<String>>()
             .as_slice(),
+        None,
         false,
         true,
     )?;

--- a/crate/cli/src/tests/certificates/encrypt.rs
+++ b/crate/cli/src/tests/certificates/encrypt.rs
@@ -193,6 +193,7 @@ async fn test_certificate_import_encrypt(
         None,
         None,
         Some(tags),
+        None,
         false,
         true,
     )?;
@@ -207,6 +208,7 @@ async fn test_certificate_import_encrypt(
         None,
         Some(root_certificate_id),
         Some(tags),
+        None,
         false,
         true,
     )?;
@@ -221,6 +223,7 @@ async fn test_certificate_import_encrypt(
         Some(private_key_id.clone()),
         Some(_subca_certificate_id),
         Some(tags),
+        None,
         false,
         true,
     )?;

--- a/crate/cli/src/tests/certificates/export.rs
+++ b/crate/cli/src/tests/certificates/export.rs
@@ -50,6 +50,7 @@ async fn test_import_export_p12_25519() {
         None,
         None,
         Some(&["import_pkcs12"]),
+        None,
         false,
         true,
     )
@@ -230,6 +231,7 @@ async fn test_import_p12_rsa() {
         None,
         None,
         Some(&["import_pkcs12"]),
+        None,
         false,
         true,
     )

--- a/crate/cli/src/tests/certificates/get_attributes.rs
+++ b/crate/cli/src/tests/certificates/get_attributes.rs
@@ -24,6 +24,7 @@ async fn test_get_attributes_p12() {
         None,
         None,
         Some(&["import_pkcs12"]),
+        None,
         false,
         true,
     )

--- a/crate/cli/src/tests/certificates/import.rs
+++ b/crate/cli/src/tests/certificates/import.rs
@@ -58,25 +58,7 @@ pub fn import_certificate(
     if let Some(key_usage_vec) = key_usage_vec {
         for key_usage in key_usage_vec {
             args.push("--key-usage".to_owned());
-            args.push(
-                match key_usage {
-                    KeyUsage::Sign => "sign",
-                    KeyUsage::Verify => "verify",
-                    KeyUsage::Encrypt => "encrypt",
-                    KeyUsage::Decrypt => "decrypt",
-                    KeyUsage::WrapKey => "wrap-key",
-                    KeyUsage::UnwrapKey => "unwrap-key",
-                    KeyUsage::MACGenerate => "mac-generate",
-                    KeyUsage::MACVerify => "mac-verify",
-                    KeyUsage::DeriveKey => "derive-key",
-                    KeyUsage::KeyAgreement => "key-agreement",
-                    KeyUsage::CertificateSign => "certificate-sign",
-                    KeyUsage::CRLSign => "crl-sign",
-                    KeyUsage::Authenticate => "authenticate",
-                    KeyUsage::Unrestricted => "unrestricted",
-                }
-                .to_string(),
-            );
+            args.push(key_usage.into());
         }
     }
     if let Some(tags) = tags {

--- a/crate/cli/src/tests/certificates/quick_cert.rs
+++ b/crate/cli/src/tests/certificates/quick_cert.rs
@@ -357,6 +357,7 @@ pub async fn test_certify_with_csr() -> Result<(), CliError> {
             None,
             None,
             Some(&["import_pkcs12"]),
+            None,
             false,
             true,
         )?;

--- a/crate/cli/src/tests/certificates/validate.rs
+++ b/crate/cli/src/tests/certificates/validate.rs
@@ -38,6 +38,7 @@ async fn import_revoked_certificate_encrypt(curve_name: &str) -> Result<(), CliE
         None,
         None,
         Some(tags),
+        None,
         false,
         true,
     )?;
@@ -53,6 +54,7 @@ async fn import_revoked_certificate_encrypt(curve_name: &str) -> Result<(), CliE
         None,
         Some(root_certificate_id),
         Some(tags),
+        None,
         false,
         true,
     )?;

--- a/crate/cli/src/tests/cover_crypt/rekey.rs
+++ b/crate/cli/src/tests/cover_crypt/rekey.rs
@@ -143,6 +143,7 @@ async fn test_rekey_error() -> Result<(), CliError> {
         None,
         None,
         &[],
+        None,
         false,
         true,
     )?;
@@ -260,6 +261,7 @@ async fn test_rekey_prune() -> Result<(), CliError> {
         None,
         None,
         &[],
+        None,
         false,
         false,
     )?;

--- a/crate/cli/src/tests/cover_crypt/rekey.rs
+++ b/crate/cli/src/tests/cover_crypt/rekey.rs
@@ -6,6 +6,7 @@ use kms_test_server::{start_default_test_kms_server, ONCE};
 use tempfile::TempDir;
 
 use crate::{
+    actions::shared::utils::KeyUsage,
     error::CliError,
     tests::{
         cover_crypt::{
@@ -261,7 +262,7 @@ async fn test_rekey_prune() -> Result<(), CliError> {
         None,
         None,
         &[],
-        None,
+        Some(vec![KeyUsage::Unrestricted]),
         false,
         false,
     )?;

--- a/crate/cli/src/tests/shared/import.rs
+++ b/crate/cli/src/tests/shared/import.rs
@@ -15,7 +15,7 @@ use crate::tests::{
     symmetric::create_key::create_symmetric_key,
 };
 use crate::{
-    actions::shared::import_key::ImportKeyFormat,
+    actions::shared::{import_key::ImportKeyFormat, utils::KeyUsage},
     error::CliError,
     tests::{
         shared::export::export_key,
@@ -32,6 +32,7 @@ pub fn import_key(
     key_format: Option<ImportKeyFormat>,
     key_id: Option<String>,
     tags: &[String],
+    key_usage_vec: Option<Vec<KeyUsage>>,
     unwrap: bool,
     replace_existing: bool,
 ) -> Result<String, CliError> {
@@ -60,6 +61,30 @@ pub fn import_key(
             ImportKeyFormat::Chacha20 => "chacha20",
         };
         args.push(kfs.to_string());
+    }
+    if let Some(key_usage_vec) = key_usage_vec {
+        for key_usage in key_usage_vec {
+            args.push("--key-usage".to_owned());
+            args.push(
+                match key_usage {
+                    KeyUsage::Sign => "sign",
+                    KeyUsage::Verify => "verify",
+                    KeyUsage::Encrypt => "encrypt",
+                    KeyUsage::Decrypt => "decrypt",
+                    KeyUsage::WrapKey => "wrap-key",
+                    KeyUsage::UnwrapKey => "unwrap-key",
+                    KeyUsage::MACGenerate => "mac-generate",
+                    KeyUsage::MACVerify => "mac-verify",
+                    KeyUsage::DeriveKey => "derive-key",
+                    KeyUsage::KeyAgreement => "key-agreement",
+                    KeyUsage::CertificateSign => "certificate-sign",
+                    KeyUsage::CRLSign => "crl-sign",
+                    KeyUsage::Authenticate => "authenticate",
+                    KeyUsage::Unrestricted => "unrestricted",
+                }
+                .to_string(),
+            );
+        }
     }
     if unwrap {
         args.push("-u".to_owned());
@@ -200,6 +225,7 @@ pub fn export_import_test(
         None,
         None,
         &[],
+        None,
         false,
         false,
     )?;

--- a/crate/cli/src/tests/shared/import.rs
+++ b/crate/cli/src/tests/shared/import.rs
@@ -118,6 +118,7 @@ pub async fn test_import_cover_crypt() -> Result<(), CliError> {
         None,
         None,
         &[],
+        None,
         false,
         false,
     )?;
@@ -132,6 +133,7 @@ pub async fn test_import_cover_crypt() -> Result<(), CliError> {
             None,
             Some(uid.clone()),
             &[],
+            None,
             false,
             false,
         )
@@ -146,6 +148,7 @@ pub async fn test_import_cover_crypt() -> Result<(), CliError> {
         None,
         Some(uid.clone()),
         &[],
+        None,
         false,
         true,
     )?;

--- a/crate/cli/src/tests/shared/import.rs
+++ b/crate/cli/src/tests/shared/import.rs
@@ -65,25 +65,7 @@ pub fn import_key(
     if let Some(key_usage_vec) = key_usage_vec {
         for key_usage in key_usage_vec {
             args.push("--key-usage".to_owned());
-            args.push(
-                match key_usage {
-                    KeyUsage::Sign => "sign",
-                    KeyUsage::Verify => "verify",
-                    KeyUsage::Encrypt => "encrypt",
-                    KeyUsage::Decrypt => "decrypt",
-                    KeyUsage::WrapKey => "wrap-key",
-                    KeyUsage::UnwrapKey => "unwrap-key",
-                    KeyUsage::MACGenerate => "mac-generate",
-                    KeyUsage::MACVerify => "mac-verify",
-                    KeyUsage::DeriveKey => "derive-key",
-                    KeyUsage::KeyAgreement => "key-agreement",
-                    KeyUsage::CertificateSign => "certificate-sign",
-                    KeyUsage::CRLSign => "crl-sign",
-                    KeyUsage::Authenticate => "authenticate",
-                    KeyUsage::Unrestricted => "unrestricted",
-                }
-                .to_string(),
-            );
+            args.push(key_usage.into());
         }
     }
     if unwrap {

--- a/crate/cli/src/tests/shared/import_export_encodings.rs
+++ b/crate/cli/src/tests/shared/import_export_encodings.rs
@@ -66,6 +66,7 @@ fn test_pems(
         Some(ImportKeyFormat::Pem),
         None,
         &[],
+        None,
         false,
         true,
     )?;

--- a/crate/cli/src/tests/shared/import_export_wrapping.rs
+++ b/crate/cli/src/tests/shared/import_export_wrapping.rs
@@ -55,6 +55,7 @@ pub async fn test_import_export_wrap_rfc_5649() -> Result<(), CliError> {
         None,
         None,
         &[],
+        None,
         false,
         false,
     )?;
@@ -139,6 +140,7 @@ pub async fn test_import_export_wrap_ecies() -> Result<(), CliError> {
         None,
         Some(wrap_private_key_uid.to_string()),
         &[],
+        None,
         false,
         true,
     )?;
@@ -152,6 +154,7 @@ pub async fn test_import_export_wrap_ecies() -> Result<(), CliError> {
         None,
         Some(wrap_public_key_uid.to_string()),
         &[],
+        None,
         false,
         true,
     )?;
@@ -282,6 +285,7 @@ fn test_import_export_wrap_private_key(
             None,
             None,
             &[],
+            None,
             true,
             true,
         )?;
@@ -325,6 +329,7 @@ fn test_import_export_wrap_private_key(
             None,
             None,
             &[],
+            None,
             false,
             true,
         )?;

--- a/crate/cli/src/tests/shared/import_export_wrapping.rs
+++ b/crate/cli/src/tests/shared/import_export_wrapping.rs
@@ -62,7 +62,6 @@ pub async fn test_import_export_wrap_rfc_5649() -> Result<(), CliError> {
     )?;
 
     // test CC
-    println!("testing Covercrypt keys");
     let (private_key_id, _public_key_id) = create_cc_master_key_pair(
         &ctx.owner_client_conf_path,
         "--policy-specifications",
@@ -78,7 +77,6 @@ pub async fn test_import_export_wrap_rfc_5649() -> Result<(), CliError> {
     )?;
 
     // test ec
-    println!("testing ec keys");
     let (private_key_id, _public_key_id) = elliptic_curve::create_key_pair::create_ec_key_pair(
         &ctx.owner_client_conf_path,
         "nist-p256",
@@ -93,7 +91,6 @@ pub async fn test_import_export_wrap_rfc_5649() -> Result<(), CliError> {
     )?;
 
     // test sym
-    println!("testing symmetric keys");
     let key_id = symmetric::create_key::create_symmetric_key(
         &ctx.owner_client_conf_path,
         None,
@@ -128,8 +125,8 @@ pub async fn test_import_export_wrap_ecies() -> Result<(), CliError> {
         wrap_private_key_uid,
         wrap_public_key_uid,
         Some(CryptographicAlgorithm::EC),
-        Some(CryptographicUsageMask::Decrypt),
-        Some(CryptographicUsageMask::Encrypt),
+        Some(CryptographicUsageMask::Decrypt | CryptographicUsageMask::UnwrapKey),
+        Some(CryptographicUsageMask::Encrypt | CryptographicUsageMask::WrapKey),
     )?;
     // Write the private key to a file and import it
     let wrap_private_key_path = tmp_path.join("wrap.private.key");

--- a/crate/cli/src/tests/shared/import_export_wrapping.rs
+++ b/crate/cli/src/tests/shared/import_export_wrapping.rs
@@ -22,6 +22,7 @@ use tempfile::TempDir;
 use tracing::debug;
 
 use crate::{
+    actions::shared::utils::KeyUsage,
     error::CliError,
     tests::{
         cover_crypt::master_key_pair::create_cc_master_key_pair,
@@ -329,7 +330,7 @@ fn test_import_export_wrap_private_key(
             None,
             None,
             &[],
-            None,
+            Some(vec![KeyUsage::Unrestricted]),
             false,
             true,
         )?;

--- a/crate/client/src/encodings.rs
+++ b/crate/client/src/encodings.rs
@@ -49,47 +49,30 @@ pub fn objects_from_pem(
     let mut objects = Vec::<Object>::new();
     let pem_s = pem::parse_many(bytes)?;
     for pem in pem_s {
+        let key_block_with_format_type =
+            |kft: KeyFormatType| key_block(kft, pem.contents().to_vec(), cryptographic_usage_mask);
+
         match pem.tag() {
             "RSA PRIVATE KEY" => objects.push(Object::PrivateKey {
-                key_block: key_block(
-                    KeyFormatType::PKCS1,
-                    pem.into_contents(),
-                    cryptographic_usage_mask,
-                ),
+                key_block: key_block_with_format_type(KeyFormatType::PKCS1),
             }),
             "RSA PUBLIC KEY" => objects.insert(
                 0,
                 Object::PublicKey {
-                    key_block: key_block(
-                        KeyFormatType::PKCS1,
-                        pem.into_contents(),
-                        cryptographic_usage_mask,
-                    ),
+                    key_block: key_block_with_format_type(KeyFormatType::PKCS1),
                 },
             ),
             "PRIVATE KEY" => objects.push(Object::PrivateKey {
-                key_block: key_block(
-                    KeyFormatType::PKCS8,
-                    pem.into_contents(),
-                    cryptographic_usage_mask,
-                ),
+                key_block: key_block_with_format_type(KeyFormatType::PKCS8),
             }),
             "PUBLIC KEY" => objects.insert(
                 0,
                 Object::PublicKey {
-                    key_block: key_block(
-                        KeyFormatType::PKCS8,
-                        pem.into_contents(),
-                        cryptographic_usage_mask,
-                    ),
+                    key_block: key_block_with_format_type(KeyFormatType::PKCS8),
                 },
             ),
             "EC PRIVATE KEY" => objects.push(Object::PrivateKey {
-                key_block: key_block(
-                    KeyFormatType::ECPrivateKey,
-                    pem.into_contents(),
-                    cryptographic_usage_mask,
-                ),
+                key_block: key_block_with_format_type(KeyFormatType::ECPrivateKey),
             }),
             "EC PUBLIC KEY" => {
                 return Err(ClientError::NotSupported(

--- a/crate/kmip/src/crypto/cover_crypt/kmip_requests.rs
+++ b/crate/kmip/src/crypto/cover_crypt/kmip_requests.rs
@@ -18,8 +18,8 @@ use crate::{
         kmip_objects::{Object, ObjectType},
         kmip_operations::{Create, CreateKeyPair, Destroy, Import, Locate, ReKeyKeyPair},
         kmip_types::{
-            Attributes, CryptographicAlgorithm, KeyFormatType, Link, LinkType,
-            LinkedObjectIdentifier, UniqueIdentifier,
+            Attributes, CryptographicAlgorithm, CryptographicUsageMask, KeyFormatType, Link,
+            LinkType, LinkedObjectIdentifier, UniqueIdentifier,
         },
     },
 };
@@ -34,6 +34,7 @@ pub fn build_create_master_keypair_request<T: IntoIterator<Item = impl AsRef<str
         cryptographic_algorithm: Some(CryptographicAlgorithm::CoverCrypt),
         key_format_type: Some(KeyFormatType::CoverCryptSecretKey),
         vendor_attributes: Some(vec![policy_as_vendor_attribute(policy)?]),
+        cryptographic_usage_mask: Some(CryptographicUsageMask::Unrestricted),
         ..Attributes::default()
     };
     attributes.set_tags(tags)?;
@@ -60,6 +61,7 @@ pub fn build_create_user_decryption_private_key_request<T: IntoIterator<Item = i
                 cover_crypt_master_private_key_id.to_owned(),
             ),
         }]),
+        cryptographic_usage_mask: Some(CryptographicUsageMask::Unrestricted),
         ..Attributes::default()
     };
     attributes.set_tags(tags)?;
@@ -96,6 +98,7 @@ pub fn build_import_decryption_private_key_request<T: IntoIterator<Item = impl A
             ),
         }]),
         vendor_attributes: Some(vec![access_policy_as_vendor_attribute(access_policy)?]),
+        cryptographic_usage_mask: Some(CryptographicUsageMask::Unrestricted),
         ..Attributes::default()
     };
     attributes.set_tags(tags)?;
@@ -171,6 +174,7 @@ pub fn build_import_private_key_request<T: IntoIterator<Item = impl AsRef<str>>>
                 cover_crypt_master_public_key_id.to_owned(),
             ),
         }]),
+        cryptographic_usage_mask: Some(CryptographicUsageMask::Unrestricted),
         ..Attributes::default()
     };
     attributes.set_tags(tags)?;

--- a/crate/kmip/src/crypto/cover_crypt/master_keys.rs
+++ b/crate/kmip/src/crypto/cover_crypt/master_keys.rs
@@ -15,8 +15,8 @@ use crate::{
         kmip_objects::{Object, ObjectType},
         kmip_operations::ErrorReason,
         kmip_types::{
-            Attributes, CryptographicAlgorithm, KeyFormatType, Link, LinkType,
-            LinkedObjectIdentifier,
+            Attributes, CryptographicAlgorithm, CryptographicUsageMask, KeyFormatType, Link,
+            LinkType, LinkedObjectIdentifier,
         },
     },
 };
@@ -101,6 +101,8 @@ fn create_master_private_key_object(
     let mut attributes = attributes.cloned().unwrap_or_default();
     attributes.object_type = Some(ObjectType::PrivateKey);
     attributes.key_format_type = Some(KeyFormatType::CoverCryptSecretKey);
+    // Covercrypt keys are set to have unrestricted usage.
+    attributes.set_cryptographic_usage_mask_bits(CryptographicUsageMask::Unrestricted);
     // add the policy to the attributes
     upsert_policy_in_attributes(&mut attributes, policy)?;
     // link the private key to the public key
@@ -138,6 +140,8 @@ fn create_master_public_key_object(
     let mut attributes = attributes.cloned().unwrap_or_default();
     attributes.object_type = Some(ObjectType::PublicKey);
     attributes.key_format_type = Some(KeyFormatType::CoverCryptPublicKey);
+    // Covercrypt keys are set to have unrestricted usage.
+    attributes.set_cryptographic_usage_mask_bits(CryptographicUsageMask::Unrestricted);
     // add the policy to the attributes
     upsert_policy_in_attributes(&mut attributes, policy)?;
     // link the public key to the private key

--- a/crate/kmip/src/crypto/cover_crypt/secret_key.rs
+++ b/crate/kmip/src/crypto/cover_crypt/secret_key.rs
@@ -46,13 +46,7 @@ pub fn wrapped_secret_key(
     let wrapped_key_attributes = Attributes {
         object_type: Some(ObjectType::SymmetricKey),
         vendor_attributes: Some(vec![access_policy_as_vendor_attribute(access_policy)?]),
-        cryptographic_usage_mask: Some(
-            CryptographicUsageMask::Encrypt
-                | CryptographicUsageMask::Decrypt
-                | CryptographicUsageMask::WrapKey
-                | CryptographicUsageMask::UnwrapKey
-                | CryptographicUsageMask::KeyAgreement,
-        ),
+        cryptographic_usage_mask: Some(CryptographicUsageMask::Unrestricted),
         ..Attributes::default()
     };
 

--- a/crate/kmip/src/crypto/cover_crypt/secret_key.rs
+++ b/crate/kmip/src/crypto/cover_crypt/secret_key.rs
@@ -15,7 +15,10 @@ use crate::{
         kmip_data_structures::{KeyBlock, KeyMaterial, KeyValue, KeyWrappingData},
         kmip_objects::{Object, ObjectType},
         kmip_operations::{ErrorReason, GetResponse},
-        kmip_types::{Attributes, CryptographicAlgorithm, KeyFormatType, WrappingMethod},
+        kmip_types::{
+            Attributes, CryptographicAlgorithm, CryptographicUsageMask, KeyFormatType,
+            WrappingMethod,
+        },
     },
 };
 
@@ -43,6 +46,13 @@ pub fn wrapped_secret_key(
     let wrapped_key_attributes = Attributes {
         object_type: Some(ObjectType::SymmetricKey),
         vendor_attributes: Some(vec![access_policy_as_vendor_attribute(access_policy)?]),
+        cryptographic_usage_mask: Some(
+            CryptographicUsageMask::Encrypt
+                | CryptographicUsageMask::Decrypt
+                | CryptographicUsageMask::WrapKey
+                | CryptographicUsageMask::UnwrapKey
+                | CryptographicUsageMask::KeyAgreement,
+        ),
         ..Attributes::default()
     };
 

--- a/crate/kmip/src/crypto/cover_crypt/user_key.rs
+++ b/crate/kmip/src/crypto/cover_crypt/user_key.rs
@@ -16,8 +16,8 @@ use crate::{
         kmip_objects::{Object, ObjectType},
         kmip_operations::ErrorReason,
         kmip_types::{
-            Attributes, CryptographicAlgorithm, KeyFormatType, Link, LinkType,
-            LinkedObjectIdentifier,
+            Attributes, CryptographicAlgorithm, CryptographicUsageMask, KeyFormatType, Link,
+            LinkType, LinkedObjectIdentifier,
         },
     },
 };
@@ -124,6 +124,8 @@ impl UserDecryptionKeysHandler {
 
         let mut attributes = attributes.cloned().unwrap_or_default();
         attributes.object_type = Some(ObjectType::PrivateKey);
+        // Covercrypt keys are set to have unrestricted usage.
+        attributes.set_cryptographic_usage_mask_bits(CryptographicUsageMask::Unrestricted);
 
         // Add the access policy to the attributes
         upsert_access_policy_in_attributes(&mut attributes, access_policy_str)?;

--- a/crate/kmip/src/crypto/wrap/unwrap_key.rs
+++ b/crate/kmip/src/crypto/wrap/unwrap_key.rs
@@ -20,7 +20,8 @@ use crate::{
         kmip_data_structures::{KeyBlock, KeyMaterial, KeyValue, KeyWrappingData},
         kmip_objects::Object,
         kmip_types::{
-            CryptographicAlgorithm, EncodingOption, KeyFormatType, PaddingMethod, WrappingMethod,
+            CryptographicAlgorithm, CryptographicUsageMask, EncodingOption, KeyFormatType,
+            PaddingMethod, WrappingMethod,
         },
     },
     kmip_bail,
@@ -105,6 +106,11 @@ pub(crate) fn unwrap(
         unwrapping_key,
         ciphertext.len()
     );
+
+    // Make sure that the key used to unwrap can be used to unwrap.
+    unwrapping_key
+        .attributes()?
+        .is_usage_mask_flag_set(CryptographicUsageMask::UnwrapKey)?;
 
     let unwrapping_key_block = unwrapping_key
         .key_block()

--- a/crate/kmip/src/crypto/wrap/wrap_key.rs
+++ b/crate/kmip/src/crypto/wrap/wrap_key.rs
@@ -25,7 +25,8 @@ use crate::{
         },
         kmip_objects::Object,
         kmip_types::{
-            CryptographicAlgorithm, EncodingOption, KeyFormatType, PaddingMethod, WrappingMethod,
+            CryptographicAlgorithm, CryptographicUsageMask, EncodingOption, KeyFormatType,
+            PaddingMethod, WrappingMethod,
         },
     },
     kmip_bail, kmip_error,
@@ -139,6 +140,12 @@ pub(crate) fn wrap(
             if key_block.key_wrapping_data.is_some() {
                 kmip_bail!("unable to wrap keys: wrapping key is wrapped and that is not supported")
             }
+
+            // Make sure that the key used to wrap can be used to wrap.
+            wrapping_key
+                .attributes()?
+                .is_usage_mask_flag_set(CryptographicUsageMask::WrapKey)?;
+
             let ciphertext = match key_block.key_format_type {
                 KeyFormatType::TransparentSymmetricKey => {
                     // wrap using rfc_5649

--- a/crate/kmip/src/kmip/kmip_types.rs
+++ b/crate/kmip/src/kmip/kmip_types.rs
@@ -1123,7 +1123,12 @@ impl Attributes {
         } else {
             Err(KmipError::InvalidKmipValue(
                 ErrorReason::Incompatible_Cryptographic_Usage_Mask,
-                format!("CryptographicUsageMask bit {} is not set", flag.bits()).to_string(),
+                format!(
+                    "CryptographicUsageMask {} a bit is not set against flags {}",
+                    usage_mask.bits(),
+                    flag.bits()
+                )
+                .to_string(),
             ))
         }
     }

--- a/crate/kmip/src/kmip/kmip_types.rs
+++ b/crate/kmip/src/kmip/kmip_types.rs
@@ -1101,6 +1101,17 @@ impl Attributes {
         self.cryptographic_usage_mask = mask;
     }
 
+    /// Set the bits in `mask` to the attributes's CryptographicUsageMask bits.
+    pub fn set_cryptographic_usage_mask_bits(&mut self, mask: CryptographicUsageMask) {
+        let mask = if let Some(attr_mask) = self.cryptographic_usage_mask {
+            attr_mask | mask
+        } else {
+            mask
+        };
+
+        self.cryptographic_usage_mask = Some(mask);
+    }
+
     /// Check that `flag` bit is set in object's CryptographicUsageMask.
     /// If FIPS mode is disabled, check if Unrestricted bit is set too.
     ///

--- a/crate/kmip/src/kmip/kmip_types.rs
+++ b/crate/kmip/src/kmip/kmip_types.rs
@@ -1115,9 +1115,10 @@ impl Attributes {
     /// Check that `flag` bit is set in object's CryptographicUsageMask.
     /// If FIPS mode is disabled, check if Unrestricted bit is set too.
     ///
-    /// Raise error if `flag` is not set or if object's CryptographicUsageMask
-    /// is None.
-    pub fn is_usage_mask_flag_set(&self, flag: CryptographicUsageMask) -> Result<(), KmipError> {
+    /// Return `true` if `flag` has at least one bit set in self's attributes,
+    /// return `false` otherwise.
+    /// Raise error if object's CryptographicUsageMask is None.
+    pub fn is_usage_authorized_for(&self, flag: CryptographicUsageMask) -> Result<bool, KmipError> {
         let usage_mask = self.cryptographic_usage_mask.ok_or_else(|| {
             KmipError::InvalidKmipValue(
                 ErrorReason::Incompatible_Cryptographic_Usage_Mask,
@@ -1129,19 +1130,7 @@ impl Attributes {
         // In non-FIPS mode, Unrestricted can be allowed.
         let flag = flag | CryptographicUsageMask::Unrestricted;
 
-        if (usage_mask & flag).bits() != 0 {
-            Ok(())
-        } else {
-            Err(KmipError::InvalidKmipValue(
-                ErrorReason::Incompatible_Cryptographic_Usage_Mask,
-                format!(
-                    "CryptographicUsageMask {} a bit is not set against flags {}",
-                    usage_mask.bits(),
-                    flag.bits()
-                )
-                .to_string(),
-            ))
-        }
+        Ok((usage_mask & flag).bits() != 0)
     }
 }
 

--- a/crate/server/src/core/operations/decrypt.rs
+++ b/crate/server/src/core/operations/decrypt.rs
@@ -126,9 +126,16 @@ async fn get_key(
 
 fn decrypt_with_aead(request: &Decrypt, owm: &ObjectWithMetadata) -> KResult<DecryptResponse> {
     // Make sure that the key used to decrypt can be used to decrypt.
-    owm.object
+    if !owm
+        .object
         .attributes()?
-        .is_usage_mask_flag_set(CryptographicUsageMask::Decrypt)?;
+        .is_usage_authorized_for(CryptographicUsageMask::Decrypt)?
+    {
+        return Err(KmsError::KmipError(
+            ErrorReason::Incompatible_Cryptographic_Usage_Mask,
+            "CryptographicUsageMask not authorized for Decrypt".to_owned(),
+        ))
+    }
 
     let ciphertext = request.data.as_ref().ok_or_else(|| {
         KmsError::InvalidRequest("Decrypt: data to decrypt must be provided".to_owned())
@@ -186,10 +193,16 @@ fn decrypt_with_private_key(
     owm: &ObjectWithMetadata,
 ) -> KResult<DecryptResponse> {
     // Make sure that the key used to decrypt can be used to decrypt.
-    owm.object
+    if !owm
+        .object
         .attributes()?
-        .is_usage_mask_flag_set(CryptographicUsageMask::Decrypt)?;
-
+        .is_usage_authorized_for(CryptographicUsageMask::Decrypt)?
+    {
+        return Err(KmsError::KmipError(
+            ErrorReason::Incompatible_Cryptographic_Usage_Mask,
+            "CryptographicUsageMask not authorized for Decrypt".to_owned(),
+        ))
+    }
     let key_block = owm.object.key_block()?;
     match &key_block.key_format_type {
         KeyFormatType::CoverCryptSecretKey => {

--- a/crate/server/src/core/operations/encrypt.rs
+++ b/crate/server/src/core/operations/encrypt.rs
@@ -128,9 +128,16 @@ async fn get_key(
 
 fn encrypt_with_aead(request: &Encrypt, owm: &ObjectWithMetadata) -> KResult<EncryptResponse> {
     // Make sure that the key used to encrypt can be used to encrypt.
-    owm.object
+    if !owm
+        .object
         .attributes()?
-        .is_usage_mask_flag_set(CryptographicUsageMask::Encrypt)?;
+        .is_usage_authorized_for(CryptographicUsageMask::Encrypt)?
+    {
+        return Err(KmsError::KmipError(
+            ErrorReason::Incompatible_Cryptographic_Usage_Mask,
+            "CryptographicUsageMask not authorized for Encrypt".to_owned(),
+        ))
+    }
 
     let plaintext = request.data.as_ref().ok_or_else(|| {
         KmsError::InvalidRequest("Encrypt: data to encrypt must be provided".to_owned())
@@ -187,9 +194,16 @@ fn encrypt_with_public_key(
     owm: &ObjectWithMetadata,
 ) -> KResult<EncryptResponse> {
     // Make sure that the key used to encrypt can be used to encrypt.
-    owm.object
+    if !owm
+        .object
         .attributes()?
-        .is_usage_mask_flag_set(CryptographicUsageMask::Encrypt)?;
+        .is_usage_authorized_for(CryptographicUsageMask::Encrypt)?
+    {
+        return Err(KmsError::KmipError(
+            ErrorReason::Incompatible_Cryptographic_Usage_Mask,
+            "CryptographicUsageMask not authorized for Encrypt".to_owned(),
+        ))
+    }
 
     let key_block = owm.object.key_block()?;
     match &key_block.key_format_type {

--- a/crate/server/src/core/operations/get_attributes.rs
+++ b/crate/server/src/core/operations/get_attributes.rs
@@ -89,7 +89,10 @@ pub async fn get_attributes(
             } else {
                 // we want the default format which yields the most infos
                 let pkey = kmip_private_key_to_openssl(&owm.object)?;
-                let default_kmip = openssl_private_key_to_kmip_default_format(&pkey)?;
+                let default_kmip = openssl_private_key_to_kmip_default_format(
+                    &pkey,
+                    attributes.cryptographic_usage_mask,
+                )?;
                 let mut default_attributes = default_kmip.attributes().cloned().unwrap_or_default();
                 default_attributes.object_type = Some(object_type);
                 //re-add the vendor attributes
@@ -110,7 +113,10 @@ pub async fn get_attributes(
             } else {
                 // we want the default format which yields the most infos
                 let pkey = kmip_public_key_to_openssl(&owm.object)?;
-                let default_kmip = openssl_public_key_to_kmip_default_format(&pkey)?;
+                let default_kmip = openssl_public_key_to_kmip_default_format(
+                    &pkey,
+                    attributes.cryptographic_usage_mask,
+                )?;
                 let mut default_attributes = default_kmip.attributes().cloned().unwrap_or_default();
                 default_attributes.object_type = Some(object_type);
                 //re-add the vendor attributes

--- a/crate/server/src/core/operations/import.rs
+++ b/crate/server/src/core/operations/import.rs
@@ -277,7 +277,6 @@ async fn process_public_key(
     }
 
     // check if the object will be replaced if it already exists
-    //let replace_existing = request.replace_existing.unwrap_or(false);
     let replace_existing = request.replace_existing.unwrap_or(false);
     Ok((
         uid.clone(),

--- a/crate/server/src/core/operations/import.rs
+++ b/crate/server/src/core/operations/import.rs
@@ -1,5 +1,7 @@
 use std::collections::HashSet;
 
+#[cfg(not(feature = "fips"))]
+use cosmian_kmip::kmip::kmip_types::CryptographicUsageMask;
 use cosmian_kmip::{
     kmip::{
         kmip_objects::{
@@ -97,6 +99,14 @@ async fn process_symmetric_key(
     }
     // replace attributes
     attributes.object_type = Some(ObjectType::SymmetricKey);
+
+    #[cfg(not(feature = "fips"))]
+    // In non-FIPS mode, if no CryptographicUsageMask has been specified,
+    // default to Unrestricted.
+    if attributes.cryptographic_usage_mask.is_none() {
+        attributes.cryptographic_usage_mask = Some(CryptographicUsageMask::Unrestricted);
+    }
+
     object_key_block.key_value.attributes = Some(Box::new(attributes.clone()));
 
     let uid = match request.unique_identifier.to_string().unwrap_or_default() {
@@ -166,6 +176,12 @@ fn process_certificate(request: Import) -> Result<(String, Vec<AtomicOperation>)
         object_type: Some(ObjectType::Certificate),
         unique_identifier: Some(UniqueIdentifier::TextString(uid.clone())),
         certificate_attributes: Some(Box::new(certificate_attributes)),
+        #[cfg(not(feature = "fips"))]
+        // In non-FIPS mode, if no CryptographicUsageMask has been specified,
+        // default to Unrestricted.
+        cryptographic_usage_mask: request_attributes
+            .cryptographic_usage_mask
+            .or(Some(CryptographicUsageMask::Unrestricted)),
         ..Attributes::default()
     };
 
@@ -219,7 +235,11 @@ async fn process_public_key(
             // first, see if the public key can be parsed as an openssl object
             let openssl_pk = kmip_public_key_to_openssl(&(object.clone()))?;
             // convert back to KMIP Object
-            openssl_public_key_to_kmip(&openssl_pk, KeyFormatType::PKCS8)?
+            openssl_public_key_to_kmip(
+                &openssl_pk,
+                KeyFormatType::PKCS8,
+                request_attributes.cryptographic_usage_mask,
+            )?
         } else {
             object
         }
@@ -244,8 +264,20 @@ async fn process_public_key(
         uid => uid,
     };
 
+    #[cfg(feature = "fips")]
     let public_key_attributes = object.attributes()?.clone();
+    #[cfg(not(feature = "fips"))]
+    let mut public_key_attributes = object.attributes_mut()?.clone();
+
+    #[cfg(not(feature = "fips"))]
+    // In non-FIPS mode, if no CryptographicUsageMask has been specified,
+    // default to Unrestricted.
+    if request_attributes.cryptographic_usage_mask.is_none() {
+        public_key_attributes.cryptographic_usage_mask = Some(CryptographicUsageMask::Unrestricted);
+    }
+
     // check if the object will be replaced if it already exists
+    //let replace_existing = request.replace_existing.unwrap_or(false);
     let replace_existing = request.replace_existing.unwrap_or(false);
     Ok((
         uid.clone(),
@@ -287,6 +319,13 @@ async fn process_private_key(
 
     // Process based on the key block type
     let key_block = object.key_block()?;
+
+    #[cfg(not(feature = "fips"))]
+    // In non-FIPS mode, if no CryptographicUsageMask has been specified,
+    // default to Unrestricted.
+    if request_attributes.cryptographic_usage_mask.is_none() {
+        request_attributes.cryptographic_usage_mask = Some(CryptographicUsageMask::Unrestricted);
+    }
 
     // wrapped keys and Covercrypt keys
     // cannot be further processed and must be imported as such
@@ -365,7 +404,11 @@ fn private_key_from_openssl(
     request_uid: &str,
 ) -> KResult<(String, Object, Option<HashSet<String>>)> {
     // convert the private key to PKCS#8
-    let mut sk = openssl_private_key_to_kmip(&sk, KeyFormatType::PKCS8)?;
+    let mut sk = openssl_private_key_to_kmip(
+        &sk,
+        KeyFormatType::PKCS8,
+        request_attributes.cryptographic_usage_mask,
+    )?;
 
     let sk_uid = if request_uid.is_empty() {
         Uuid::new_v4().to_string()

--- a/crate/server/src/core/operations/wrapping/unwrap.rs
+++ b/crate/server/src/core/operations/wrapping/unwrap.rs
@@ -82,6 +82,8 @@ pub async fn unwrap_key(
         _ => kms_bail!("unwrap_key: unsupported object type: {}", object_type),
     };
 
+    // Check on key CryptographicUsageMask is done inside `unwrap_key_block`.
     unwrap_key_block(object_key_block, &unwrapping_key.object)?;
+
     Ok(())
 }

--- a/crate/server/src/core/operations/wrapping/wrap.rs
+++ b/crate/server/src/core/operations/wrapping/wrap.rs
@@ -76,6 +76,7 @@ pub async fn wrap_key(
         _ => kms_bail!("wrap_key: unsupported object type: {}", object_type),
     };
 
+    // Check on key CryptographicUsageMask is done inside `wrap_key_block`.
     wrap_key_block(
         object_key_block,
         &wrapping_key.object,

--- a/crate/server/src/tests/mod.rs
+++ b/crate/server/src/tests/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(not(feature = "fips"))]
 mod cover_crypt_tests;
 #[cfg(not(feature = "fips"))]
 mod curve_25519_tests;


### PR DESCRIPTION
KMIP standard [specifies](https://docs.oasis-open.org/kmip/kmip-spec/v2.1/cs01/kmip-spec-v2.1-cs01.html#_Toc32239339)
> The Cryptographic Usage Mask attribute defines the cryptographic usage of a key. This is a bit mask that indicates to the client which cryptographic functions MAY be performed using the key, and which ones SHALL NOT be performed.

At the moment, the KMS does not check if the key used for a crypto operation has the right to do so. This PR aims at mitigating this.

The problem is that this bitfield is left as None by default when constructing keys from different sources (import, conversions...) which is against what a restricted FIPS-enabled KMS would want (you want the keys to have **specific** usages, clearly defined on creation).