### PR TITLE
fix(validate): use certificate file path in ckms arguments

### DIFF
--- a/crate/cli/src/actions/certificates/validate_certificate.rs
+++ b/crate/cli/src/actions/certificates/validate_certificate.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use clap::Parser;
 use cosmian_kms_client::{
     cosmian_kmip::crypto::generic::kmip_requests::build_validate_certificate_request,
@@ -13,9 +15,9 @@ use crate::{actions::console, error::CliError};
 /// complete, and no components has been flagged as removed.
 #[derive(Parser, Debug)]
 pub struct ValidateCertificatesAction {
-    /// One or more Certificates.
+    /// One or more Certificates filepath.
     #[clap(long = "certificate", short = 'v')]
-    certificate: Vec<String>,
+    certificate: Vec<PathBuf>,
     /// One or more Unique Identifiers of Certificate Objects.
     #[clap(long = "unique-identifier", short = 'k')]
     unique_identifier: Vec<String>,
@@ -28,7 +30,7 @@ pub struct ValidateCertificatesAction {
 impl ValidateCertificatesAction {
     pub async fn run(&self, client_connector: &KmsClient) -> Result<(), CliError> {
         let request = build_validate_certificate_request(
-            self.certificate.clone(),
+            &self.certificate,
             &self.unique_identifier,
             self.validity_time.clone(),
         )?;

--- a/crate/cli/src/tests/certificates/validate.rs
+++ b/crate/cli/src/tests/certificates/validate.rs
@@ -171,22 +171,6 @@ async fn test_validate_cli() -> Result<(), CliError> {
     )?;
     info!("leaf1 cert imported: {leaf1_certificate_id}");
 
-    let leaf2_certificate_id = import_certificate(
-        &ctx.owner_client_conf_path,
-        "certificates",
-        "test_data/certificates/chain/leaf2.cert.pem",
-        CertificateInputFormat::Pem,
-        None,
-        None,
-        None,
-        Some(intermediate_certificate_id.clone()),
-        None,
-        None,
-        false,
-        true,
-    )?;
-    info!("leaf2 cert imported: {leaf2_certificate_id}");
-
     let test1_res = validate_certificate(
         &ctx.owner_client_conf_path,
         "certificates",
@@ -207,11 +191,10 @@ async fn test_validate_cli() -> Result<(), CliError> {
     let test2_res = validate_certificate(
         &ctx.owner_client_conf_path,
         "certificates",
-        vec![],
+        vec!["test_data/certificates/chain/leaf2.cert.der".to_string()],
         vec![
             intermediate_certificate_id.clone(),
             root_certificate_id.clone(),
-            leaf2_certificate_id.clone(),
         ],
         None,
     )?;
@@ -224,12 +207,8 @@ async fn test_validate_cli() -> Result<(), CliError> {
     let test3_res = validate_certificate(
         &ctx.owner_client_conf_path,
         "certificates",
-        vec![],
-        vec![
-            intermediate_certificate_id,
-            root_certificate_id.clone(),
-            leaf2_certificate_id,
-        ],
+        vec!["test_data/certificates/chain/leaf2.cert.der".to_string()],
+        vec![intermediate_certificate_id, root_certificate_id.clone()],
         // Date: 15/04/2048
         Some("4804152030Z".to_string()),
     );

--- a/crate/server/src/core/operations/validate.rs
+++ b/crate/server/src/core/operations/validate.rs
@@ -310,7 +310,7 @@ fn sort_certificates(certificates: &[X509]) -> KResult<Vec<X509>> {
 
     if sorted_chains.len() != certificates.len() {
         return Err(KmsError::Certificate(
-            "Failed to sort the certificates".to_string(),
+            "Failed to sort the certificates. Certificate chain incomplete?".to_string(),
         ));
     }
 

--- a/documentation/docs/cli/main_commands.md
+++ b/documentation/docs/cli/main_commands.md
@@ -846,7 +846,7 @@ Validate a certificate
 ### Usage
 `ckms certificates validate [options]`
 ### Arguments
-`--certificate [-v] <CERTIFICATE>` One or more Certificates
+`--certificate [-v] <CERTIFICATE>` One or more Certificates filepath
 
 `--unique-identifier [-k] <UNIQUE_IDENTIFIER>` One or more Unique Identifiers of Certificate Objects
 


### PR DESCRIPTION
From a CLI-ckms perspective, the Validate operation must use either unique ids or certificates filepath (instead of string).