### PR TITLE
fix(server): in get_attributes, use attributes from ObjectWithMetadata

### DIFF
--- a/crate/cli/src/actions/shared/get_attributes.rs
+++ b/crate/cli/src/actions/shared/get_attributes.rs
@@ -9,7 +9,7 @@ use cosmian_kms_client::{
     write_bytes_to_file, KmsClient,
 };
 use serde_json::Value;
-use tracing::debug;
+use tracing::{debug, trace};
 
 use crate::{actions::console, cli_bail, error::CliError};
 
@@ -79,6 +79,7 @@ pub struct GetAttributesAction {
 
 impl GetAttributesAction {
     pub async fn process(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+        trace!("GetAttributesAction: {:?}", self);
         let id = if let Some(key_id) = &self.id {
             key_id.clone()
         } else if let Some(tags) = &self.tags {
@@ -139,6 +140,8 @@ impl GetAttributesAction {
                 attribute_references: Some(references),
             })
             .await?;
+
+        trace!("GetAttributes response for {unique_identifier}: {attributes:?}",);
 
         // if no tag asked -> return values for all possible tags
         let tags = if self.attribute_tags.is_empty() {

--- a/crate/cli/src/tests/certificates/validate.rs
+++ b/crate/cli/src/tests/certificates/validate.rs
@@ -95,7 +95,7 @@ pub fn validate_certificate(
 ) -> Result<String, CliError> {
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
     cmd.env(KMS_CLI_CONF_ENV, cli_conf_path);
-    cmd.env("RUST_LOG", "cosmian_kms_cli=trace,cosmian_kms_server=trace");
+    cmd.env("RUST_LOG", "cosmian_kms_cli=debug,cosmian_kms_server=debug");
     let mut args: Vec<String> = vec!["validate".to_owned()];
     for certificate in certificates {
         args.push("--certificate".to_owned());

--- a/crate/logger/src/log_utils.rs
+++ b/crate/logger/src/log_utils.rs
@@ -7,17 +7,19 @@ static LOG_INIT: Once = Once::new();
 /// # Panics
 ///
 /// Will panic if we cannot set global tracing subscriber
-pub fn log_init(paths: &str) {
+pub fn log_init(default_value: &str) {
     LOG_INIT.call_once(|| {
         if std::env::var("RUST_BACKTRACE").is_err() {
             std::env::set_var("RUST_BACKTRACE", "1");
         }
 
-        if let Ok(old_value) = std::env::var("RUST_LOG") {
-            let new_value = format!("{old_value},{paths}");
-            std::env::set_var("RUST_LOG", new_value);
-            tracing_setup();
+        if let Ok(current_value) = std::env::var("RUST_LOG") {
+            std::env::set_var("RUST_LOG", current_value);
+        } else {
+            std::env::set_var("RUST_LOG", default_value);
         }
+
+        tracing_setup();
     });
 }
 

--- a/crate/server/src/core/operations/get_attributes.rs
+++ b/crate/server/src/core/operations/get_attributes.rs
@@ -64,6 +64,10 @@ pub async fn get_attributes(
         params,
     )
     .await?;
+    trace!(
+        "Retrieved object for get attributes: {:?}",
+        serde_json::to_string(&owm)
+    );
     let object_type = owm.object.object_type();
 
     let attributes = match &owm.object {
@@ -100,7 +104,7 @@ pub async fn get_attributes(
                     .vendor_attributes
                     .clone_from(&attributes.vendor_attributes);
                 // re-add the links
-                default_attributes.link.clone_from(&attributes.link);
+                default_attributes.link.clone_from(&owm.attributes.link);
                 default_attributes
             }
         }
@@ -124,13 +128,14 @@ pub async fn get_attributes(
                     .vendor_attributes
                     .clone_from(&attributes.vendor_attributes);
                 // re-add the links
-                default_attributes.link.clone_from(&attributes.link);
+                default_attributes.link.clone_from(&owm.attributes.link);
                 default_attributes
             }
         }
         Object::SymmetricKey { key_block } => {
             let mut attributes = key_block.key_value.attributes.clone().unwrap_or_default();
             attributes.object_type = Some(object_type);
+            attributes.link.clone_from(&owm.attributes.link);
             *attributes
         }
     };

--- a/crate/server/src/core/operations/import.rs
+++ b/crate/server/src/core/operations/import.rs
@@ -634,6 +634,11 @@ pub(crate) fn add_imported_links_to_attributes(
     attributes: &mut Attributes,
     links_to_add: &Attributes,
 ) {
+    trace!(
+        "Adding imported links to attributes: attributes={:?}, links_to_add={:?}",
+        attributes,
+        links_to_add
+    );
     if let Some(new_links) = links_to_add.link.as_ref() {
         match attributes.link.as_mut() {
             Some(existing_links) => {
@@ -648,4 +653,8 @@ pub(crate) fn add_imported_links_to_attributes(
             }
         }
     }
+    trace!(
+        "Added imported links to attributes: attributes={:?}",
+        attributes
+    );
 }

--- a/crate/server/src/core/operations/validate.rs
+++ b/crate/server/src/core/operations/validate.rs
@@ -265,7 +265,7 @@ async fn certificate_by_uid(
     user: &str,
     params: Option<&ExtraDatabaseParams>,
 ) -> KResult<Vec<u8>> {
-    let uid_own = retrieve_object_for_operation(
+    let uid_owm = retrieve_object_for_operation(
         unique_identifier,
         ObjectOperationType::Validate,
         kms,
@@ -277,7 +277,7 @@ async fn certificate_by_uid(
     if let Object::Certificate {
         certificate_type: _,
         certificate_value,
-    } = uid_own.object
+    } = uid_owm.object
     {
         Ok(certificate_value)
     } else {
@@ -285,7 +285,7 @@ async fn certificate_by_uid(
             ErrorReason::Invalid_Object_Type,
             format!(
                 "Requested a Certificate Object, got a {}",
-                uid_own.object.object_type()
+                uid_owm.object.object_type()
             ),
         )))
     }

--- a/crate/server/src/database/object_with_metadata.rs
+++ b/crate/server/src/database/object_with_metadata.rs
@@ -4,6 +4,7 @@ use cosmian_kmip::kmip::{
     kmip_types::{Attributes, StateEnumeration},
 };
 use cosmian_kms_client::access::ObjectOperationType;
+use serde::Serialize;
 use serde_json::Value;
 use sqlx::{mysql::MySqlRow, postgres::PgRow, sqlite::SqliteRow, Row};
 
@@ -11,7 +12,7 @@ use super::{state_from_string, DBObject};
 use crate::{error::KmsError, result::KResultHelper};
 
 /// An object with its metadata such as permissions and state
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ObjectWithMetadata {
     pub(crate) id: String,
     pub(crate) object: Object,


### PR DESCRIPTION
in get_attributes, use attributes from ObjectWithMetadata instead of Object.Attributes:

- [x] attributes are saved in the column `Attributes` and must be recovered from ObjectWithMetadata
- [x] simplify `log_init` of ckms 