### PR TITLE
test: hardcode clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ authors = [
 license = "BUSL-1.1" # "Business Source License 1.1"
 license-file = "LICENSE"
 repository = "https://github.com/Cosmian/kms"
+keywords = ["kms", "cosmian"]
+categories = ["security"]
 
 [profile.release]
 lto = true

--- a/crate/cli/src/actions/access.rs
+++ b/crate/cli/src/actions/access.rs
@@ -7,7 +7,7 @@ use cosmian_kms_client::{
 
 use crate::{
     actions::console,
-    error::{result::CliResultHelper, CliError},
+    error::result::{CliResult, CliResultHelper},
 };
 
 /// Manage the users' access rights to the cryptographic objects
@@ -21,7 +21,7 @@ pub enum AccessAction {
 }
 
 impl AccessAction {
-    pub async fn process(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn process(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         match self {
             Self::Grant(action) => action.run(kms_rest_client).await?,
             Self::Revoke(action) => action.run(kms_rest_client).await?,
@@ -58,7 +58,7 @@ pub struct GrantAccess {
 }
 
 impl GrantAccess {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         let access = Access {
             unique_identifier: Some(UniqueIdentifier::TextString(self.object_uid.clone())),
             user_id: self.user.clone(),
@@ -104,7 +104,7 @@ pub struct RevokeAccess {
 }
 
 impl RevokeAccess {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         let access = Access {
             unique_identifier: Some(UniqueIdentifier::TextString(self.object_uid.clone())),
             user_id: self.user.clone(),
@@ -138,7 +138,7 @@ pub struct ListAccessesGranted {
 }
 
 impl ListAccessesGranted {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         let accesses = kms_rest_client
             .list_access(&self.object_uid)
             .await
@@ -164,7 +164,7 @@ impl ListAccessesGranted {
 pub struct ListOwnedObjects;
 
 impl ListOwnedObjects {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         let objects = kms_rest_client
             .list_owned_objects()
             .await
@@ -190,7 +190,7 @@ impl ListOwnedObjects {
 pub struct ListAccessRightsObtained;
 
 impl ListAccessRightsObtained {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         let objects = kms_rest_client
             .list_access_rights_obtained()
             .await

--- a/crate/cli/src/actions/certificates/certify.rs
+++ b/crate/cli/src/actions/certificates/certify.rs
@@ -19,7 +19,10 @@ use cosmian_kms_client::{
     read_bytes_from_file, KmsClient,
 };
 
-use crate::{actions::console, error::CliError};
+use crate::{
+    actions::console,
+    error::{result::CliResult, CliError},
+};
 
 /// The algorithm to use for the keypair generation
 #[derive(clap::ValueEnum, Debug, Clone, Copy)]
@@ -190,7 +193,7 @@ pub struct CertifyAction {
 }
 
 impl CertifyAction {
-    pub async fn run(&self, client_connector: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, client_connector: &KmsClient) -> CliResult<()> {
         let mut attributes = Attributes {
             object_type: Some(ObjectType::Certificate),
             ..Attributes::default()

--- a/crate/cli/src/actions/certificates/decrypt_certificate.rs
+++ b/crate/cli/src/actions/certificates/decrypt_certificate.rs
@@ -9,7 +9,7 @@ use cosmian_kms_client::{
 use crate::{
     actions::console,
     cli_bail,
-    error::{result::CliResultHelper, CliError},
+    error::result::{CliResult, CliResultHelper},
 };
 
 /// Decrypt a file using the private key of a certificate.
@@ -41,7 +41,7 @@ pub struct DecryptCertificateAction {
 }
 
 impl DecryptCertificateAction {
-    pub async fn run(&self, client_connector: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, client_connector: &KmsClient) -> CliResult<()> {
         // Read the file to decrypt
         let ciphertext = read_bytes_from_file(&self.input_file)?;
 

--- a/crate/cli/src/actions/certificates/destroy_certificate.rs
+++ b/crate/cli/src/actions/certificates/destroy_certificate.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use cosmian_kms_client::KmsClient;
 
-use crate::{actions::shared::utils::destroy, cli_bail, error::CliError};
+use crate::{actions::shared::utils::destroy, cli_bail, error::result::CliResult};
 
 /// Destroy a certificate.
 ///
@@ -27,7 +27,7 @@ pub struct DestroyCertificateAction {
 }
 
 impl DestroyCertificateAction {
-    pub async fn run(&self, client_connector: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, client_connector: &KmsClient) -> CliResult<()> {
         let id = if let Some(certificate_id) = &self.certificate_id {
             certificate_id.clone()
         } else if let Some(tags) = &self.tags {

--- a/crate/cli/src/actions/certificates/encrypt_certificate.rs
+++ b/crate/cli/src/actions/certificates/encrypt_certificate.rs
@@ -10,7 +10,7 @@ use zeroize::Zeroizing;
 use crate::{
     actions::console,
     cli_bail,
-    error::{result::CliResultHelper, CliError},
+    error::result::{CliResult, CliResultHelper},
 };
 
 /// Encrypt a file using the certificate public key.
@@ -43,7 +43,7 @@ pub struct EncryptCertificateAction {
 }
 
 impl EncryptCertificateAction {
-    pub async fn run(&self, client_connector: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, client_connector: &KmsClient) -> CliResult<()> {
         // Read the file to encrypt
         let data = Zeroizing::from(read_bytes_from_file(&self.input_file)?);
 

--- a/crate/cli/src/actions/certificates/export_certificate.rs
+++ b/crate/cli/src/actions/certificates/export_certificate.rs
@@ -8,7 +8,7 @@ use cosmian_kms_client::{
 };
 use tracing::trace;
 
-use crate::{actions::console, cli_bail, error::CliError};
+use crate::{actions::console, cli_bail, error::result::CliResult};
 
 #[derive(clap::ValueEnum, Debug, Clone, PartialEq, Eq)]
 pub enum CertificateExportFormat {
@@ -78,7 +78,7 @@ pub struct ExportCertificateAction {
 
 impl ExportCertificateAction {
     /// Export a certificate from the KMS
-    pub async fn run(&self, client_connector: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, client_connector: &KmsClient) -> CliResult<()> {
         trace!("Export certificate: {:?}", self);
 
         let object_id: String = if let Some(object_id) = &self.unique_id {

--- a/crate/cli/src/actions/certificates/import_certificate.rs
+++ b/crate/cli/src/actions/certificates/import_certificate.rs
@@ -304,7 +304,7 @@ impl ImportCertificateAction {
         Ok(private_key_id)
     }
 
-    fn get_certificate_file(&self) -> Result<&PathBuf, CliError> {
+    fn get_certificate_file(&self) -> CliResult<&PathBuf> {
         self.certificate_file.as_ref().ok_or_else(|| {
             CliError::InvalidRequest(format!(
                 "Certificate file parameter is MANDATORY for {:?} format",
@@ -359,7 +359,7 @@ impl ImportCertificateAction {
 }
 
 /// Build a chain of certificates from a PEM stack
-fn build_chain_from_stack(pem_chain: &[u8]) -> Result<Vec<Object>, CliError> {
+fn build_chain_from_stack(pem_chain: &[u8]) -> CliResult<Vec<Object>> {
     let pem_s = pem::parse_many(pem_chain)
         .map_err(|e| CliError::Conversion(format!("Cannot parse PEM content. Error: {e:?}")))?; // check the PEM is valid (no error
     let mut objects = vec![];

--- a/crate/cli/src/actions/certificates/import_certificate.rs
+++ b/crate/cli/src/actions/certificates/import_certificate.rs
@@ -24,7 +24,7 @@ use crate::{
             utils::{build_usage_mask_from_key_usage, KeyUsage},
         },
     },
-    error::CliError,
+    error::{result::CliResult, CliError},
 };
 
 const MOZILLA_CCADB: &str =
@@ -118,7 +118,7 @@ pub struct ImportCertificateAction {
 }
 
 impl ImportCertificateAction {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         debug!("CLI: entering import certificate");
 
         //generate the leaf certificate attributes if links are specified
@@ -271,7 +271,7 @@ impl ImportCertificateAction {
     }
 
     /// Import the certificate, the chain and the associated private key
-    async fn import_pkcs12(&self, kms_rest_client: &KmsClient) -> Result<String, CliError> {
+    async fn import_pkcs12(&self, kms_rest_client: &KmsClient) -> CliResult<String> {
         let cryptographic_usage_mask = self
             .key_usage
             .as_deref()
@@ -321,7 +321,7 @@ impl ImportCertificateAction {
         mut objects: Vec<Object>,
         replace_existing: bool,
         leaf_certificate_attributes: Option<Attributes>,
-    ) -> Result<String, CliError> {
+    ) -> CliResult<String> {
         let mut previous_identifier: Option<String> = None;
         while let Some(object) = objects.pop() {
             let mut import_attributes = if objects.is_empty() {

--- a/crate/cli/src/actions/certificates/mod.rs
+++ b/crate/cli/src/actions/certificates/mod.rs
@@ -11,7 +11,7 @@ use self::{
     export_certificate::ExportCertificateAction, import_certificate::ImportCertificateAction,
     revoke_certificate::RevokeCertificateAction, validate_certificate::ValidateCertificatesAction,
 };
-use crate::error::CliError;
+use crate::error::result::CliResult;
 
 mod certify;
 mod decrypt_certificate;
@@ -36,7 +36,7 @@ pub enum CertificatesCommands {
 }
 
 impl CertificatesCommands {
-    pub async fn process(&self, client_connector: &KmsClient) -> Result<(), CliError> {
+    pub async fn process(&self, client_connector: &KmsClient) -> CliResult<()> {
         match self {
             Self::Certify(action) => action.run(client_connector).await,
             Self::Decrypt(action) => action.run(client_connector).await,

--- a/crate/cli/src/actions/certificates/revoke_certificate.rs
+++ b/crate/cli/src/actions/certificates/revoke_certificate.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use cosmian_kms_client::KmsClient;
 
-use crate::{actions::shared::utils::revoke, cli_bail, error::CliError};
+use crate::{actions::shared::utils::revoke, cli_bail, error::result::CliResult};
 
 /// Revoke a certificate.
 ///
@@ -30,7 +30,7 @@ pub struct RevokeCertificateAction {
 }
 
 impl RevokeCertificateAction {
-    pub async fn run(&self, client_connector: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, client_connector: &KmsClient) -> CliResult<()> {
         let id = if let Some(certificate_id) = &self.certificate_id {
             certificate_id.clone()
         } else if let Some(tags) = &self.tags {

--- a/crate/cli/src/actions/certificates/validate_certificate.rs
+++ b/crate/cli/src/actions/certificates/validate_certificate.rs
@@ -6,7 +6,7 @@ use cosmian_kms_client::{
     kmip::kmip_types::ValidityIndicator, KmsClient,
 };
 
-use crate::{actions::console, error::CliError};
+use crate::{actions::console, error::result::CliResult};
 
 /// Validate a certificate.
 ///
@@ -28,7 +28,7 @@ pub struct ValidateCertificatesAction {
 }
 
 impl ValidateCertificatesAction {
-    pub async fn run(&self, client_connector: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, client_connector: &KmsClient) -> CliResult<()> {
         let request = build_validate_certificate_request(
             &self.certificate,
             &self.unique_identifier,

--- a/crate/cli/src/actions/console.rs
+++ b/crate/cli/src/actions/console.rs
@@ -7,7 +7,7 @@ use cosmian_kms_client::{
 use serde::Serialize;
 use serde_json::Value;
 
-use crate::error::CliError;
+use crate::error::result::CliResult;
 
 pub const KMS_CLI_FORMAT: &str = "KMS_CLI_FORMAT";
 pub const CLI_DEFAULT_FORMAT: &str = "text";
@@ -90,7 +90,7 @@ impl Stdout {
         self.object_owned = Some(object_owned);
     }
 
-    pub fn write(&self) -> Result<(), CliError> {
+    pub fn write(&self) -> CliResult<()> {
         let json_format_from_env = std::env::var(KMS_CLI_FORMAT)
             .unwrap_or_else(|_| CLI_DEFAULT_FORMAT.to_string())
             .to_lowercase()

--- a/crate/cli/src/actions/cover_crypt/decrypt.rs
+++ b/crate/cli/src/actions/cover_crypt/decrypt.rs
@@ -13,7 +13,7 @@ use cosmian_kms_client::{
 
 use crate::{
     cli_bail,
-    error::{result::CliResultHelper, CliError},
+    error::result::{CliResult, CliResultHelper},
 };
 
 /// Decrypt a file using Covercrypt
@@ -45,7 +45,7 @@ pub struct DecryptAction {
 }
 
 impl DecryptAction {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         // Read the file(s) to decrypt
         let (cryptographic_algorithm, data) = if self.input_files.len() > 1 {
             (

--- a/crate/cli/src/actions/cover_crypt/encrypt.rs
+++ b/crate/cli/src/actions/cover_crypt/encrypt.rs
@@ -13,7 +13,7 @@ use cosmian_kms_client::{
 
 use crate::{
     cli_bail,
-    error::{result::CliResultHelper, CliError},
+    error::result::{CliResult, CliResultHelper},
 };
 
 /// Encrypt a file using Covercrypt
@@ -51,7 +51,7 @@ pub struct EncryptAction {
 }
 
 impl EncryptAction {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         // Read the file(s) to encrypt
         let (cryptographic_algorithm, mut data) = if self.input_files.len() > 1 {
             (

--- a/crate/cli/src/actions/cover_crypt/keys/create_key_pair.rs
+++ b/crate/cli/src/actions/cover_crypt/keys/create_key_pair.rs
@@ -12,7 +12,7 @@ use crate::{
         cover_crypt::policy::{policy_from_binary_file, policy_from_json_file},
     },
     cli_bail,
-    error::{result::CliResultHelper, CliError},
+    error::result::{CliResult, CliResultHelper},
 };
 
 /// Create a new master key pair for a given policy and return the key IDs.
@@ -67,7 +67,7 @@ pub struct CreateMasterKeyPairAction {
 }
 
 impl CreateMasterKeyPairAction {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         // Parse the json policy file
         let policy = if let Some(specs_file) = &self.policy_specifications_file {
             policy_from_json_file(specs_file)?

--- a/crate/cli/src/actions/cover_crypt/keys/create_user_key.rs
+++ b/crate/cli/src/actions/cover_crypt/keys/create_user_key.rs
@@ -7,7 +7,7 @@ use cosmian_kms_client::{
 
 use crate::{
     actions::console,
-    error::{result::CliResultHelper, CliError},
+    error::result::{CliResult, CliResultHelper},
 };
 
 /// Create a new user decryption key given an access policy expressed as a boolean expression.
@@ -65,7 +65,7 @@ pub struct CreateUserKeyAction {
 }
 
 impl CreateUserKeyAction {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         // Verify boolean expression in self.access_policy
         AccessPolicy::from_boolean_expression(&self.access_policy)
             .with_context(|| "bad access policy syntax")?;

--- a/crate/cli/src/actions/cover_crypt/keys/destroy_key.rs
+++ b/crate/cli/src/actions/cover_crypt/keys/destroy_key.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use cosmian_kms_client::KmsClient;
 
-use crate::{actions::shared::utils::destroy, cli_bail, error::CliError};
+use crate::{actions::shared::utils::destroy, cli_bail, error::result::CliResult};
 
 /// Destroy a Covercrypt master or user decryption key.
 ///
@@ -29,7 +29,7 @@ pub struct DestroyKeyAction {
 }
 
 impl DestroyKeyAction {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         let id = if let Some(key_id) = &self.key_id {
             key_id.clone()
         } else if let Some(tags) = &self.tags {

--- a/crate/cli/src/actions/cover_crypt/keys/mod.rs
+++ b/crate/cli/src/actions/cover_crypt/keys/mod.rs
@@ -12,7 +12,7 @@ use self::{
 use crate::actions::shared::{UnwrapKeyAction, WrapKeyAction};
 use crate::{
     actions::shared::{ExportKeyAction, ImportKeyAction},
-    error::CliError,
+    error::result::CliResult,
 };
 
 mod create_key_pair;
@@ -39,7 +39,7 @@ pub enum KeysCommands {
 }
 
 impl KeysCommands {
-    pub async fn process(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn process(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         match self {
             Self::CreateMasterKeyPair(action) => action.run(kms_rest_client).await?,
             Self::CreateUserKey(action) => action.run(kms_rest_client).await?,

--- a/crate/cli/src/actions/cover_crypt/keys/rekey.rs
+++ b/crate/cli/src/actions/cover_crypt/keys/rekey.rs
@@ -9,7 +9,7 @@ use cosmian_kms_client::{
 use crate::{
     actions::console,
     cli_bail,
-    error::{result::CliResultHelper, CliError},
+    error::result::{CliResult, CliResultHelper},
 };
 
 /// Rekey the master and user keys for a given access policy.
@@ -39,7 +39,7 @@ pub struct RekeyAction {
 }
 
 impl RekeyAction {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         let id = if let Some(key_id) = &self.secret_key_id {
             key_id.clone()
         } else if let Some(tags) = &self.tags {
@@ -106,7 +106,7 @@ pub struct PruneAction {
 }
 
 impl PruneAction {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         let id = if let Some(key_id) = &self.secret_key_id {
             key_id.clone()
         } else if let Some(tags) = &self.tags {

--- a/crate/cli/src/actions/cover_crypt/keys/revoke_key.rs
+++ b/crate/cli/src/actions/cover_crypt/keys/revoke_key.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use cosmian_kms_client::KmsClient;
 
-use crate::{actions::shared::utils::revoke, cli_bail, error::CliError};
+use crate::{actions::shared::utils::revoke, cli_bail, error::result::CliResult};
 
 /// Revoke a Covercrypt master or user decryption key.
 ///
@@ -34,7 +34,7 @@ pub struct RevokeKeyAction {
 }
 
 impl RevokeKeyAction {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         let id = if let Some(key_id) = &self.key_id {
             key_id.clone()
         } else if let Some(tags) = &self.tags {

--- a/crate/cli/src/actions/cover_crypt/mod.rs
+++ b/crate/cli/src/actions/cover_crypt/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     actions::cover_crypt::{
         decrypt::DecryptAction, encrypt::EncryptAction, keys::KeysCommands, policy::PolicyCommands,
     },
-    error::CliError,
+    error::result::CliResult,
 };
 
 pub(crate) mod decrypt;
@@ -25,7 +25,7 @@ pub enum CovercryptCommands {
 }
 
 impl CovercryptCommands {
-    pub async fn process(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn process(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         match self {
             Self::Policy(command) => command.process(kms_rest_client).await?,
             Self::Keys(command) => command.process(kms_rest_client).await?,

--- a/crate/cli/src/actions/cover_crypt/policy.rs
+++ b/crate/cli/src/actions/cover_crypt/policy.rs
@@ -22,10 +22,10 @@ use cosmian_kms_client::{
 use crate::{
     actions::console,
     cli_bail,
-    error::{result::CliResultHelper, CliError},
+    error::result::{CliResult, CliResultHelper},
 };
 
-pub fn policy_from_binary_file(bin_filename: &impl AsRef<Path>) -> Result<Policy, CliError> {
+pub fn policy_from_binary_file(bin_filename: &impl AsRef<Path>) -> CliResult<Policy> {
     let policy_buffer = read_bytes_from_file(bin_filename)?;
     Policy::parse_and_convert(policy_buffer.as_slice()).with_context(|| {
         format!(
@@ -35,7 +35,7 @@ pub fn policy_from_binary_file(bin_filename: &impl AsRef<Path>) -> Result<Policy
     })
 }
 
-pub fn policy_from_json_file(specs_filename: &impl AsRef<Path>) -> Result<Policy, CliError> {
+pub fn policy_from_json_file(specs_filename: &impl AsRef<Path>) -> CliResult<Policy> {
     let policy_specs: HashMap<String, Vec<String>> = read_from_json_file(&specs_filename)?;
     policy_specs.try_into().with_context(|| {
         format!(
@@ -59,7 +59,7 @@ pub enum PolicyCommands {
 }
 
 impl PolicyCommands {
-    pub async fn process(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn process(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         match self {
             Self::View(action) => action.run(kms_rest_client).await?,
             Self::Specs(action) => action.run(kms_rest_client).await?,
@@ -125,7 +125,7 @@ pub struct CreateAction {
 }
 
 impl CreateAction {
-    pub async fn run(&self) -> Result<(), CliError> {
+    pub async fn run(&self) -> CliResult<()> {
         // Parse the json policy file
         let policy = policy_from_json_file(&self.policy_specifications_file)?;
 
@@ -149,7 +149,7 @@ async fn recover_policy(
     key_file: Option<&PathBuf>,
     unwrap: bool,
     kms_rest_client: &KmsClient,
-) -> Result<Policy, CliError> {
+) -> CliResult<Policy> {
     // Recover the KMIP Object
     let object: Object = if let Some(key_id) = key_id {
         export_object(kms_rest_client, key_id, unwrap, None, false, None)
@@ -191,7 +191,7 @@ pub struct SpecsAction {
     policy_specs_file: PathBuf,
 }
 impl SpecsAction {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         // Recover the policy
         let policy = recover_policy(
             self.key_id.as_deref(),
@@ -231,7 +231,7 @@ pub struct BinaryAction {
     policy_binary_file: PathBuf,
 }
 impl BinaryAction {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         // Recover the policy
         let policy = recover_policy(
             self.key_id.as_deref(),
@@ -273,7 +273,7 @@ pub struct ViewAction {
     detailed: bool,
 }
 impl ViewAction {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         // Recover the policy
         let policy = recover_policy(
             self.key_id.as_deref(),
@@ -318,7 +318,7 @@ pub struct AddAttributeAction {
     tags: Option<Vec<String>>,
 }
 impl AddAttributeAction {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         let id = if let Some(key_id) = &self.secret_key_id {
             key_id.clone()
         } else if let Some(tags) = &self.tags {
@@ -380,7 +380,7 @@ pub struct RenameAttributeAction {
     tags: Option<Vec<String>>,
 }
 impl RenameAttributeAction {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         let id = if let Some(key_id) = &self.secret_key_id {
             key_id.clone()
         } else if let Some(tags) = &self.tags {
@@ -434,7 +434,7 @@ pub struct DisableAttributeAction {
     tags: Option<Vec<String>>,
 }
 impl DisableAttributeAction {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         let id = if let Some(key_id) = &self.secret_key_id {
             key_id.clone()
         } else if let Some(tags) = &self.tags {
@@ -489,7 +489,7 @@ pub struct RemoveAttributeAction {
     tags: Option<Vec<String>>,
 }
 impl RemoveAttributeAction {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         let id = if let Some(key_id) = &self.secret_key_id {
             key_id.clone()
         } else if let Some(tags) = &self.tags {

--- a/crate/cli/src/actions/elliptic_curves/decrypt.rs
+++ b/crate/cli/src/actions/elliptic_curves/decrypt.rs
@@ -9,7 +9,7 @@ use cosmian_kms_client::{
 use crate::{
     actions::console,
     cli_bail,
-    error::{result::CliResultHelper, CliError},
+    error::result::{CliResult, CliResultHelper},
 };
 
 /// Decrypts a file with the given private key using ECIES
@@ -41,7 +41,7 @@ pub struct DecryptAction {
 }
 
 impl DecryptAction {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         // Read the file to decrypt
         let data = read_bytes_from_file(&self.input_file)
             .with_context(|| "Cannot read bytes from the file to decrypt")?;

--- a/crate/cli/src/actions/elliptic_curves/encrypt.rs
+++ b/crate/cli/src/actions/elliptic_curves/encrypt.rs
@@ -9,7 +9,7 @@ use cosmian_kms_client::{
 use crate::{
     actions::console,
     cli_bail,
-    error::{result::CliResultHelper, CliError},
+    error::result::{CliResult, CliResultHelper},
 };
 
 /// Encrypt a file with the given public key using ECIES
@@ -42,7 +42,7 @@ pub struct EncryptAction {
 }
 
 impl EncryptAction {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         // Read the file to encrypt
         let mut data = read_bytes_from_file(&self.input_file)
             .with_context(|| "Cannot read bytes from the file to encrypt")?;

--- a/crate/cli/src/actions/elliptic_curves/keys/create_key_pair.rs
+++ b/crate/cli/src/actions/elliptic_curves/keys/create_key_pair.rs
@@ -9,7 +9,7 @@ use cosmian_kms_client::{
 
 use crate::{
     actions::console,
-    error::{result::CliResultHelper, CliError},
+    error::result::{CliResult, CliResultHelper},
 };
 
 #[derive(clap::ValueEnum, Debug, Clone, Copy)]
@@ -76,7 +76,7 @@ pub struct CreateKeyPairAction {
 }
 
 impl CreateKeyPairAction {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         let create_key_pair_request = create_ec_key_pair_request(&self.tags, self.curve.into())?;
 
         // Query the KMS with your kmip data and get the key pair ids

--- a/crate/cli/src/actions/elliptic_curves/keys/destroy_key.rs
+++ b/crate/cli/src/actions/elliptic_curves/keys/destroy_key.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use cosmian_kms_client::KmsClient;
 
-use crate::{actions::shared::utils::destroy, cli_bail, error::CliError};
+use crate::{actions::shared::utils::destroy, cli_bail, error::result::CliResult};
 
 /// Destroy a public or private key.
 ///
@@ -26,7 +26,7 @@ pub struct DestroyKeyAction {
 }
 
 impl DestroyKeyAction {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         let id = if let Some(key_id) = &self.key_id {
             key_id.clone()
         } else if let Some(tags) = &self.tags {

--- a/crate/cli/src/actions/elliptic_curves/keys/mod.rs
+++ b/crate/cli/src/actions/elliptic_curves/keys/mod.rs
@@ -9,7 +9,7 @@ use self::{
 use crate::actions::shared::{UnwrapKeyAction, WrapKeyAction};
 use crate::{
     actions::shared::{ExportKeyAction, ImportKeyAction},
-    error::CliError,
+    error::result::CliResult,
 };
 
 mod create_key_pair;
@@ -31,7 +31,7 @@ pub enum KeysCommands {
 }
 
 impl KeysCommands {
-    pub async fn process(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn process(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         match self {
             Self::Create(action) => action.run(kms_rest_client).await?,
             Self::Export(action) => action.run(kms_rest_client).await?,

--- a/crate/cli/src/actions/elliptic_curves/keys/revoke_key.rs
+++ b/crate/cli/src/actions/elliptic_curves/keys/revoke_key.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use cosmian_kms_client::KmsClient;
 
-use crate::{actions::shared::utils::revoke, cli_bail, error::CliError};
+use crate::{actions::shared::utils::revoke, cli_bail, error::result::CliResult};
 
 /// Revoke a public or private key.
 ///
@@ -28,7 +28,7 @@ pub struct RevokeKeyAction {
 }
 
 impl RevokeKeyAction {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         let id = if let Some(key_id) = &self.key_id {
             key_id.clone()
         } else if let Some(tags) = &self.tags {

--- a/crate/cli/src/actions/elliptic_curves/mod.rs
+++ b/crate/cli/src/actions/elliptic_curves/mod.rs
@@ -4,7 +4,7 @@ use cosmian_kms_client::KmsClient;
 use self::keys::KeysCommands;
 #[cfg(not(feature = "fips"))]
 use self::{decrypt::DecryptAction, encrypt::EncryptAction};
-use crate::error::CliError;
+use crate::error::result::CliResult;
 
 #[cfg(not(feature = "fips"))]
 mod decrypt;
@@ -24,7 +24,7 @@ pub enum EllipticCurveCommands {
 }
 
 impl EllipticCurveCommands {
-    pub async fn process(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn process(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         match self {
             Self::Keys(command) => command.process(kms_rest_client).await?,
             #[cfg(not(feature = "fips"))]

--- a/crate/cli/src/actions/google/gmail_client/client_builder.rs
+++ b/crate/cli/src/actions/google/gmail_client/client_builder.rs
@@ -4,7 +4,7 @@ use reqwest::{Client, Response};
 use serde::Deserialize;
 
 use super::{service_account::ServiceAccount, token::retrieve_token, GoogleApiError};
-use crate::error::CliError;
+use crate::error::{result::CliResult, CliError};
 
 #[derive(Deserialize)]
 pub(crate) struct RequestError {
@@ -23,7 +23,7 @@ struct GmailClientBuilder {
 }
 
 impl GmailClientBuilder {
-    pub(crate) fn new(conf_path: &PathBuf, user_id: String) -> Result<Self, CliError> {
+    pub(crate) fn new(conf_path: &PathBuf, user_id: String) -> CliResult<Self> {
         let service_account = ServiceAccount::load_from_config(conf_path)?;
         Ok(Self {
             service_account,
@@ -54,13 +54,13 @@ pub(crate) struct GmailClient {
 }
 
 impl GmailClient {
-    pub(crate) async fn new(conf_path: &PathBuf, user_id: &str) -> Result<Self, CliError> {
+    pub(crate) async fn new(conf_path: &PathBuf, user_id: &str) -> CliResult<Self> {
         GmailClientBuilder::new(conf_path, user_id.to_string())?
             .build()
             .await
     }
 
-    pub(crate) async fn handle_response(response: Response) -> Result<(), CliError> {
+    pub(crate) async fn handle_response(response: Response) -> CliResult<()> {
         if response.status().is_success() {
             println!(
                 "{}",

--- a/crate/cli/src/actions/google/gmail_client/client_builder.rs
+++ b/crate/cli/src/actions/google/gmail_client/client_builder.rs
@@ -31,7 +31,7 @@ impl GmailClientBuilder {
         })
     }
 
-    pub(crate) async fn build(self) -> Result<GmailClient, CliError> {
+    pub(crate) async fn build(self) -> CliResult<GmailClient> {
         let token = retrieve_token(&self.service_account, &self.user_id).await?;
 
         Ok(GmailClient {

--- a/crate/cli/src/actions/google/gmail_client/service_account.rs
+++ b/crate/cli/src/actions/google/gmail_client/service_account.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use cosmian_kms_client::ClientConf;
 use serde::{Deserialize, Serialize};
 
-use crate::error::CliError;
+use crate::error::{result::CliResult, CliError};
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub(crate) struct ServiceAccount {
@@ -21,7 +21,7 @@ pub(crate) struct ServiceAccount {
 }
 
 impl ServiceAccount {
-    pub(crate) fn load_from_config(conf_path: &PathBuf) -> Result<Self, CliError> {
+    pub(crate) fn load_from_config(conf_path: &PathBuf) -> CliResult<Self> {
         let conf = ClientConf::load(conf_path)?;
         let gmail_api_conf = conf.gmail_api_conf.ok_or_else(|| {
             CliError::Default(format!("No gmail_api_conf object in {conf_path:?}"))

--- a/crate/cli/src/actions/google/identities/delete_identities.rs
+++ b/crate/cli/src/actions/google/identities/delete_identities.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use clap::Parser;
 
 use super::IDENTITIES_ENDPOINT;
-use crate::{actions::google::gmail_client::GmailClient, error::CliError};
+use crate::{actions::google::gmail_client::GmailClient, error::result::CliResult};
 
 /// Deletes a client-side encryption identity. The authenticated user can no longer use the identity
 /// to send encrypted messages. You cannot restore the identity after you delete it. Instead, use
@@ -18,7 +18,7 @@ pub struct DeleteIdentitiesAction {
 }
 
 impl DeleteIdentitiesAction {
-    pub async fn run(&self, conf_path: &PathBuf) -> Result<(), CliError> {
+    pub async fn run(&self, conf_path: &PathBuf) -> CliResult<()> {
         let gmail_client = GmailClient::new(conf_path, &self.user_id);
         let endpoint = [IDENTITIES_ENDPOINT, &self.user_id].concat();
         let response = gmail_client.await?.delete(&endpoint).await?;

--- a/crate/cli/src/actions/google/identities/get_identities.rs
+++ b/crate/cli/src/actions/google/identities/get_identities.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use clap::Parser;
 
 use super::IDENTITIES_ENDPOINT;
-use crate::{actions::google::gmail_client::GmailClient, error::CliError};
+use crate::{actions::google::gmail_client::GmailClient, error::result::CliResult};
 
 /// Retrieves a client-side encryption identity configuration.
 #[derive(Parser)]
@@ -16,7 +16,7 @@ pub struct GetIdentitiesAction {
 }
 
 impl GetIdentitiesAction {
-    pub async fn run(&self, conf_path: &PathBuf) -> Result<(), CliError> {
+    pub async fn run(&self, conf_path: &PathBuf) -> CliResult<()> {
         let gmail_client = GmailClient::new(conf_path, &self.user_id);
         let endpoint = [IDENTITIES_ENDPOINT, &self.user_id].concat();
         let response = gmail_client.await?.get(&endpoint).await?;

--- a/crate/cli/src/actions/google/identities/insert_identities.rs
+++ b/crate/cli/src/actions/google/identities/insert_identities.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use serde::{Deserialize, Serialize};
 
 use super::IDENTITIES_ENDPOINT;
-use crate::{actions::google::gmail_client::GmailClient, error::CliError};
+use crate::{actions::google::gmail_client::GmailClient, error::result::CliResult};
 
 #[derive(Serialize, Deserialize)]
 #[allow(non_snake_case)]
@@ -31,7 +31,7 @@ pub struct InsertIdentitiesAction {
 }
 
 impl InsertIdentitiesAction {
-    pub async fn run(&self, conf_path: &PathBuf) -> Result<(), CliError> {
+    pub async fn run(&self, conf_path: &PathBuf) -> CliResult<()> {
         let gmail_client = GmailClient::new(conf_path, &self.user_id);
 
         // Construct identity_info

--- a/crate/cli/src/actions/google/identities/list_identities.rs
+++ b/crate/cli/src/actions/google/identities/list_identities.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use clap::Parser;
 
 use super::IDENTITIES_ENDPOINT;
-use crate::{actions::google::gmail_client::GmailClient, error::CliError};
+use crate::{actions::google::gmail_client::GmailClient, error::result::CliResult};
 
 /// Lists the client-side encrypted identities for an authenticated user.
 #[derive(Parser)]
@@ -15,7 +15,7 @@ pub struct ListIdentitiesAction {
 }
 
 impl ListIdentitiesAction {
-    pub async fn run(&self, conf_path: &PathBuf) -> Result<(), CliError> {
+    pub async fn run(&self, conf_path: &PathBuf) -> CliResult<()> {
         let gmail_client = GmailClient::new(conf_path, &self.user_id);
         let response = gmail_client.await?.get(IDENTITIES_ENDPOINT).await?;
         GmailClient::handle_response(response).await

--- a/crate/cli/src/actions/google/identities/mod.rs
+++ b/crate/cli/src/actions/google/identities/mod.rs
@@ -7,7 +7,7 @@ use self::{
     insert_identities::InsertIdentitiesAction, list_identities::ListIdentitiesAction,
     patch_identities::PatchIdentitiesAction,
 };
-use crate::error::CliError;
+use crate::error::result::CliResult;
 
 mod delete_identities;
 mod get_identities;
@@ -28,7 +28,7 @@ pub enum IdentitiesCommands {
 }
 
 impl IdentitiesCommands {
-    pub async fn process(&self, conf_path: &PathBuf) -> Result<(), CliError> {
+    pub async fn process(&self, conf_path: &PathBuf) -> CliResult<()> {
         match self {
             Self::Get(action) => action.run(conf_path).await,
             Self::List(action) => action.run(conf_path).await,

--- a/crate/cli/src/actions/google/identities/patch_identities.rs
+++ b/crate/cli/src/actions/google/identities/patch_identities.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use serde::{Deserialize, Serialize};
 
 use super::IDENTITIES_ENDPOINT;
-use crate::{actions::google::gmail_client::GmailClient, error::CliError};
+use crate::{actions::google::gmail_client::GmailClient, error::result::CliResult};
 
 #[derive(Serialize, Deserialize)]
 #[allow(non_snake_case)]
@@ -30,7 +30,7 @@ pub struct PatchIdentitiesAction {
 }
 
 impl PatchIdentitiesAction {
-    pub async fn run(&self, conf_path: &PathBuf) -> Result<(), CliError> {
+    pub async fn run(&self, conf_path: &PathBuf) -> CliResult<()> {
         let gmail_client = GmailClient::new(conf_path, &self.user_id);
         let endpoint = [IDENTITIES_ENDPOINT, &self.user_id].concat();
 

--- a/crate/cli/src/actions/google/keypairs/disable_keypairs.rs
+++ b/crate/cli/src/actions/google/keypairs/disable_keypairs.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use clap::Parser;
 
 use super::KEYPAIRS_ENDPOINT;
-use crate::{actions::google::gmail_client::GmailClient, error::CliError};
+use crate::{actions::google::gmail_client::GmailClient, error::result::CliResult};
 
 /// Turns off a client-side encryption key pair. The authenticated user can no longer use the key
 /// pair to decrypt incoming CSE message texts or sign outgoing CSE mail. To regain access, use the
@@ -22,7 +22,7 @@ pub struct DisableKeypairsAction {
 }
 
 impl DisableKeypairsAction {
-    pub async fn run(&self, conf_path: &PathBuf) -> Result<(), CliError> {
+    pub async fn run(&self, conf_path: &PathBuf) -> CliResult<()> {
         let endpoint = [KEYPAIRS_ENDPOINT, &self.keypairs_id, ":disable"].concat();
         let gmail_client = GmailClient::new(conf_path, &self.user_id);
         let response = gmail_client.await?.post(&endpoint, String::new()).await?;

--- a/crate/cli/src/actions/google/keypairs/enable_keypairs.rs
+++ b/crate/cli/src/actions/google/keypairs/enable_keypairs.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use clap::Parser;
 
 use super::KEYPAIRS_ENDPOINT;
-use crate::{actions::google::gmail_client::GmailClient, error::CliError};
+use crate::{actions::google::gmail_client::GmailClient, error::result::CliResult};
 
 /// Turns on a client-side encryption key pair that was turned off. The key pair becomes active
 /// again for any associated client-side encryption identities.
@@ -20,7 +20,7 @@ pub struct EnableKeypairsAction {
 }
 
 impl EnableKeypairsAction {
-    pub async fn run(&self, conf_path: &PathBuf) -> Result<(), CliError> {
+    pub async fn run(&self, conf_path: &PathBuf) -> CliResult<()> {
         let endpoint = [KEYPAIRS_ENDPOINT, &self.keypairs_id, ":enable"].concat();
         let gmail_client = GmailClient::new(conf_path, &self.user_id);
         let response = gmail_client.await?.post(&endpoint, String::new()).await?;

--- a/crate/cli/src/actions/google/keypairs/get_keypairs.rs
+++ b/crate/cli/src/actions/google/keypairs/get_keypairs.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use clap::Parser;
 
 use super::KEYPAIRS_ENDPOINT;
-use crate::{actions::google::gmail_client::GmailClient, error::CliError};
+use crate::{actions::google::gmail_client::GmailClient, error::result::CliResult};
 
 /// Retrieves an existing client-side encryption key pair.
 #[derive(Parser)]
@@ -19,7 +19,7 @@ pub struct GetKeypairsAction {
 }
 
 impl GetKeypairsAction {
-    pub async fn run(&self, conf_path: &PathBuf) -> Result<(), CliError> {
+    pub async fn run(&self, conf_path: &PathBuf) -> CliResult<()> {
         let endpoint = [KEYPAIRS_ENDPOINT, &self.keypairs_id].concat();
         let gmail_client = GmailClient::new(conf_path, &self.user_id);
         let response = gmail_client.await?.get(&endpoint).await?;

--- a/crate/cli/src/actions/google/keypairs/insert_keypairs.rs
+++ b/crate/cli/src/actions/google/keypairs/insert_keypairs.rs
@@ -59,7 +59,7 @@ struct KaclsKeyMetadata {
 }
 
 impl InsertKeypairsAction {
-    fn get_input_files(indir: &PathBuf, ext: &str) -> Result<Vec<PathBuf>, CliError> {
+    fn get_input_files(indir: &PathBuf, ext: &str) -> CliResult<Vec<PathBuf>> {
         Ok(fs::read_dir(indir)?
             .filter_map(|entry| entry.ok().map(|e| e.path()))
             .filter(|f| f.is_file())
@@ -67,10 +67,7 @@ impl InsertKeypairsAction {
             .collect())
     }
 
-    fn get_email_to_file(
-        files: &[PathBuf],
-        ext: &str,
-    ) -> Result<HashMap<String, PathBuf>, CliError> {
+    fn get_email_to_file(files: &[PathBuf], ext: &str) -> CliResult<HashMap<String, PathBuf>> {
         let mut email_file_map = HashMap::new();
 
         for file in files {

--- a/crate/cli/src/actions/google/keypairs/insert_keypairs.rs
+++ b/crate/cli/src/actions/google/keypairs/insert_keypairs.rs
@@ -9,7 +9,10 @@ use clap::Parser;
 use serde::{Deserialize, Serialize};
 
 use super::KEYPAIRS_ENDPOINT;
-use crate::{actions::google::gmail_client::GmailClient, error::CliError};
+use crate::{
+    actions::google::gmail_client::GmailClient,
+    error::{result::CliResult, CliError},
+};
 
 /// Creates and uploads a client-side encryption S/MIME public key certificate chain and private key
 /// metadata for a user.
@@ -97,10 +100,10 @@ impl InsertKeypairsAction {
         email_cert_file_map: &HashMap<String, PathBuf>,
         email: &str,
         key_file: &PathBuf,
-    ) -> Result<(), CliError> {
+    ) -> CliResult<()> {
         tracing::info!("Processing {email:?}.");
 
-        let read_to_string = |path: &PathBuf| -> Result<String, CliError> {
+        let read_to_string = |path: &PathBuf| -> CliResult<String> {
             let mut f = File::open(path)?;
             let mut s = String::new();
             f.read_to_string(&mut s)?;
@@ -130,7 +133,7 @@ impl InsertKeypairsAction {
         Ok(())
     }
 
-    pub async fn run(&self, conf_path: &PathBuf) -> Result<(), CliError> {
+    pub async fn run(&self, conf_path: &PathBuf) -> CliResult<()> {
         let gmail_client = GmailClient::new(conf_path, &self.user_id).await?;
 
         let wrapped_key_files = Self::get_input_files(&self.inkeydir, "wrap")?;

--- a/crate/cli/src/actions/google/keypairs/list_keypairs.rs
+++ b/crate/cli/src/actions/google/keypairs/list_keypairs.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use clap::Parser;
 
 use super::KEYPAIRS_ENDPOINT;
-use crate::{actions::google::gmail_client::GmailClient, error::CliError};
+use crate::{actions::google::gmail_client::GmailClient, error::result::CliResult};
 
 /// Lists client-side encryption key pairs for a user.
 #[derive(Parser)]
@@ -15,7 +15,7 @@ pub struct ListKeypairsAction {
 }
 
 impl ListKeypairsAction {
-    pub async fn run(&self, conf_path: &PathBuf) -> Result<(), CliError> {
+    pub async fn run(&self, conf_path: &PathBuf) -> CliResult<()> {
         let gmail_client = GmailClient::new(conf_path, &self.user_id);
         let response = gmail_client.await?.get(KEYPAIRS_ENDPOINT).await?;
         GmailClient::handle_response(response).await

--- a/crate/cli/src/actions/google/keypairs/mod.rs
+++ b/crate/cli/src/actions/google/keypairs/mod.rs
@@ -7,7 +7,7 @@ use self::{
     get_keypairs::GetKeypairsAction, insert_keypairs::InsertKeypairsAction,
     list_keypairs::ListKeypairsAction, obliterate_keypairs::ObliterateKeypairsAction,
 };
-use crate::error::CliError;
+use crate::error::result::CliResult;
 
 mod disable_keypairs;
 mod enable_keypairs;
@@ -30,7 +30,7 @@ pub enum KeypairsCommands {
 }
 
 impl KeypairsCommands {
-    pub async fn process(&self, conf_path: &PathBuf) -> Result<(), CliError> {
+    pub async fn process(&self, conf_path: &PathBuf) -> CliResult<()> {
         match self {
             Self::Get(action) => action.run(conf_path).await,
             Self::List(action) => action.run(conf_path).await,

--- a/crate/cli/src/actions/google/keypairs/obliterate_keypairs.rs
+++ b/crate/cli/src/actions/google/keypairs/obliterate_keypairs.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use clap::Parser;
 
 use super::KEYPAIRS_ENDPOINT;
-use crate::{actions::google::gmail_client::GmailClient, error::CliError};
+use crate::{actions::google::gmail_client::GmailClient, error::result::CliResult};
 
 /// Deletes a client-side encryption key pair permanently and immediately. You can only permanently
 /// delete key pairs that have been turned off for more than 30 days. To turn off a key pair, use
@@ -23,7 +23,7 @@ pub struct ObliterateKeypairsAction {
 }
 
 impl ObliterateKeypairsAction {
-    pub async fn run(&self, conf_path: &PathBuf) -> Result<(), CliError> {
+    pub async fn run(&self, conf_path: &PathBuf) -> CliResult<()> {
         let endpoint: String = [KEYPAIRS_ENDPOINT, &self.keypairs_id, ":obliterate"].concat();
         let gmail_client = GmailClient::new(conf_path, &self.user_id);
         let response = gmail_client.await?.post(&endpoint, String::new()).await?;

--- a/crate/cli/src/actions/google/mod.rs
+++ b/crate/cli/src/actions/google/mod.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use clap::Parser;
 
 use self::{identities::IdentitiesCommands, keypairs::KeypairsCommands};
-use crate::error::CliError;
+use crate::error::result::CliResult;
 
 mod gmail_client;
 mod identities;
@@ -20,7 +20,7 @@ pub enum GoogleCommands {
 }
 
 impl GoogleCommands {
-    pub async fn process(&self, conf_path: &PathBuf) -> Result<(), CliError> {
+    pub async fn process(&self, conf_path: &PathBuf) -> CliResult<()> {
         match self {
             Self::Keypairs(command) => command.process(conf_path).await?,
             Self::Identities(command) => command.process(conf_path).await?,

--- a/crate/cli/src/actions/login.rs
+++ b/crate/cli/src/actions/login.rs
@@ -25,7 +25,10 @@ use oauth2::{
 use serde::Deserialize;
 use url::Url;
 
-use crate::{cli_bail, error::CliError};
+use crate::{
+    cli_bail,
+    error::{result::CliResult, CliError},
+};
 
 /// Login to the Identity Provider of the KMS server using the `OAuth2` authorization code flow.
 ///
@@ -45,7 +48,7 @@ use crate::{cli_bail, error::CliError};
 pub struct LoginAction;
 
 impl LoginAction {
-    pub async fn process(&self, conf_path: &PathBuf) -> Result<(), CliError> {
+    pub async fn process(&self, conf_path: &PathBuf) -> CliResult<()> {
         let mut conf = ClientConf::load(conf_path)?;
         let oauth2_conf = conf
             .oauth2_conf
@@ -184,7 +187,7 @@ impl LoginState {
     /// This function should be called immediately after the user has been instructed to browse to the authorization URL.
     /// It starts a server on localhost:17899 and waits for the authorization code to be received
     /// from the browser window. Once the code is received, the server is closed and the code is returned.
-    pub async fn finalize(&self) -> Result<String, CliError> {
+    pub async fn finalize(&self) -> CliResult<String> {
         // recover the authorization code, state and other parameters from the redirect URL
         let auth_parameters = Self::receive_authorization_parameters()?;
 

--- a/crate/cli/src/actions/login.rs
+++ b/crate/cli/src/actions/login.rs
@@ -237,7 +237,7 @@ impl LoginState {
 
     /// This function starts the server on `localhost:17899` and waits for the authorization code to be received
     /// from the browser window. Once the code is received, the server is closed and the authorization code is returned.
-    fn receive_authorization_parameters() -> Result<HashMap<String, String>, CliError> {
+    fn receive_authorization_parameters() -> CliResult<HashMap<String, String>> {
         let (auth_params_tx, auth_params_rx) = mpsc::channel::<HashMap<String, String>>();
         // Spawn the server into a runtime
         let tokio_handle = tokio::runtime::Handle::current();
@@ -297,7 +297,7 @@ pub async fn request_token(
     redirect_url: &Url,
     pkce_verifier: &PkceCodeVerifier,
     authorization_code: &str,
-) -> Result<OAuthResponse, CliError> {
+) -> CliResult<OAuthResponse> {
     let params = vec![
         ("grant_type", "authorization_code"),
         ("redirect_uri", redirect_url.as_str()),

--- a/crate/cli/src/actions/logout.rs
+++ b/crate/cli/src/actions/logout.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use clap::Parser;
 use cosmian_kms_client::ClientConf;
 
-use crate::error::CliError;
+use crate::error::result::CliResult;
 
 /// Logout from the Identity Provider.
 ///
@@ -13,7 +13,7 @@ use crate::error::CliError;
 pub struct LogoutAction;
 
 impl LogoutAction {
-    pub fn process(&self, conf_path: &PathBuf) -> Result<(), CliError> {
+    pub fn process(&self, conf_path: &PathBuf) -> CliResult<()> {
         let mut conf = ClientConf::load(conf_path)?;
         conf.kms_access_token = None;
         conf.save(conf_path)?;

--- a/crate/cli/src/actions/markdown.rs
+++ b/crate/cli/src/actions/markdown.rs
@@ -2,7 +2,7 @@ use std::{fmt::Write, fs::File, io::Write as io_Write, path::PathBuf};
 
 use clap::{builder::StyledStr, Command, Parser};
 
-use crate::error::{result::CliResult, CliError};
+use crate::error::result::CliResult;
 
 /// Generate the CLI documentation as markdown
 #[derive(Parser, Debug)]
@@ -125,7 +125,7 @@ fn write_subcommands<'a>(
     parent_index: &str,
     parent_command: &str,
     cmd: &'a Command,
-) -> Result<Vec<&'a Command>, CliError> {
+) -> CliResult<Vec<&'a Command>> {
     let mut sc = Vec::new();
     for (i, sub_command) in cmd.get_subcommands().enumerate() {
         if i == 0 {

--- a/crate/cli/src/actions/markdown.rs
+++ b/crate/cli/src/actions/markdown.rs
@@ -2,7 +2,7 @@ use std::{fmt::Write, fs::File, io::Write as io_Write, path::PathBuf};
 
 use clap::{builder::StyledStr, Command, Parser};
 
-use crate::error::CliError;
+use crate::error::{result::CliResult, CliError};
 
 /// Generate the CLI documentation as markdown
 #[derive(Parser, Debug)]
@@ -13,7 +13,7 @@ pub struct MarkdownAction {
 }
 
 impl MarkdownAction {
-    pub fn process(&self, cmd: &Command) -> Result<(), CliError> {
+    pub fn process(&self, cmd: &Command) -> CliResult<()> {
         let mut output = String::new();
         writeln!(
             output,
@@ -28,12 +28,7 @@ impl MarkdownAction {
     }
 }
 
-fn write_command(
-    out: &mut dyn Write,
-    index: &str,
-    parent: &str,
-    cmd: &Command,
-) -> Result<(), CliError> {
+fn write_command(out: &mut dyn Write, index: &str, parent: &str, cmd: &Command) -> CliResult<()> {
     if !parent.is_empty() {
         writeln!(out, "---")?;
         writeln!(out)?;
@@ -163,7 +158,7 @@ fn write_subcommands<'a>(
     Ok(sc)
 }
 
-fn to_md(out: &mut dyn Write, ss: &StyledStr) -> Result<(), CliError> {
+fn to_md(out: &mut dyn Write, ss: &StyledStr) -> CliResult<()> {
     let s = ss.to_string();
     let split = s.split('\n');
     let mut in_list = false;

--- a/crate/cli/src/actions/new_database.rs
+++ b/crate/cli/src/actions/new_database.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use cosmian_kms_client::KmsClient;
 
-use crate::error::{result::CliResultHelper, CliError};
+use crate::error::result::{CliResult, CliResultHelper};
 
 /// Initialize a new user encrypted database and return the secret (`SQLCipher` only).
 ///
@@ -19,7 +19,7 @@ use crate::error::{result::CliResultHelper, CliError};
 pub struct NewDatabaseAction;
 
 impl NewDatabaseAction {
-    pub async fn process(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn process(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         // Query the KMS to get a new database
         let token = kms_rest_client
             .new_database()

--- a/crate/cli/src/actions/rsa/decrypt.rs
+++ b/crate/cli/src/actions/rsa/decrypt.rs
@@ -12,7 +12,7 @@ use crate::{
         rsa::{to_cryptographic_parameters, EncryptionAlgorithm, HashFn},
     },
     cli_bail,
-    error::{result::CliResultHelper, CliError},
+    error::result::{CliResult, CliResultHelper},
 };
 
 /// Decrypt a file with the given public key using either
@@ -76,7 +76,7 @@ pub struct DecryptAction {
 }
 
 impl DecryptAction {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         // Read the file to decrypt
         let data = read_bytes_from_file(&self.input_file)
             .with_context(|| "Cannot read bytes from the file to decrypt")?;

--- a/crate/cli/src/actions/rsa/encrypt.rs
+++ b/crate/cli/src/actions/rsa/encrypt.rs
@@ -12,7 +12,7 @@ use crate::{
         rsa::{to_cryptographic_parameters, EncryptionAlgorithm, HashFn},
     },
     cli_bail,
-    error::{result::CliResultHelper, CliError},
+    error::result::{CliResult, CliResultHelper},
 };
 
 /// Encrypt a file with the given public key using either
@@ -75,7 +75,7 @@ pub struct EncryptAction {
 }
 
 impl EncryptAction {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         // Read the file to encrypt
         let mut data = read_bytes_from_file(&self.input_file)
             .with_context(|| "Cannot read bytes from the file to encrypt")?;

--- a/crate/cli/src/actions/rsa/keys/create_key_pair.rs
+++ b/crate/cli/src/actions/rsa/keys/create_key_pair.rs
@@ -5,7 +5,7 @@ use cosmian_kms_client::{
 
 use crate::{
     actions::console,
-    error::{result::CliResultHelper, CliError},
+    error::result::{CliResult, CliResultHelper},
 };
 
 /// Create a new RSA key pair
@@ -35,7 +35,7 @@ pub struct CreateKeyPairAction {
 }
 
 impl CreateKeyPairAction {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         let create_key_pair_request = create_rsa_key_pair_request(&self.tags, self.key_size)?;
 
         // Query the KMS with your kmip data and get the key pair ids

--- a/crate/cli/src/actions/rsa/keys/destroy_key.rs
+++ b/crate/cli/src/actions/rsa/keys/destroy_key.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use cosmian_kms_client::KmsClient;
 
-use crate::{actions::shared::utils::destroy, cli_bail, error::CliError};
+use crate::{actions::shared::utils::destroy, cli_bail, error::result::CliResult};
 
 /// Destroy a public or private key.
 ///
@@ -26,7 +26,7 @@ pub struct DestroyKeyAction {
 }
 
 impl DestroyKeyAction {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         let id = if let Some(key_id) = &self.key_id {
             key_id.clone()
         } else if let Some(tags) = &self.tags {

--- a/crate/cli/src/actions/rsa/keys/mod.rs
+++ b/crate/cli/src/actions/rsa/keys/mod.rs
@@ -9,7 +9,7 @@ use self::{
 use crate::actions::shared::{UnwrapKeyAction, WrapKeyAction};
 use crate::{
     actions::shared::{ExportKeyAction, ImportKeyAction},
-    error::CliError,
+    error::result::CliResult,
 };
 
 mod create_key_pair;
@@ -31,7 +31,7 @@ pub enum KeysCommands {
 }
 
 impl KeysCommands {
-    pub async fn process(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn process(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         match self {
             Self::Create(action) => action.run(kms_rest_client).await?,
             Self::Export(action) => action.run(kms_rest_client).await?,

--- a/crate/cli/src/actions/rsa/keys/revoke_key.rs
+++ b/crate/cli/src/actions/rsa/keys/revoke_key.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use cosmian_kms_client::KmsClient;
 
-use crate::{actions::shared::utils::revoke, cli_bail, error::CliError};
+use crate::{actions::shared::utils::revoke, cli_bail, error::result::CliResult};
 
 /// Revoke a public or private key.
 ///
@@ -28,7 +28,7 @@ pub struct RevokeKeyAction {
 }
 
 impl RevokeKeyAction {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         let id = if let Some(key_id) = &self.key_id {
             key_id.clone()
         } else if let Some(tags) = &self.tags {

--- a/crate/cli/src/actions/rsa/mod.rs
+++ b/crate/cli/src/actions/rsa/mod.rs
@@ -8,7 +8,7 @@ use cosmian_kms_client::{
 };
 
 use self::{decrypt::DecryptAction, encrypt::EncryptAction, keys::KeysCommands};
-use crate::error::CliError;
+use crate::error::result::CliResult;
 
 mod decrypt;
 mod encrypt;
@@ -24,7 +24,7 @@ pub enum RsaCommands {
 }
 
 impl RsaCommands {
-    pub async fn process(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn process(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         match self {
             Self::Keys(command) => command.process(kms_rest_client).await?,
             Self::Encrypt(action) => action.run(kms_rest_client).await?,

--- a/crate/cli/src/actions/shared/get_attributes.rs
+++ b/crate/cli/src/actions/shared/get_attributes.rs
@@ -11,7 +11,7 @@ use cosmian_kms_client::{
 use serde_json::Value;
 use tracing::{debug, trace};
 
-use crate::{actions::console, cli_bail, error::CliError};
+use crate::{actions::console, cli_bail, error::result::CliResult};
 
 #[derive(clap::ValueEnum, Debug, Clone, PartialEq, Eq, Hash)]
 pub enum AttributeTag {
@@ -78,7 +78,7 @@ pub struct GetAttributesAction {
 }
 
 impl GetAttributesAction {
-    pub async fn process(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn process(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         trace!("GetAttributesAction: {:?}", self);
         let id = if let Some(key_id) = &self.id {
             key_id.clone()

--- a/crate/cli/src/actions/shared/import_key.rs
+++ b/crate/cli/src/actions/shared/import_key.rs
@@ -203,7 +203,7 @@ impl ImportKeyAction {
 }
 
 /// Read a key from a PEM file
-fn read_key_from_pem(bytes: &[u8]) -> Result<Object, CliError> {
+fn read_key_from_pem(bytes: &[u8]) -> CliResult<Object> {
     let mut objects = objects_from_pem(bytes)?;
     let object = objects
         .pop()

--- a/crate/cli/src/actions/shared/locate.rs
+++ b/crate/cli/src/actions/shared/locate.rs
@@ -16,7 +16,7 @@ use cosmian_kms_client::{
 };
 use strum::IntoEnumIterator;
 
-use crate::{actions::console, error::CliError};
+use crate::{actions::console, error::result::CliResult};
 
 /// Locate cryptographic objects inside the KMS
 ///
@@ -94,7 +94,7 @@ pub struct LocateObjectsAction {
 
 impl LocateObjectsAction {
     /// Export a key from the KMS
-    pub async fn process(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn process(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         let mut attributes = Attributes::default();
 
         if let Some(crypto_algo) = self.cryptographic_algorithm {

--- a/crate/cli/src/actions/shared/unwrap_key.rs
+++ b/crate/cli/src/actions/shared/unwrap_key.rs
@@ -13,7 +13,7 @@ use cosmian_kms_client::{
 use crate::{
     actions::console,
     cli_bail,
-    error::{result::CliResultHelper, CliError},
+    error::result::{CliResult, CliResultHelper},
 };
 
 /// Locally unwrap a key in KMIP JSON TTLV format.
@@ -68,7 +68,7 @@ pub struct UnwrapKeyAction {
 
 impl UnwrapKeyAction {
     /// Export a key from the KMS
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         // read the key file
         let mut object = read_object_from_json_ttlv_file(&self.key_file_in)?;
 

--- a/crate/cli/src/actions/shared/utils/destroy_utils.rs
+++ b/crate/cli/src/actions/shared/utils/destroy_utils.rs
@@ -6,10 +6,10 @@ use cosmian_kms_client::{
 use crate::{
     actions::console,
     cli_bail,
-    error::{result::CliResultHelper, CliError},
+    error::result::{CliResult, CliResultHelper},
 };
 
-pub(crate) async fn destroy(kms_rest_client: &KmsClient, key_id: &str) -> Result<(), CliError> {
+pub(crate) async fn destroy(kms_rest_client: &KmsClient, key_id: &str) -> CliResult<()> {
     // Create the kmip query
     let destroy_query = Destroy {
         unique_identifier: Some(UniqueIdentifier::TextString(key_id.to_string())),

--- a/crate/cli/src/actions/shared/utils/revoke_utils.rs
+++ b/crate/cli/src/actions/shared/utils/revoke_utils.rs
@@ -9,14 +9,14 @@ use cosmian_kms_client::{
 use crate::{
     actions::console,
     cli_bail,
-    error::{result::CliResultHelper, CliError},
+    error::result::{CliResult, CliResultHelper},
 };
 
 pub(crate) async fn revoke(
     kms_rest_client: &KmsClient,
     key_id: &str,
     revocation_reason: &str,
-) -> Result<(), CliError> {
+) -> CliResult<()> {
     // Create the kmip query
     let revoke_query = build_revoke_key_request(
         key_id,

--- a/crate/cli/src/actions/shared/wrap_key.rs
+++ b/crate/cli/src/actions/shared/wrap_key.rs
@@ -18,7 +18,7 @@ use cosmian_kms_client::{
 use crate::{
     actions::{console, shared::SYMMETRIC_WRAPPING_KEY_SIZE},
     cli_bail,
-    error::{result::CliResultHelper, CliError},
+    error::result::{CliResult, CliResultHelper},
 };
 
 /// Locally wrap a key in KMIP JSON TTLV format.
@@ -62,7 +62,7 @@ pub struct WrapKeyAction {
 }
 
 impl WrapKeyAction {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         // read the key file
         let mut object = read_object_from_json_ttlv_file(&self.key_file_in)?;
 

--- a/crate/cli/src/actions/symmetric/decrypt.rs
+++ b/crate/cli/src/actions/symmetric/decrypt.rs
@@ -9,7 +9,7 @@ use cosmian_kms_client::{
 use crate::{
     actions::console,
     cli_bail,
-    error::{result::CliResultHelper, CliError},
+    error::result::{CliResult, CliResultHelper},
 };
 
 /// Decrypts a file using AES GCM
@@ -47,7 +47,7 @@ pub struct DecryptAction {
 }
 
 impl DecryptAction {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         // Read the file to decrypt
         let mut data = read_bytes_from_file(&self.input_file)
             .with_context(|| "Cannot read bytes from the file to decrypt")?;

--- a/crate/cli/src/actions/symmetric/encrypt.rs
+++ b/crate/cli/src/actions/symmetric/encrypt.rs
@@ -9,7 +9,7 @@ use cosmian_kms_client::{
 use crate::{
     actions::console,
     cli_bail,
-    error::{result::CliResultHelper, CliError},
+    error::result::{CliResult, CliResultHelper},
 };
 
 /// Encrypt a file using AES GCM
@@ -48,7 +48,7 @@ pub struct EncryptAction {
 }
 
 impl EncryptAction {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         // Read the file to encrypt
         let data = read_bytes_from_file(&self.input_file)
             .with_context(|| "Cannot read bytes from the file to encrypt")?;

--- a/crate/cli/src/actions/symmetric/keys/create_key.rs
+++ b/crate/cli/src/actions/symmetric/keys/create_key.rs
@@ -11,7 +11,7 @@ use cosmian_kms_client::{
 use crate::{
     actions::console,
     cli_bail,
-    error::{result::CliResultHelper, CliError},
+    error::result::{CliResult, CliResultHelper},
 };
 
 #[derive(clap::ValueEnum, Debug, Clone, Copy)]
@@ -63,7 +63,7 @@ pub struct CreateKeyAction {
 }
 
 impl CreateKeyAction {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         let mut key_bytes = None;
         let number_of_bits = if let Some(key_b64) = &self.wrap_key_b64 {
             let bytes = general_purpose::STANDARD

--- a/crate/cli/src/actions/symmetric/keys/destroy_key.rs
+++ b/crate/cli/src/actions/symmetric/keys/destroy_key.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use cosmian_kms_client::KmsClient;
 
-use crate::{actions::shared::utils::destroy, cli_bail, error::CliError};
+use crate::{actions::shared::utils::destroy, cli_bail, error::result::CliResult};
 
 /// Destroy a symmetric key.
 ///
@@ -23,7 +23,7 @@ pub struct DestroyKeyAction {
 }
 
 impl DestroyKeyAction {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         let id = if let Some(key_id) = &self.key_id {
             key_id.clone()
         } else if let Some(tags) = &self.tags {

--- a/crate/cli/src/actions/symmetric/keys/mod.rs
+++ b/crate/cli/src/actions/symmetric/keys/mod.rs
@@ -8,7 +8,7 @@ use self::{
 use crate::actions::shared::{UnwrapKeyAction, WrapKeyAction};
 use crate::{
     actions::shared::{ExportKeyAction, ImportKeyAction},
-    error::CliError,
+    error::result::CliResult,
 };
 
 mod create_key;
@@ -30,7 +30,7 @@ pub enum KeysCommands {
 }
 
 impl KeysCommands {
-    pub async fn process(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn process(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         match self {
             Self::Create(action) => action.run(kms_rest_client).await?,
             Self::Export(action) => action.run(kms_rest_client).await?,

--- a/crate/cli/src/actions/symmetric/keys/revoke_key.rs
+++ b/crate/cli/src/actions/symmetric/keys/revoke_key.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use cosmian_kms_client::KmsClient;
 
-use crate::{actions::shared::utils::revoke, cli_bail, error::CliError};
+use crate::{actions::shared::utils::revoke, cli_bail, error::result::CliResult};
 
 /// Revoke a symmetric key.
 ///
@@ -25,7 +25,7 @@ pub struct RevokeKeyAction {
 }
 
 impl RevokeKeyAction {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         let id = if let Some(key_id) = &self.key_id {
             key_id.clone()
         } else if let Some(tags) = &self.tags {

--- a/crate/cli/src/actions/symmetric/mod.rs
+++ b/crate/cli/src/actions/symmetric/mod.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use cosmian_kms_client::KmsClient;
 
 use self::{decrypt::DecryptAction, encrypt::EncryptAction, keys::KeysCommands};
-use crate::error::CliError;
+use crate::error::result::CliResult;
 
 mod decrypt;
 mod encrypt;
@@ -18,7 +18,7 @@ pub enum SymmetricCommands {
 }
 
 impl SymmetricCommands {
-    pub async fn process(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn process(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         match self {
             Self::Keys(command) => command.process(kms_rest_client).await?,
             Self::Encrypt(action) => action.run(kms_rest_client).await?,

--- a/crate/cli/src/actions/version.rs
+++ b/crate/cli/src/actions/version.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use cosmian_kms_client::KmsClient;
 
 use super::console;
-use crate::error::{result::CliResultHelper, CliError};
+use crate::error::result::{CliResult, CliResultHelper};
 
 /// Print the version of the server
 #[derive(Parser, Debug)]
@@ -10,7 +10,7 @@ use crate::error::{result::CliResultHelper, CliError};
 pub struct ServerVersionAction;
 
 impl ServerVersionAction {
-    pub async fn process(&self, kms_rest_client: &KmsClient) -> Result<(), CliError> {
+    pub async fn process(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         let version = kms_rest_client
             .version()
             .await

--- a/crate/cli/src/error/mod.rs
+++ b/crate/cli/src/error/mod.rs
@@ -1,4 +1,4 @@
-use std::{array::TryFromSliceError, str::Utf8Error};
+use std::{array::TryFromSliceError, num::TryFromIntError, str::Utf8Error};
 
 #[cfg(test)]
 use assert_cmd::cargo::CargoError;
@@ -150,6 +150,12 @@ impl From<reqwest::Error> for CliError {
     }
 }
 
+impl From<TryFromIntError> for CliError {
+    fn from(e: TryFromIntError) -> Self {
+        Self::Default(format!("{e}: Details: {e:?}"))
+    }
+}
+
 #[cfg(test)]
 impl From<CargoError> for CliError {
     fn from(e: CargoError) -> Self {
@@ -262,7 +268,8 @@ macro_rules! cli_bail {
 
 #[cfg(test)]
 mod tests {
-    use super::CliError;
+
+    use crate::error::result::CliResult;
 
     #[test]
     fn test_cli_error_interpolation() {
@@ -277,7 +284,7 @@ mod tests {
         assert_eq!("interpolate 44", err.unwrap_err().to_string());
     }
 
-    fn bail() -> Result<(), CliError> {
+    fn bail() -> CliResult<()> {
         let var = 43;
         if true {
             cli_bail!("interpolate {var}");
@@ -285,7 +292,7 @@ mod tests {
         Ok(())
     }
 
-    fn ensure() -> Result<(), CliError> {
+    fn ensure() -> CliResult<()> {
         let var = 44;
         cli_ensure!(false, "interpolate {var}");
         Ok(())

--- a/crate/cli/src/lib.rs
+++ b/crate/cli/src/lib.rs
@@ -1,3 +1,25 @@
+#![deny(
+    nonstandard_style,
+    refining_impl_trait,
+    future_incompatible,
+    keyword_idents,
+    let_underscore,
+    rust_2024_compatibility,
+    clippy::all,
+    clippy::suspicious,
+    clippy::complexity,
+    clippy::perf,
+    clippy::style,
+    clippy::pedantic,
+    clippy::cargo
+)]
+#![allow(
+    clippy::module_name_repetitions,
+    clippy::missing_errors_doc,
+    clippy::too_many_lines,
+    clippy::cargo_common_metadata,
+    clippy::multiple_crate_versions
+)]
 pub mod actions;
 pub mod error;
 

--- a/crate/cli/src/main.rs
+++ b/crate/cli/src/main.rs
@@ -18,7 +18,7 @@ use cosmian_kms_cli::{
         symmetric::SymmetricCommands,
         version::ServerVersionAction,
     },
-    error::CliError,
+    error::result::CliResult,
 };
 use cosmian_kms_client::ClientConf;
 
@@ -85,7 +85,7 @@ async fn main() {
     }
 }
 
-async fn main_() -> Result<(), CliError> {
+async fn main_() -> CliResult<()> {
     // Set up environment variables and logging options if RUST_LOG if defined
     // Ex: `export RUST_LOG="info,cosmian=info,cosmian_kms_cli=info,actix_web=info,sqlx::query=error,mysql=info"``
     cosmian_logger::log_utils::log_init(None);

--- a/crate/cli/src/tests/access.rs
+++ b/crate/cli/src/tests/access.rs
@@ -6,7 +6,7 @@ use kms_test_server::start_default_test_kms_server_with_cert_auth;
 
 use super::{symmetric::create_key::create_symmetric_key, utils::recover_cmd_logs};
 use crate::{
-    error::CliError,
+    error::{result::CliResult, CliError},
     tests::{
         shared::{destroy, export_key, revoke},
         symmetric::encrypt_decrypt::run_encrypt_decrypt_test,
@@ -17,7 +17,7 @@ use crate::{
 pub(crate) const SUB_COMMAND: &str = "access-rights";
 
 /// Generates a symmetric key
-fn gen_key(cli_conf_path: &str) -> Result<String, CliError> {
+fn gen_key(cli_conf_path: &str) -> CliResult<String> {
     create_symmetric_key(cli_conf_path, None, None, None, &[])
 }
 
@@ -27,7 +27,7 @@ pub(crate) fn grant_access(
     object_id: &str,
     user: &str,
     operations: &[&str],
-) -> Result<(), CliError> {
+) -> CliResult<()> {
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
     cmd.env(KMS_CLI_CONF_ENV, cli_conf_path);
 
@@ -51,7 +51,7 @@ pub(crate) fn revoke_access(
     object_id: &str,
     user: &str,
     operations: &[&str],
-) -> Result<(), CliError> {
+) -> CliResult<()> {
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
     cmd.env(KMS_CLI_CONF_ENV, cli_conf_path);
 
@@ -70,7 +70,7 @@ pub(crate) fn revoke_access(
 }
 
 /// List accesses granted on an object
-fn list_access(cli_conf_path: &str, object_id: &str) -> Result<String, CliError> {
+fn list_access(cli_conf_path: &str, object_id: &str) -> CliResult<String> {
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
     cmd.env(KMS_CLI_CONF_ENV, cli_conf_path);
 
@@ -87,7 +87,7 @@ fn list_access(cli_conf_path: &str, object_id: &str) -> Result<String, CliError>
 }
 
 /// List objects owned by the user
-fn list_owned_objects(cli_conf_path: &str) -> Result<String, CliError> {
+fn list_owned_objects(cli_conf_path: &str) -> CliResult<String> {
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
     cmd.env(KMS_CLI_CONF_ENV, cli_conf_path);
 
@@ -104,7 +104,7 @@ fn list_owned_objects(cli_conf_path: &str) -> Result<String, CliError> {
 }
 
 /// List accesses granted
-fn list_accesses_rights_obtained(cli_conf_path: &str) -> Result<String, CliError> {
+fn list_accesses_rights_obtained(cli_conf_path: &str) -> CliResult<String> {
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
     cmd.env(KMS_CLI_CONF_ENV, cli_conf_path);
 
@@ -121,8 +121,10 @@ fn list_accesses_rights_obtained(cli_conf_path: &str) -> Result<String, CliError
 }
 
 #[tokio::test]
-pub(crate) async fn test_ownership_and_grant() -> Result<(), CliError> {
-    std::env::set_var("RUST_LOG", "cosmian_kms_cli=info");
+pub(crate) async fn test_ownership_and_grant() -> CliResult<()> {
+    unsafe {
+        std::env::set_var("RUST_LOG", "cosmian_kms_cli=info");
+    }
     // the client conf will use the owner cert
     let ctx = start_default_test_kms_server_with_cert_auth().await;
     let key_id = gen_key(&ctx.owner_client_conf_path)?;
@@ -257,7 +259,7 @@ pub(crate) async fn test_ownership_and_grant() -> Result<(), CliError> {
 }
 
 #[tokio::test]
-pub(crate) async fn test_grant_error() -> Result<(), CliError> {
+pub(crate) async fn test_grant_error() -> CliResult<()> {
     let ctx = start_default_test_kms_server_with_cert_auth().await;
     let key_id = gen_key(&ctx.owner_client_conf_path)?;
 
@@ -298,7 +300,7 @@ pub(crate) async fn test_grant_error() -> Result<(), CliError> {
 }
 
 #[tokio::test]
-pub(crate) async fn test_revoke_access() -> Result<(), CliError> {
+pub(crate) async fn test_revoke_access() -> CliResult<()> {
     // the client conf will use the owner cert
     let ctx = start_default_test_kms_server_with_cert_auth().await;
     let key_id = gen_key(&ctx.owner_client_conf_path)?;
@@ -392,7 +394,7 @@ pub(crate) async fn test_revoke_access() -> Result<(), CliError> {
 }
 
 #[tokio::test]
-pub(crate) async fn test_list_access_rights() -> Result<(), CliError> {
+pub(crate) async fn test_list_access_rights() -> CliResult<()> {
     let ctx = start_default_test_kms_server_with_cert_auth().await;
     let key_id = gen_key(&ctx.owner_client_conf_path)?;
 
@@ -416,14 +418,14 @@ pub(crate) async fn test_list_access_rights() -> Result<(), CliError> {
 }
 
 #[tokio::test]
-pub(crate) async fn test_list_access_rights_error() -> Result<(), CliError> {
+pub(crate) async fn test_list_access_rights_error() -> CliResult<()> {
     let ctx = start_default_test_kms_server_with_cert_auth().await;
     assert!(list_access(&ctx.user_client_conf_path, "BAD KEY").is_err());
     Ok(())
 }
 
 #[tokio::test]
-pub(crate) async fn test_list_owned_objects() -> Result<(), CliError> {
+pub(crate) async fn test_list_owned_objects() -> CliResult<()> {
     let ctx = start_default_test_kms_server_with_cert_auth().await;
     let key_id = gen_key(&ctx.owner_client_conf_path)?;
 
@@ -460,7 +462,7 @@ pub(crate) async fn test_list_owned_objects() -> Result<(), CliError> {
 }
 
 #[tokio::test]
-pub(crate) async fn test_access_right_obtained() -> Result<(), CliError> {
+pub(crate) async fn test_access_right_obtained() -> CliResult<()> {
     let ctx = start_default_test_kms_server_with_cert_auth().await;
     let key_id = gen_key(&ctx.owner_client_conf_path)?;
 
@@ -493,7 +495,7 @@ pub(crate) async fn test_access_right_obtained() -> Result<(), CliError> {
 }
 
 #[tokio::test]
-pub(crate) async fn test_ownership_and_grant_wildcard_user() -> Result<(), CliError> {
+pub(crate) async fn test_ownership_and_grant_wildcard_user() -> CliResult<()> {
     // the client conf will use the owner cert
     let ctx = start_default_test_kms_server_with_cert_auth().await;
     let key_id = gen_key(&ctx.owner_client_conf_path)?;
@@ -603,7 +605,7 @@ pub(crate) async fn test_ownership_and_grant_wildcard_user() -> Result<(), CliEr
 }
 
 #[tokio::test]
-pub(crate) async fn test_access_right_obtained_using_wildcard() -> Result<(), CliError> {
+pub(crate) async fn test_access_right_obtained_using_wildcard() -> CliResult<()> {
     let ctx = start_default_test_kms_server_with_cert_auth().await;
     let key_id = gen_key(&ctx.owner_client_conf_path)?;
 
@@ -641,7 +643,7 @@ pub(crate) async fn test_access_right_obtained_using_wildcard() -> Result<(), Cl
 }
 
 #[tokio::test]
-pub(crate) async fn test_grant_multiple_operations() -> Result<(), CliError> {
+pub(crate) async fn test_grant_multiple_operations() -> CliResult<()> {
     let ctx = start_default_test_kms_server_with_cert_auth().await;
     let key_id = gen_key(&ctx.owner_client_conf_path)?;
 

--- a/crate/cli/src/tests/auth_tests.rs
+++ b/crate/cli/src/tests/auth_tests.rs
@@ -6,7 +6,7 @@ use kms_test_server::start_test_server_with_options;
 
 use super::utils::recover_cmd_logs;
 use crate::{
-    error::CliError,
+    error::result::CliResult,
     tests::{access::SUB_COMMAND, PROG_NAME},
 };
 
@@ -20,7 +20,7 @@ fn run_cli_command(owner_client_conf_path: &str) {
 }
 
 #[tokio::test]
-pub(crate) async fn test_all_authentications() -> Result<(), CliError> {
+pub(crate) async fn test_all_authentications() -> CliResult<()> {
     // let us not make other test cases fail
     const PORT: u16 = 9999;
     // plaintext no auth

--- a/crate/cli/src/tests/certificates/certify.rs
+++ b/crate/cli/src/tests/certificates/certify.rs
@@ -113,7 +113,7 @@ pub(crate) fn certify(cli_conf_path: &str, certify_op: CertifyOp) -> CliResult<S
     ))
 }
 
-fn import_root_and_intermediate(ctx: &TestsContext) -> Result<(String, String, String), CliError> {
+fn import_root_and_intermediate(ctx: &TestsContext) -> CliResult<(String, String, String)> {
     // import Root CA
     let root_ca_id = import_certificate(
         &ctx.owner_client_conf_path,

--- a/crate/cli/src/tests/certificates/certify.rs
+++ b/crate/cli/src/tests/certificates/certify.rs
@@ -19,7 +19,7 @@ use x509_parser::{der_parser::oid, prelude::*};
 use super::validate;
 use crate::{
     actions::certificates::{Algorithm, CertificateExportFormat, CertificateInputFormat},
-    error::CliError,
+    error::{result::CliResult, CliError},
     tests::{
         certificates::{export::export_certificate, import::import_certificate},
         rsa::create_key_pair::create_rsa_4096_bits_key_pair,
@@ -45,7 +45,7 @@ pub(crate) struct CertifyOp {
     tags: Option<Vec<String>>,
 }
 
-pub(crate) fn certify(cli_conf_path: &str, certify_op: CertifyOp) -> Result<String, CliError> {
+pub(crate) fn certify(cli_conf_path: &str, certify_op: CertifyOp) -> CliResult<String> {
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
     cmd.env(KMS_CLI_CONF_ENV, cli_conf_path);
 
@@ -119,7 +119,7 @@ fn import_root_and_intermediate(ctx: &TestsContext) -> Result<(String, String, S
         &ctx.owner_client_conf_path,
         "certificates",
         "test_data/certificates/csr/ca.crt",
-        CertificateInputFormat::Pem,
+        &CertificateInputFormat::Pem,
         None,
         Some(Uuid::new_v4().to_string()),
         None,
@@ -134,7 +134,7 @@ fn import_root_and_intermediate(ctx: &TestsContext) -> Result<(String, String, S
         &ctx.owner_client_conf_path,
         "certificates",
         "test_data/certificates/csr/intermediate.crt",
-        CertificateInputFormat::Pem,
+        &CertificateInputFormat::Pem,
         None,
         Some(Uuid::new_v4().to_string()),
         None,
@@ -150,7 +150,7 @@ fn import_root_and_intermediate(ctx: &TestsContext) -> Result<(String, String, S
         &ctx.owner_client_conf_path,
         "certificates",
         "test_data/certificates/csr/intermediate.p12",
-        CertificateInputFormat::Pkcs12,
+        &CertificateInputFormat::Pkcs12,
         Some("secret"),
         Some(Uuid::new_v4().to_string()),
         None,
@@ -396,7 +396,7 @@ fn check_public_and_private_key_linked(
 }
 
 #[tokio::test]
-async fn test_certify_a_csr_without_extensions() -> Result<(), CliError> {
+async fn test_certify_a_csr_without_extensions() -> CliResult<()> {
     // Create a test server
     let ctx = start_default_test_kms_server().await;
     // import signers
@@ -413,7 +413,7 @@ async fn test_certify_a_csr_without_extensions() -> Result<(), CliError> {
         },
     )?;
 
-    let _ = check_certificate_chain(ctx, &issuer_private_key_id, &certificate_id);
+    check_certificate_chain(ctx, &issuer_private_key_id, &certificate_id);
 
     let validation = validate::validate_certificate(
         &ctx.owner_client_conf_path,
@@ -428,7 +428,7 @@ async fn test_certify_a_csr_without_extensions() -> Result<(), CliError> {
 }
 
 #[tokio::test]
-async fn test_certify_a_csr_with_extensions() -> Result<(), CliError> {
+async fn test_certify_a_csr_with_extensions() -> CliResult<()> {
     // Create a test server
     let ctx = start_default_test_kms_server().await;
     // import signers
@@ -465,7 +465,7 @@ async fn test_certify_a_csr_with_extensions() -> Result<(), CliError> {
 }
 
 #[tokio::test]
-async fn test_certify_a_public_key_test_without_extensions() -> Result<(), CliError> {
+async fn test_certify_a_public_key_test_without_extensions() -> CliResult<()> {
     // Create a test server
     let ctx = start_default_test_kms_server().await;
 
@@ -507,7 +507,7 @@ async fn test_certify_a_public_key_test_without_extensions() -> Result<(), CliEr
 }
 
 #[tokio::test]
-async fn test_certify_a_public_key_test_with_extensions() -> Result<(), CliError> {
+async fn test_certify_a_public_key_test_with_extensions() -> CliResult<()> {
     // Create a test server
     let ctx = start_default_test_kms_server().await;
 
@@ -555,7 +555,7 @@ async fn test_certify_a_public_key_test_with_extensions() -> Result<(), CliError
 }
 
 #[tokio::test]
-async fn test_certify_renew_a_certificate() -> Result<(), CliError> {
+async fn test_certify_renew_a_certificate() -> CliResult<()> {
     // Create a test server
     let ctx = start_default_test_kms_server().await;
     // import signers
@@ -609,7 +609,7 @@ async fn test_certify_renew_a_certificate() -> Result<(), CliError> {
 }
 
 #[tokio::test]
-async fn test_certify_issue_with_subject_name() -> Result<(), CliError> {
+async fn test_certify_issue_with_subject_name() -> CliResult<()> {
     // Create a test server
     let ctx = start_default_test_kms_server().await;
     // import signers
@@ -636,7 +636,7 @@ async fn test_certify_issue_with_subject_name() -> Result<(), CliError> {
     // check links to public key
     let (public_key_id, public_key_attributes) =
         check_certificate_and_public_key_linked(ctx, &certificate_id, &attributes);
-    let _ = check_public_and_private_key_linked(ctx, &public_key_id, &public_key_attributes);
+    check_public_and_private_key_linked(ctx, &public_key_id, &public_key_attributes);
 
     let validation = validate::validate_certificate(
         &ctx.owner_client_conf_path,
@@ -650,7 +650,7 @@ async fn test_certify_issue_with_subject_name() -> Result<(), CliError> {
 }
 
 #[tokio::test]
-async fn test_certify_a_public_key_test_self_signed() -> Result<(), CliError> {
+async fn test_certify_a_public_key_test_self_signed() -> CliResult<()> {
     // Create a test server
     let ctx = start_default_test_kms_server().await;
 
@@ -687,8 +687,7 @@ async fn test_certify_a_public_key_test_self_signed() -> Result<(), CliError> {
 }
 
 #[tokio::test]
-async fn test_certify_issue_with_subject_name_self_signed_without_extensions()
--> Result<(), CliError> {
+async fn test_certify_issue_with_subject_name_self_signed_without_extensions() -> CliResult<()> {
     // Create a test server
     let ctx = start_default_test_kms_server().await;
 
@@ -723,8 +722,7 @@ async fn test_certify_issue_with_subject_name_self_signed_without_extensions()
 }
 
 #[tokio::test]
-async fn test_certify_issue_with_subject_name_self_signed_with_extensions() -> Result<(), CliError>
-{
+async fn test_certify_issue_with_subject_name_self_signed_with_extensions() -> CliResult<()> {
     // Create a test server
     let ctx = start_default_test_kms_server().await;
 

--- a/crate/cli/src/tests/certificates/encrypt.rs
+++ b/crate/cli/src/tests/certificates/encrypt.rs
@@ -13,7 +13,7 @@ use crate::{
         certificates::CertificateInputFormat,
         shared::{import_key::ImportKeyFormat, utils::KeyUsage, ExportKeyFormat},
     },
-    error::CliError,
+    error::{result::CliResult, CliError},
     tests::{
         certificates::import::import_certificate,
         shared::{export_key, import_key},
@@ -29,7 +29,7 @@ pub(crate) fn encrypt(
     certificate_id: &str,
     output_file: Option<&str>,
     authentication_data: Option<&str>,
-) -> Result<(), CliError> {
+) -> CliResult<()> {
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
     cmd.env(KMS_CLI_CONF_ENV, cli_conf_path);
 
@@ -59,7 +59,7 @@ pub(crate) fn decrypt(
     private_key_id: &str,
     output_file: Option<&str>,
     authentication_data: Option<&str>,
-) -> Result<(), CliError> {
+) -> CliResult<()> {
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
     cmd.env(KMS_CLI_CONF_ENV, cli_conf_path);
 
@@ -83,7 +83,7 @@ pub(crate) fn decrypt(
 }
 
 // #[tokio::test]
-// async fn test_certificate_encrypt_decrypt_certify() -> Result<(), CliError> {
+// async fn test_certificate_encrypt_decrypt_certify() -> CliResult<()> {
 //      let ctx = start_default_test_kms_server().await;
 //     // create a temp dir
 //     let tmp_dir = TempDir::new()?;
@@ -154,7 +154,7 @@ async fn test_certificate_import_encrypt(
     cert_path: &str,
     key_path: &str,
     tags: &[&str],
-) -> Result<(), CliError> {
+) -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
     // create a temp dir
     let tmp_dir = TempDir::new()?;
@@ -187,7 +187,7 @@ async fn test_certificate_import_encrypt(
         &ctx.owner_client_conf_path,
         "certificates",
         &format!("test_data/certificates/{ca_path}"),
-        CertificateInputFormat::Pem,
+        &CertificateInputFormat::Pem,
         None,
         None,
         None,
@@ -202,7 +202,7 @@ async fn test_certificate_import_encrypt(
         &ctx.owner_client_conf_path,
         "certificates",
         &format!("test_data/certificates/{subca_path}"),
-        CertificateInputFormat::Pem,
+        &CertificateInputFormat::Pem,
         None,
         None,
         None,
@@ -217,7 +217,7 @@ async fn test_certificate_import_encrypt(
         &ctx.owner_client_conf_path,
         "certificates",
         &format!("test_data/certificates/{cert_path}"),
-        CertificateInputFormat::Pem,
+        &CertificateInputFormat::Pem,
         None,
         None,
         Some(private_key_id.clone()),
@@ -257,7 +257,7 @@ async fn test_certificate_import_encrypt(
 
 #[tokio::test]
 #[cfg(not(feature = "fips"))]
-async fn test_certificate_import_ca_and_encrypt_using_x25519() -> Result<(), CliError> {
+async fn test_certificate_import_ca_and_encrypt_using_x25519() -> CliResult<()> {
     test_certificate_import_encrypt(
         "p12/root.pem",
         "p12/subca.pem",
@@ -268,7 +268,7 @@ async fn test_certificate_import_ca_and_encrypt_using_x25519() -> Result<(), Cli
     .await
 }
 
-async fn import_encrypt_decrypt(filename: &str) -> Result<(), CliError> {
+async fn import_encrypt_decrypt(filename: &str) -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
 
     // create a temp dir
@@ -306,7 +306,7 @@ async fn import_encrypt_decrypt(filename: &str) -> Result<(), CliError> {
         &ctx.owner_client_conf_path,
         "certificates",
         &format!("test_data/certificates/openssl/{filename}-cert.pem"),
-        CertificateInputFormat::Pem,
+        &CertificateInputFormat::Pem,
         None,
         Some(Uuid::new_v4().to_string()),
         Some(private_key_id.clone()),
@@ -408,13 +408,13 @@ async fn import_encrypt_decrypt(filename: &str) -> Result<(), CliError> {
 #[tokio::test]
 #[cfg(not(feature = "fips"))]
 // P-192 should not be used in FIPS mode. See NIST.SP.800-186 - Section 3.2.1.1.
-async fn test_certificate_encrypt_using_prime192() -> Result<(), CliError> {
+async fn test_certificate_encrypt_using_prime192() -> CliResult<()> {
     import_encrypt_decrypt("prime192v1").await
 }
 
 #[tokio::test]
 #[cfg(not(feature = "fips"))]
-async fn test_certificate_encrypt_using_prime224() -> Result<(), CliError> {
+async fn test_certificate_encrypt_using_prime224() -> CliResult<()> {
     import_encrypt_decrypt("secp224r1").await
 }
 
@@ -422,30 +422,30 @@ async fn test_certificate_encrypt_using_prime224() -> Result<(), CliError> {
 #[cfg(not(feature = "fips"))]
 // Edwards curve shall be used **for digital signature only**.
 // See NIST.SP.800-186 - Section 3.1.2 table 2 and NIST.FIPS.186-5.
-async fn test_certificate_encrypt_using_ed25519() -> Result<(), CliError> {
+async fn test_certificate_encrypt_using_ed25519() -> CliResult<()> {
     import_encrypt_decrypt("ED25519").await
 }
 
 #[tokio::test]
 #[cfg(not(feature = "fips"))]
-async fn test_certificate_encrypt_using_prime256() -> Result<(), CliError> {
+async fn test_certificate_encrypt_using_prime256() -> CliResult<()> {
     import_encrypt_decrypt("prime256v1").await
 }
 
 #[tokio::test]
 #[cfg(not(feature = "fips"))]
-async fn test_certificate_encrypt_using_secp384r1() -> Result<(), CliError> {
+async fn test_certificate_encrypt_using_secp384r1() -> CliResult<()> {
     import_encrypt_decrypt("secp384r1").await
 }
 
 #[tokio::test]
 #[cfg(not(feature = "fips"))]
-async fn test_certificate_encrypt_using_secp521r1() -> Result<(), CliError> {
+async fn test_certificate_encrypt_using_secp521r1() -> CliResult<()> {
     import_encrypt_decrypt("secp521r1").await
 }
 
 #[tokio::test]
-async fn test_certificate_encrypt_using_rsa() -> Result<(), CliError> {
+async fn test_certificate_encrypt_using_rsa() -> CliResult<()> {
     import_encrypt_decrypt("rsa-2048").await?;
     import_encrypt_decrypt("rsa-3072").await?;
     import_encrypt_decrypt("rsa-4096").await

--- a/crate/cli/src/tests/certificates/export.rs
+++ b/crate/cli/src/tests/certificates/export.rs
@@ -19,7 +19,7 @@ use crate::{
         certificates::{CertificateExportFormat, CertificateInputFormat},
         shared::ExportKeyFormat::JsonTtlv,
     },
-    error::CliError,
+    error::{result::CliResult, CliError},
     tests::{
         certificates::import::import_certificate, shared::export_key, utils::recover_cmd_logs,
         PROG_NAME,
@@ -41,7 +41,7 @@ async fn test_import_export_p12_25519() {
         &ctx.owner_client_conf_path,
         "certificates",
         "test_data/certificates/another_p12/server.p12",
-        CertificateInputFormat::Pkcs12,
+        &CertificateInputFormat::Pkcs12,
         Some("secret"),
         Some(Uuid::new_v4().to_string()),
         None,
@@ -221,7 +221,7 @@ async fn test_import_p12_rsa() {
         &ctx.owner_client_conf_path,
         "certificates",
         "test_data/certificates/csr/intermediate.p12",
-        CertificateInputFormat::Pkcs12,
+        &CertificateInputFormat::Pkcs12,
         Some("secret"),
         None,
         None,
@@ -272,7 +272,7 @@ pub(crate) fn export_certificate(
     certificate_format: Option<CertificateExportFormat>,
     pkcs_12_password: Option<String>,
     allow_revoked: bool,
-) -> Result<(), CliError> {
+) -> CliResult<()> {
     let mut args: Vec<String> = [
         "export",
         "--certificate-id",

--- a/crate/cli/src/tests/certificates/get_attributes.rs
+++ b/crate/cli/src/tests/certificates/get_attributes.rs
@@ -15,7 +15,7 @@ async fn test_get_attributes_p12() {
         &ctx.owner_client_conf_path,
         "certificates",
         "test_data/certificates/csr/intermediate.p12",
-        CertificateInputFormat::Pkcs12,
+        &CertificateInputFormat::Pkcs12,
         Some("secret"),
         Some("get_attributes_test_p12_cert".to_string()),
         None,

--- a/crate/cli/src/tests/certificates/import.rs
+++ b/crate/cli/src/tests/certificates/import.rs
@@ -5,7 +5,7 @@ use cosmian_kms_client::KMS_CLI_CONF_ENV;
 
 use crate::{
     actions::{certificates::CertificateInputFormat, shared::utils::KeyUsage},
-    error::CliError,
+    error::{result::CliResult, CliError},
     tests::{
         utils::{extract_uids::extract_unique_identifier, recover_cmd_logs},
         PROG_NAME,
@@ -17,7 +17,7 @@ pub(crate) fn import_certificate(
     cli_conf_path: &str,
     sub_command: &str,
     key_file: &str,
-    format: CertificateInputFormat,
+    format: &CertificateInputFormat,
     pkcs12_password: Option<&str>,
     certificate_id: Option<String>,
     private_key_id: Option<String>,
@@ -26,7 +26,7 @@ pub(crate) fn import_certificate(
     key_usage_vec: Option<Vec<KeyUsage>>,
     unwrap: bool,
     replace_existing: bool,
-) -> Result<String, CliError> {
+) -> CliResult<String> {
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
     cmd.env(KMS_CLI_CONF_ENV, cli_conf_path);
 
@@ -89,7 +89,7 @@ pub(crate) fn import_certificate(
 }
 
 // #[tokio::test]
-// pub async fn test_certificate_import_different_format() -> Result<(), CliError> {
+// pub async fn test_certificate_import_different_format() -> CliResult<()> {
 //     // Create a test server
 //     let ctx = start_default_test_kms_server().await;
 //     // import as TTLV JSON

--- a/crate/cli/src/tests/certificates/validate.rs
+++ b/crate/cli/src/tests/certificates/validate.rs
@@ -8,7 +8,7 @@ use tracing::{debug, info};
 
 use crate::{
     actions::certificates::CertificateInputFormat,
-    error::CliError,
+    error::{result::CliResult, CliError},
     tests::{
         certificates::{encrypt::encrypt, import::import_certificate},
         utils::recover_cmd_logs,
@@ -16,7 +16,7 @@ use crate::{
     },
 };
 
-async fn import_revoked_certificate_encrypt(curve_name: &str) -> Result<(), CliError> {
+async fn import_revoked_certificate_encrypt(curve_name: &str) -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
 
     // create a temp dir
@@ -38,7 +38,7 @@ async fn import_revoked_certificate_encrypt(curve_name: &str) -> Result<(), CliE
         &ctx.owner_client_conf_path,
         "certificates",
         &format!("test_data/certificates/openssl/{curve_name}-cert.pem"),
-        CertificateInputFormat::Pem,
+        &CertificateInputFormat::Pem,
         None,
         None,
         None,
@@ -54,7 +54,7 @@ async fn import_revoked_certificate_encrypt(curve_name: &str) -> Result<(), CliE
         &ctx.owner_client_conf_path,
         "certificates",
         &format!("test_data/certificates/openssl/{curve_name}-revoked.crt"),
-        CertificateInputFormat::Pem,
+        &CertificateInputFormat::Pem,
         None,
         None,
         None,
@@ -82,7 +82,7 @@ async fn import_revoked_certificate_encrypt(curve_name: &str) -> Result<(), CliE
 
 #[tokio::test]
 #[ignore]
-async fn test_import_revoked_certificate_encrypt_prime256() -> Result<(), CliError> {
+async fn test_import_revoked_certificate_encrypt_prime256() -> CliResult<()> {
     import_revoked_certificate_encrypt("prime256v1").await
 }
 
@@ -92,7 +92,7 @@ pub(crate) fn validate_certificate(
     certificates: Vec<String>,
     uids: Vec<String>,
     date: Option<String>,
-) -> Result<String, CliError> {
+) -> CliResult<String> {
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
     cmd.env(KMS_CLI_CONF_ENV, cli_conf_path);
     let mut args: Vec<String> = vec!["validate".to_owned()];
@@ -120,7 +120,7 @@ pub(crate) fn validate_certificate(
 }
 
 #[tokio::test]
-async fn test_validate_cli() -> Result<(), CliError> {
+async fn test_validate_cli() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
 
     info!("importing root cert");
@@ -128,7 +128,7 @@ async fn test_validate_cli() -> Result<(), CliError> {
         &ctx.owner_client_conf_path,
         "certificates",
         "test_data/certificates/chain/ca.cert.pem",
-        CertificateInputFormat::Pem,
+        &CertificateInputFormat::Pem,
         None,
         None,
         None,
@@ -144,7 +144,7 @@ async fn test_validate_cli() -> Result<(), CliError> {
         &ctx.owner_client_conf_path,
         "certificates",
         "test_data/certificates/chain/intermediate.cert.pem",
-        CertificateInputFormat::Pem,
+        &CertificateInputFormat::Pem,
         None,
         None,
         None,
@@ -159,7 +159,7 @@ async fn test_validate_cli() -> Result<(), CliError> {
         &ctx.owner_client_conf_path,
         "certificates",
         "test_data/certificates/chain/leaf1.cert.pem",
-        CertificateInputFormat::Pem,
+        &CertificateInputFormat::Pem,
         None,
         None,
         None,

--- a/crate/cli/src/tests/cover_crypt/conf.rs
+++ b/crate/cli/src/tests/cover_crypt/conf.rs
@@ -6,12 +6,12 @@ use kms_test_server::{generate_invalid_conf, start_default_test_kms_server};
 use predicates::prelude::*;
 
 use crate::{
-    error::CliError,
+    error::{result::CliResult, CliError},
     tests::{utils::recover_cmd_logs, PROG_NAME},
 };
 
 #[tokio::test]
-pub async fn test_bad_conf() -> Result<(), CliError> {
+pub async fn test_bad_conf() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
 
     let invalid_conf_path = generate_invalid_conf(&ctx.owner_client_conf);
@@ -51,7 +51,7 @@ pub async fn test_bad_conf() -> Result<(), CliError> {
 }
 
 #[tokio::test]
-pub async fn test_secrets_group_id_bad() -> Result<(), CliError> {
+pub async fn test_secrets_group_id_bad() -> CliResult<()> {
     let _ctx = start_default_test_kms_server().await;
 
     let mut cmd = Command::cargo_bin(PROG_NAME)?;

--- a/crate/cli/src/tests/cover_crypt/encrypt_decrypt.rs
+++ b/crate/cli/src/tests/cover_crypt/encrypt_decrypt.rs
@@ -6,7 +6,7 @@ use kms_test_server::start_default_test_kms_server;
 use tempfile::TempDir;
 
 use crate::{
-    error::CliError,
+    error::{result::CliResult, CliError},
     tests::{
         cover_crypt::{
             master_key_pair::create_cc_master_key_pair,
@@ -25,7 +25,7 @@ pub fn encrypt(
     access_policy: &str,
     output_file: Option<&str>,
     authentication_data: Option<&str>,
-) -> Result<(), CliError> {
+) -> CliResult<()> {
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
     cmd.env(KMS_CLI_CONF_ENV, cli_conf_path);
 
@@ -58,7 +58,7 @@ pub fn decrypt(
     private_key_id: &str,
     output_file: Option<&str>,
     authentication_data: Option<&str>,
-) -> Result<(), CliError> {
+) -> CliResult<()> {
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
     cmd.env(KMS_CLI_CONF_ENV, cli_conf_path);
 
@@ -84,7 +84,7 @@ pub fn decrypt(
 }
 
 #[tokio::test]
-async fn test_encrypt_decrypt_using_object_ids() -> Result<(), CliError> {
+async fn test_encrypt_decrypt_using_object_ids() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
     // create a temp dir
     let tmp_dir = TempDir::new()?;
@@ -157,7 +157,7 @@ async fn test_encrypt_decrypt_using_object_ids() -> Result<(), CliError> {
 }
 
 #[tokio::test]
-async fn test_encrypt_decrypt_bulk_using_object_ids() -> Result<(), CliError> {
+async fn test_encrypt_decrypt_bulk_using_object_ids() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
     // create a temp dir
     let tmp_dir = TempDir::new()?;
@@ -288,7 +288,7 @@ async fn test_encrypt_decrypt_bulk_using_object_ids() -> Result<(), CliError> {
 }
 
 #[tokio::test]
-async fn test_encrypt_decrypt_using_tags() -> Result<(), CliError> {
+async fn test_encrypt_decrypt_using_tags() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
     // create a temp dir
     let tmp_dir = TempDir::new()?;
@@ -391,7 +391,7 @@ async fn test_encrypt_decrypt_using_tags() -> Result<(), CliError> {
 }
 
 #[tokio::test]
-async fn test_encrypt_decrypt_bulk_using_tags() -> Result<(), CliError> {
+async fn test_encrypt_decrypt_bulk_using_tags() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
     // create a temp dir
     let tmp_dir = TempDir::new()?;

--- a/crate/cli/src/tests/cover_crypt/master_key_pair.rs
+++ b/crate/cli/src/tests/cover_crypt/master_key_pair.rs
@@ -6,7 +6,7 @@ use kms_test_server::start_default_test_kms_server;
 
 use super::SUB_COMMAND;
 use crate::{
-    error::CliError,
+    error::{result::CliResult, CliError},
     tests::{
         utils::{
             extract_uids::{extract_private_key, extract_public_key},
@@ -55,7 +55,7 @@ pub fn create_cc_master_key_pair(
 }
 
 #[tokio::test]
-pub async fn test_create_master_key_pair() -> Result<(), CliError> {
+pub async fn test_create_master_key_pair() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
     // from specs
     create_cc_master_key_pair(
@@ -75,7 +75,7 @@ pub async fn test_create_master_key_pair() -> Result<(), CliError> {
 }
 
 #[tokio::test]
-pub async fn test_create_master_key_pair_error() -> Result<(), CliError> {
+pub async fn test_create_master_key_pair_error() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
 
     let err = create_cc_master_key_pair(

--- a/crate/cli/src/tests/cover_crypt/master_key_pair.rs
+++ b/crate/cli/src/tests/cover_crypt/master_key_pair.rs
@@ -21,7 +21,7 @@ pub fn create_cc_master_key_pair(
     policy_option: &str,
     file: &str,
     tags: &[&str],
-) -> Result<(String, String), CliError> {
+) -> CliResult<(String, String)> {
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
     cmd.env(KMS_CLI_CONF_ENV, cli_conf_path);
 

--- a/crate/cli/src/tests/cover_crypt/policy.rs
+++ b/crate/cli/src/tests/cover_crypt/policy.rs
@@ -7,7 +7,7 @@ use predicates::prelude::*;
 use tempfile::TempDir;
 
 use crate::{
-    error::CliError,
+    error::{result::CliResult, CliError},
     tests::{
         cover_crypt::{
             encrypt_decrypt::{decrypt, encrypt},
@@ -21,7 +21,7 @@ use crate::{
 };
 
 #[tokio::test]
-async fn test_view_policy() -> Result<(), CliError> {
+async fn test_view_policy() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
     cmd.env(KMS_CLI_CONF_ENV, &ctx.owner_client_conf_path);
@@ -60,7 +60,7 @@ async fn test_view_policy() -> Result<(), CliError> {
 }
 
 #[tokio::test]
-async fn test_create_policy() -> Result<(), CliError> {
+async fn test_create_policy() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
     cmd.env(KMS_CLI_CONF_ENV, &ctx.owner_client_conf_path);
@@ -86,7 +86,7 @@ pub async fn rename(
     master_private_key_id: &str,
     attribute: &str,
     new_name: &str,
-) -> Result<(), CliError> {
+) -> CliResult<()> {
     start_default_test_kms_server().await;
 
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
@@ -114,7 +114,7 @@ pub async fn add(
     cli_conf_path: &str,
     master_private_key_id: &str,
     new_attribute: &str,
-) -> Result<(), CliError> {
+) -> CliResult<()> {
     start_default_test_kms_server().await;
 
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
@@ -141,7 +141,7 @@ pub async fn disable(
     cli_conf_path: &str,
     master_private_key_id: &str,
     attribute: &str,
-) -> Result<(), CliError> {
+) -> CliResult<()> {
     start_default_test_kms_server().await;
 
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
@@ -168,7 +168,7 @@ pub async fn remove(
     cli_conf_path: &str,
     master_private_key_id: &str,
     attribute: &str,
-) -> Result<(), CliError> {
+) -> CliResult<()> {
     start_default_test_kms_server().await;
 
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
@@ -192,7 +192,7 @@ pub async fn remove(
 }
 
 #[tokio::test]
-async fn test_edit_policy() -> Result<(), CliError> {
+async fn test_edit_policy() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
     // create a temp dir
     let tmp_dir = TempDir::new()?;

--- a/crate/cli/src/tests/cover_crypt/rekey.rs
+++ b/crate/cli/src/tests/cover_crypt/rekey.rs
@@ -7,7 +7,7 @@ use tempfile::TempDir;
 
 use crate::{
     actions::shared::utils::KeyUsage,
-    error::CliError,
+    error::{result::CliResult, CliError},
     tests::{
         cover_crypt::{
             encrypt_decrypt::{decrypt, encrypt},
@@ -26,7 +26,7 @@ pub async fn rekey(
     cli_conf_path: &str,
     master_private_key_id: &str,
     access_policy: &str,
-) -> Result<(), CliError> {
+) -> CliResult<()> {
     start_default_test_kms_server().await;
 
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
@@ -53,7 +53,7 @@ pub async fn prune(
     cli_conf_path: &str,
     master_private_key_id: &str,
     access_policy: &str,
-) -> Result<(), CliError> {
+) -> CliResult<()> {
     start_default_test_kms_server().await;
 
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
@@ -77,7 +77,7 @@ pub async fn prune(
 }
 
 #[tokio::test]
-async fn test_rekey_error() -> Result<(), CliError> {
+async fn test_rekey_error() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
 
     // generate a new master key pair
@@ -163,7 +163,7 @@ async fn test_rekey_error() -> Result<(), CliError> {
 }
 
 #[tokio::test]
-async fn test_rekey_prune() -> Result<(), CliError> {
+async fn test_rekey_prune() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
     // create a temp dir
     let tmp_dir = TempDir::new()?;

--- a/crate/cli/src/tests/cover_crypt/user_decryption_keys.rs
+++ b/crate/cli/src/tests/cover_crypt/user_decryption_keys.rs
@@ -6,7 +6,7 @@ use kms_test_server::start_default_test_kms_server;
 
 use super::SUB_COMMAND;
 use crate::{
-    error::CliError,
+    error::{result::CliResult, CliError},
     tests::{
         cover_crypt::master_key_pair::create_cc_master_key_pair,
         utils::{extract_uids::extract_user_key, recover_cmd_logs},
@@ -19,7 +19,7 @@ pub fn create_user_decryption_key(
     master_private_key_id: &str,
     access_policy: &str,
     tags: &[&str],
-) -> Result<String, CliError> {
+) -> CliResult<String> {
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
     cmd.env(KMS_CLI_CONF_ENV, cli_conf_path);
 
@@ -50,7 +50,7 @@ pub fn create_user_decryption_key(
 }
 
 #[tokio::test]
-pub async fn test_user_decryption_key() -> Result<(), CliError> {
+pub async fn test_user_decryption_key() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
 
     // generate a new master key pair
@@ -74,7 +74,7 @@ pub async fn test_user_decryption_key() -> Result<(), CliError> {
 }
 
 #[tokio::test]
-pub async fn test_user_decryption_key_error() -> Result<(), CliError> {
+pub async fn test_user_decryption_key_error() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
 
     // generate a new master key pair

--- a/crate/cli/src/tests/elliptic_curve/create_key_pair.rs
+++ b/crate/cli/src/tests/elliptic_curve/create_key_pair.rs
@@ -20,7 +20,7 @@ pub(crate) fn create_ec_key_pair(
     cli_conf_path: &str,
     curve: &str,
     tags: &[&str],
-) -> Result<(String, String), CliError> {
+) -> CliResult<(String, String)> {
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
     cmd.env(KMS_CLI_CONF_ENV, cli_conf_path);
 

--- a/crate/cli/src/tests/elliptic_curve/create_key_pair.rs
+++ b/crate/cli/src/tests/elliptic_curve/create_key_pair.rs
@@ -6,7 +6,7 @@ use kms_test_server::start_default_test_kms_server;
 
 use super::SUB_COMMAND;
 use crate::{
-    error::CliError,
+    error::{result::CliResult, CliError},
     tests::{
         utils::{
             extract_uids::{extract_private_key, extract_public_key},
@@ -54,7 +54,7 @@ pub(crate) fn create_ec_key_pair(
 }
 
 #[tokio::test]
-pub(crate) async fn test_create_key_pair() -> Result<(), CliError> {
+pub(crate) async fn test_create_key_pair() -> CliResult<()> {
     // from specs
     let ctx = start_default_test_kms_server().await;
     create_ec_key_pair(&ctx.owner_client_conf_path, "nist-p256", &["tag1", "tag2"])?;

--- a/crate/cli/src/tests/elliptic_curve/encrypt_decrypt.rs
+++ b/crate/cli/src/tests/elliptic_curve/encrypt_decrypt.rs
@@ -8,7 +8,7 @@ use tempfile::TempDir;
 
 use super::SUB_COMMAND;
 use crate::{
-    error::CliError,
+    error::{result::CliResult, CliError},
     tests::{
         elliptic_curve::create_key_pair::create_ec_key_pair, utils::recover_cmd_logs, PROG_NAME,
     },
@@ -21,7 +21,7 @@ pub fn encrypt(
     public_key_id: &str,
     output_file: Option<&str>,
     authentication_data: Option<&str>,
-) -> Result<(), CliError> {
+) -> CliResult<()> {
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
     cmd.env(KMS_CLI_CONF_ENV, cli_conf_path);
 
@@ -53,7 +53,7 @@ pub fn decrypt(
     private_key_id: &str,
     output_file: Option<&str>,
     authentication_data: Option<&str>,
-) -> Result<(), CliError> {
+) -> CliResult<()> {
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
     cmd.env(KMS_CLI_CONF_ENV, cli_conf_path);
 
@@ -77,7 +77,7 @@ pub fn decrypt(
 }
 
 #[tokio::test]
-async fn test_encrypt_decrypt_using_ids() -> Result<(), CliError> {
+async fn test_encrypt_decrypt_using_ids() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
     // create a temp dir
     let tmp_dir = TempDir::new()?;
@@ -119,7 +119,7 @@ async fn test_encrypt_decrypt_using_ids() -> Result<(), CliError> {
 }
 
 #[tokio::test]
-async fn test_encrypt_decrypt_using_tags() -> Result<(), CliError> {
+async fn test_encrypt_decrypt_using_tags() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
     // create a temp dir
     let tmp_dir = TempDir::new()?;

--- a/crate/cli/src/tests/new_database.rs
+++ b/crate/cli/src/tests/new_database.rs
@@ -9,7 +9,7 @@ use predicates::prelude::*;
 use tempfile::TempDir;
 
 use crate::{
-    error::CliError,
+    error::result::CliResult,
     tests::{
         shared::export_key, symmetric::create_key::create_symmetric_key, utils::recover_cmd_logs,
         PROG_NAME,
@@ -17,7 +17,7 @@ use crate::{
 };
 
 #[tokio::test]
-pub(crate) async fn test_new_database() -> Result<(), CliError> {
+pub(crate) async fn test_new_database() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
 
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
@@ -33,7 +33,7 @@ pub(crate) async fn test_new_database() -> Result<(), CliError> {
 }
 
 #[tokio::test]
-pub(crate) async fn test_secrets_bad() -> Result<(), CliError> {
+pub(crate) async fn test_secrets_bad() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
 
     let bad_conf_path = generate_invalid_conf(&ctx.owner_client_conf);
@@ -51,7 +51,7 @@ pub(crate) async fn test_secrets_bad() -> Result<(), CliError> {
 }
 
 #[tokio::test]
-pub(crate) async fn test_conf_does_not_exist() -> Result<(), CliError> {
+pub(crate) async fn test_conf_does_not_exist() -> CliResult<()> {
     start_default_test_kms_server().await;
 
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
@@ -64,7 +64,7 @@ pub(crate) async fn test_conf_does_not_exist() -> Result<(), CliError> {
 }
 
 #[tokio::test]
-pub(crate) async fn test_secrets_key_bad() -> Result<(), CliError> {
+pub(crate) async fn test_secrets_key_bad() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
 
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
@@ -84,7 +84,7 @@ pub(crate) async fn test_secrets_key_bad() -> Result<(), CliError> {
 }
 
 #[tokio::test]
-async fn test_multiple_databases() -> Result<(), CliError> {
+async fn test_multiple_databases() -> CliResult<()> {
     // create a temp dir
     let tmp_dir = TempDir::new()?;
     let tmp_path = tmp_dir.path();

--- a/crate/cli/src/tests/rsa/create_key_pair.rs
+++ b/crate/cli/src/tests/rsa/create_key_pair.rs
@@ -19,7 +19,7 @@ use crate::{
 pub(crate) fn create_rsa_4096_bits_key_pair(
     cli_conf_path: &str,
     tags: &[&str],
-) -> Result<(String, String), CliError> {
+) -> CliResult<(String, String)> {
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
     cmd.env(KMS_CLI_CONF_ENV, cli_conf_path);
 

--- a/crate/cli/src/tests/rsa/create_key_pair.rs
+++ b/crate/cli/src/tests/rsa/create_key_pair.rs
@@ -6,7 +6,7 @@ use kms_test_server::start_default_test_kms_server;
 
 use super::SUB_COMMAND;
 use crate::{
-    error::CliError,
+    error::{result::CliResult, CliError},
     tests::{
         utils::{
             extract_uids::{extract_private_key, extract_public_key},
@@ -51,7 +51,7 @@ pub(crate) fn create_rsa_4096_bits_key_pair(
 }
 
 #[tokio::test]
-pub(crate) async fn test_rsa_create_key_pair() -> Result<(), CliError> {
+pub(crate) async fn test_rsa_create_key_pair() -> CliResult<()> {
     // from specs
     let ctx = start_default_test_kms_server().await;
     create_rsa_4096_bits_key_pair(&ctx.owner_client_conf_path, &["tag1", "tag2"])?;

--- a/crate/cli/src/tests/rsa/encrypt_decrypt.rs
+++ b/crate/cli/src/tests/rsa/encrypt_decrypt.rs
@@ -9,7 +9,7 @@ use tempfile::TempDir;
 use super::SUB_COMMAND;
 use crate::{
     actions::rsa::{EncryptionAlgorithm, HashFn},
-    error::CliError,
+    error::{result::CliResult, CliError},
     tests::{
         rsa::create_key_pair::create_rsa_4096_bits_key_pair, utils::recover_cmd_logs, PROG_NAME,
     },
@@ -24,7 +24,7 @@ pub(crate) fn encrypt(
     hash_fn: Option<HashFn>,
     output_file: Option<&str>,
     authentication_data: Option<&str>,
-) -> Result<(), CliError> {
+) -> CliResult<()> {
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
     cmd.env(KMS_CLI_CONF_ENV, cli_conf_path);
 
@@ -65,7 +65,7 @@ pub(crate) fn decrypt(
     hash_fn: Option<HashFn>,
     output_file: Option<&str>,
     authentication_data: Option<&str>,
-) -> Result<(), CliError> {
+) -> CliResult<()> {
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
     cmd.env(KMS_CLI_CONF_ENV, cli_conf_path);
 
@@ -98,7 +98,7 @@ pub(crate) fn decrypt(
 
 #[cfg(not(feature = "fips"))]
 #[tokio::test]
-async fn test_rsa_encrypt_decrypt_using_ckm_rsa_pkcs() -> Result<(), CliError> {
+async fn test_rsa_encrypt_decrypt_using_ckm_rsa_pkcs() -> CliResult<()> {
     // to enable this, add cosmian_logger = { path = "../logger" } to dev-dependencies in Cargo.toml
     // log_init(
     //     "cosmian_kms_cli=trace,cosmian_kms_server=info,cosmian_kms_server::core::operations=trace,\
@@ -170,7 +170,7 @@ async fn test_rsa_encrypt_decrypt_using_ckm_rsa_pkcs() -> Result<(), CliError> {
 }
 
 #[tokio::test]
-async fn test_rsa_encrypt_decrypt_using_ckm_rsa_pkcs_oaep() -> Result<(), CliError> {
+async fn test_rsa_encrypt_decrypt_using_ckm_rsa_pkcs_oaep() -> CliResult<()> {
     // to enable this, add cosmian_logger = { path = "../logger" } to dev-dependencies in Cargo.toml
     // log_init(
     //     "cosmian_kms_cli=trace,cosmian_kms_server=info,cosmian_kms_server::core::operations=trace,\
@@ -256,7 +256,7 @@ async fn test_rsa_encrypt_decrypt_using_ckm_rsa_pkcs_oaep() -> Result<(), CliErr
 }
 
 #[tokio::test]
-async fn test_rsa_encrypt_decrypt_using_rsa_aes_key_wrap() -> Result<(), CliError> {
+async fn test_rsa_encrypt_decrypt_using_rsa_aes_key_wrap() -> CliResult<()> {
     // log_init(
     //     "cosmian_kms_cli=trace,cosmian_kms_server=trace,cosmian_kms_utils=trace,cosmian_kmip=trace",
     // );
@@ -336,7 +336,7 @@ async fn test_rsa_encrypt_decrypt_using_rsa_aes_key_wrap() -> Result<(), CliErro
 }
 
 #[tokio::test]
-async fn test_rsa_encrypt_decrypt_using_tags() -> Result<(), CliError> {
+async fn test_rsa_encrypt_decrypt_using_tags() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
     // create a temp dir
     let tmp_dir = TempDir::new()?;

--- a/crate/cli/src/tests/shared/destroy.rs
+++ b/crate/cli/src/tests/shared/destroy.rs
@@ -11,7 +11,7 @@ use crate::tests::cover_crypt::{
 };
 use crate::{
     cli_bail,
-    error::CliError,
+    error::{result::CliResult, CliError},
     tests::{
         elliptic_curve::create_key_pair::create_ec_key_pair,
         shared::{export::export_key, revoke::revoke},
@@ -21,11 +21,7 @@ use crate::{
     },
 };
 
-pub(crate) fn destroy(
-    cli_conf_path: &str,
-    sub_command: &str,
-    key_id: &str,
-) -> Result<(), CliError> {
+pub(crate) fn destroy(cli_conf_path: &str, sub_command: &str, key_id: &str) -> CliResult<()> {
     let args: Vec<String> = ["keys", "destroy", "--key-id", key_id]
         .iter()
         .map(std::string::ToString::to_string)
@@ -43,7 +39,7 @@ pub(crate) fn destroy(
     ))
 }
 
-fn assert_destroyed(cli_conf_path: &str, key_id: &str) -> Result<(), CliError> {
+fn assert_destroyed(cli_conf_path: &str, key_id: &str) -> CliResult<()> {
     // create a temp dir
     let tmp_dir = TempDir::new()?;
     let tmp_path = tmp_dir.path();
@@ -90,7 +86,7 @@ fn assert_destroyed(cli_conf_path: &str, key_id: &str) -> Result<(), CliError> {
 }
 
 #[tokio::test]
-async fn test_destroy_symmetric_key() -> Result<(), CliError> {
+async fn test_destroy_symmetric_key() -> CliResult<()> {
     // init the test server
     let ctx = start_default_test_kms_server().await;
 
@@ -114,7 +110,7 @@ async fn test_destroy_symmetric_key() -> Result<(), CliError> {
 }
 
 #[tokio::test]
-async fn test_destroy_ec_key() -> Result<(), CliError> {
+async fn test_destroy_ec_key() -> CliResult<()> {
     // init the test server
     let ctx = start_default_test_kms_server().await;
 
@@ -176,7 +172,7 @@ async fn test_destroy_ec_key() -> Result<(), CliError> {
 
 #[cfg(not(feature = "fips"))]
 #[tokio::test]
-async fn test_destroy_cover_crypt() -> Result<(), CliError> {
+async fn test_destroy_cover_crypt() -> CliResult<()> {
     // init the test server
     let ctx = start_default_test_kms_server().await;
 

--- a/crate/cli/src/tests/shared/export.rs
+++ b/crate/cli/src/tests/shared/export.rs
@@ -30,7 +30,7 @@ use crate::tests::cover_crypt::{
 use crate::tests::elliptic_curve::create_key_pair::create_ec_key_pair;
 use crate::{
     actions::shared::ExportKeyFormat,
-    error::CliError,
+    error::{result::CliResult, CliError},
     tests::{symmetric::create_key::create_symmetric_key, utils::recover_cmd_logs, PROG_NAME},
 };
 
@@ -44,7 +44,7 @@ pub(crate) fn export_key(
     unwrap: bool,
     wrap_key_id: Option<String>,
     allow_revoked: bool,
-) -> Result<(), CliError> {
+) -> CliResult<()> {
     let mut args: Vec<String> = ["keys", "export", "--key-id", key_id, key_file]
         .iter()
         .map(std::string::ToString::to_string)
@@ -89,7 +89,7 @@ pub(crate) fn export_key(
 }
 
 #[tokio::test]
-pub(crate) async fn test_export_sym() -> Result<(), CliError> {
+pub(crate) async fn test_export_sym() -> CliResult<()> {
     // create a temp dir
     let tmp_dir = TempDir::new()?;
     let tmp_path = tmp_dir.path();
@@ -150,7 +150,7 @@ pub(crate) async fn test_export_sym() -> Result<(), CliError> {
 }
 
 #[tokio::test]
-pub(crate) async fn test_export_sym_allow_revoked() -> Result<(), CliError> {
+pub(crate) async fn test_export_sym_allow_revoked() -> CliResult<()> {
     // create a temp dir
     let tmp_dir = TempDir::new()?;
     let tmp_path = tmp_dir.path();
@@ -176,7 +176,7 @@ pub(crate) async fn test_export_sym_allow_revoked() -> Result<(), CliError> {
 
 #[cfg(not(feature = "fips"))]
 #[tokio::test]
-pub async fn test_export_covercrypt() -> Result<(), CliError> {
+pub async fn test_export_covercrypt() -> CliResult<()> {
     // create a temp dir
     let tmp_dir = TempDir::new()?;
     let tmp_path = tmp_dir.path();
@@ -222,7 +222,7 @@ pub async fn test_export_covercrypt() -> Result<(), CliError> {
         key_id: &str,
         tmp_path: &Path,
         ctx: &TestsContext,
-    ) -> Result<(), CliError> {
+    ) -> CliResult<()> {
         // Export the key
         export_key(
             &ctx.owner_client_conf_path,
@@ -262,7 +262,7 @@ pub async fn test_export_covercrypt() -> Result<(), CliError> {
 
 #[cfg(not(feature = "fips"))]
 #[tokio::test]
-pub async fn test_export_error_cover_crypt() -> Result<(), CliError> {
+pub async fn test_export_error_cover_crypt() -> CliResult<()> {
     // create a temp dir
     let tmp_dir = TempDir::new()?;
     let tmp_path = tmp_dir.path();
@@ -310,7 +310,7 @@ pub async fn test_export_error_cover_crypt() -> Result<(), CliError> {
 
 #[cfg(not(feature = "fips"))]
 #[tokio::test]
-pub async fn test_export_x25519() -> Result<(), CliError> {
+pub async fn test_export_x25519() -> CliResult<()> {
     // create a temp dir
     let tmp_dir = TempDir::new()?;
     let tmp_path = tmp_dir.path();

--- a/crate/cli/src/tests/shared/get_attributes.rs
+++ b/crate/cli/src/tests/shared/get_attributes.rs
@@ -6,7 +6,10 @@ use serde_json::Value;
 
 use crate::{
     actions::shared::AttributeTag,
-    error::{result::CliResultHelper, CliError},
+    error::{
+        result::{CliResult, CliResultHelper},
+        CliError,
+    },
     tests::{utils::recover_cmd_logs, PROG_NAME},
 };
 
@@ -14,7 +17,7 @@ pub(crate) fn get_attributes(
     cli_conf_path: &str,
     uid: &str,
     attribute_tags: &[AttributeTag],
-) -> Result<HashMap<AttributeTag, Value>, CliError> {
+) -> CliResult<HashMap<AttributeTag, Value>> {
     let temp_file = tempfile::NamedTempFile::new()?;
     let mut args: Vec<String> = [
         "--id",

--- a/crate/cli/src/tests/shared/import.rs
+++ b/crate/cli/src/tests/shared/import.rs
@@ -16,7 +16,7 @@ use crate::tests::{
 };
 use crate::{
     actions::shared::{import_key::ImportKeyFormat, utils::KeyUsage},
-    error::CliError,
+    error::{result::CliResult, CliError},
     tests::{
         shared::export::export_key,
         utils::{extract_uids::extract_unique_identifier, recover_cmd_logs},
@@ -35,7 +35,7 @@ pub(crate) fn import_key(
     key_usage_vec: Option<Vec<KeyUsage>>,
     unwrap: bool,
     replace_existing: bool,
-) -> Result<String, CliError> {
+) -> CliResult<String> {
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
     cmd.env(KMS_CLI_CONF_ENV, cli_conf_path);
 
@@ -90,7 +90,7 @@ pub(crate) fn import_key(
 
 #[cfg(not(feature = "fips"))]
 #[tokio::test]
-pub async fn test_import_cover_crypt() -> Result<(), CliError> {
+pub async fn test_import_cover_crypt() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
 
     let uid: String = import_key(
@@ -141,7 +141,7 @@ pub async fn test_import_cover_crypt() -> Result<(), CliError> {
 
 #[cfg(not(feature = "fips"))]
 #[tokio::test]
-pub async fn test_generate_export_import() -> Result<(), CliError> {
+pub async fn test_generate_export_import() -> CliResult<()> {
     cosmian_logger::log_utils::log_init(Some("cosmian_kms_server=debug,cosmian_kms_utils=debug"));
     let ctx = start_default_test_kms_server().await;
 
@@ -187,7 +187,7 @@ pub(crate) fn export_import_test(
     sub_command: &str,
     private_key_id: &str,
     algorithm: CryptographicAlgorithm,
-) -> Result<(), CliError> {
+) -> CliResult<()> {
     // Export
     export_key(
         cli_conf_path,

--- a/crate/cli/src/tests/shared/import_export_encodings.rs
+++ b/crate/cli/src/tests/shared/import_export_encodings.rs
@@ -5,12 +5,12 @@ use kms_test_server::{start_default_test_kms_server, TestsContext};
 
 use crate::{
     actions::shared::{import_key::ImportKeyFormat, ExportKeyFormat},
-    error::CliError,
+    error::result::CliResult,
     tests::shared::{export_key, import_key},
 };
 
 #[tokio::test]
-async fn test_import_export_encodings() -> Result<(), CliError> {
+async fn test_import_export_encodings() -> CliResult<()> {
     // init the test server
     let ctx = start_default_test_kms_server().await;
 
@@ -57,7 +57,7 @@ fn test_pems(
     ctx: &TestsContext,
     key_file_path: &str,
     export_format: ExportKeyFormat,
-) -> Result<(), CliError> {
+) -> CliResult<()> {
     // import the  key
     let key_uid = import_key(
         &ctx.owner_client_conf_path,

--- a/crate/cli/src/tests/shared/import_export_wrapping.rs
+++ b/crate/cli/src/tests/shared/import_export_wrapping.rs
@@ -23,7 +23,7 @@ use tracing::debug;
 
 use crate::{
     actions::shared::utils::KeyUsage,
-    error::CliError,
+    error::{result::CliResult, CliError},
     tests::{
         cover_crypt::master_key_pair::create_cc_master_key_pair,
         elliptic_curve,
@@ -33,7 +33,7 @@ use crate::{
 };
 
 #[tokio::test]
-pub async fn test_import_export_wrap_rfc_5649() -> Result<(), CliError> {
+pub async fn test_import_export_wrap_rfc_5649() -> CliResult<()> {
     // create a temp dir
     let tmp_dir = TempDir::new()?;
     let tmp_path = tmp_dir.path();
@@ -111,7 +111,7 @@ pub async fn test_import_export_wrap_rfc_5649() -> Result<(), CliError> {
 
 #[cfg(not(feature = "fips"))]
 #[tokio::test]
-pub async fn test_import_export_wrap_ecies() -> Result<(), CliError> {
+pub async fn test_import_export_wrap_ecies() -> CliResult<()> {
     cosmian_logger::log_utils::log_init(Some("debug"));
     // create a temp dir
     let tmp_dir = TempDir::new()?;
@@ -210,7 +210,7 @@ fn test_import_export_wrap_private_key(
     private_key_id: &str,
     wrapping_key_uid: &str,
     unwrapping_key: &Object,
-) -> Result<(), CliError> {
+) -> CliResult<()> {
     // create a temp dir
     let tmp_dir = TempDir::new()?;
     let tmp_path = tmp_dir.path();

--- a/crate/cli/src/tests/shared/locate.rs
+++ b/crate/cli/src/tests/shared/locate.rs
@@ -26,7 +26,7 @@ pub(crate) fn locate(
     algorithm: Option<&str>,
     cryptographic_length: Option<usize>,
     key_format_type: Option<&str>,
-) -> Result<Vec<String>, CliError> {
+) -> CliResult<Vec<String>> {
     let mut args: Vec<String> = vec![];
     if let Some(tags) = tags {
         for tag in tags {

--- a/crate/cli/src/tests/shared/locate.rs
+++ b/crate/cli/src/tests/shared/locate.rs
@@ -13,7 +13,7 @@ use crate::tests::{
     },
 };
 use crate::{
-    error::CliError,
+    error::{result::CliResult, CliError},
     tests::{
         elliptic_curve::create_key_pair::create_ec_key_pair,
         symmetric::create_key::create_symmetric_key, utils::recover_cmd_logs, PROG_NAME,
@@ -67,8 +67,10 @@ pub(crate) fn locate(
 
 #[cfg(not(feature = "fips"))]
 #[tokio::test]
-pub async fn test_locate_cover_crypt() -> Result<(), CliError> {
-    std::env::set_var("RUST_LOG", "cosmian_kms_cli=info");
+pub async fn test_locate_cover_crypt() -> CliResult<()> {
+    unsafe {
+        std::env::set_var("RUST_LOG", "cosmian_kms_cli=info");
+    }
     // init the test server
     let ctx = start_default_test_kms_server_with_cert_auth().await;
 
@@ -213,7 +215,7 @@ pub async fn test_locate_cover_crypt() -> Result<(), CliError> {
 }
 
 #[tokio::test]
-pub(crate) async fn test_locate_elliptic_curve() -> Result<(), CliError> {
+pub(crate) async fn test_locate_elliptic_curve() -> CliResult<()> {
     // init the test server
     let ctx = start_default_test_kms_server_with_cert_auth().await;
 
@@ -301,7 +303,7 @@ pub(crate) async fn test_locate_elliptic_curve() -> Result<(), CliError> {
 }
 
 #[tokio::test]
-pub(crate) async fn test_locate_symmetric_key() -> Result<(), CliError> {
+pub(crate) async fn test_locate_symmetric_key() -> CliResult<()> {
     // init the test server
     let ctx = start_default_test_kms_server_with_cert_auth().await;
 
@@ -370,7 +372,7 @@ pub(crate) async fn test_locate_symmetric_key() -> Result<(), CliError> {
 
 #[cfg(not(feature = "fips"))]
 #[tokio::test]
-pub async fn test_locate_grant() -> Result<(), CliError> {
+pub async fn test_locate_grant() -> CliResult<()> {
     // init the test server
     let ctx = start_default_test_kms_server_with_cert_auth().await;
 

--- a/crate/cli/src/tests/shared/revoke.rs
+++ b/crate/cli/src/tests/shared/revoke.rs
@@ -10,7 +10,7 @@ use crate::tests::cover_crypt::{
     master_key_pair::create_cc_master_key_pair, user_decryption_keys::create_user_decryption_key,
 };
 use crate::{
-    error::CliError,
+    error::{result::CliResult, CliError},
     tests::{
         elliptic_curve::create_key_pair::create_ec_key_pair, shared::export::export_key,
         symmetric::create_key::create_symmetric_key, utils::recover_cmd_logs, PROG_NAME,
@@ -22,7 +22,7 @@ pub(crate) fn revoke(
     sub_command: &str,
     key_id: &str,
     revocation_reason: &str,
-) -> Result<(), CliError> {
+) -> CliResult<()> {
     let args: Vec<String> = ["keys", "revoke", "--key-id", key_id, revocation_reason]
         .iter()
         .map(std::string::ToString::to_string)
@@ -40,7 +40,7 @@ pub(crate) fn revoke(
     ))
 }
 
-fn assert_revoker(cli_conf_path: &str, key_id: &str) -> Result<(), CliError> {
+fn assert_revoker(cli_conf_path: &str, key_id: &str) -> CliResult<()> {
     // create a temp dir
     let tmp_dir = TempDir::new()?;
     let tmp_path = tmp_dir.path();
@@ -78,7 +78,7 @@ fn assert_revoker(cli_conf_path: &str, key_id: &str) -> Result<(), CliError> {
 }
 
 #[tokio::test]
-async fn test_revoke_symmetric_key() -> Result<(), CliError> {
+async fn test_revoke_symmetric_key() -> CliResult<()> {
     // init the test server
     let ctx = start_default_test_kms_server().await;
 
@@ -98,7 +98,7 @@ async fn test_revoke_symmetric_key() -> Result<(), CliError> {
 }
 
 #[tokio::test]
-async fn test_revoke_ec_key() -> Result<(), CliError> {
+async fn test_revoke_ec_key() -> CliResult<()> {
     // init the test server
     let ctx = start_default_test_kms_server().await;
 
@@ -145,7 +145,7 @@ async fn test_revoke_ec_key() -> Result<(), CliError> {
 
 #[cfg(not(feature = "fips"))]
 #[tokio::test]
-async fn test_revoke_cover_crypt() -> Result<(), CliError> {
+async fn test_revoke_cover_crypt() -> CliResult<()> {
     // init the test server
     let ctx = start_default_test_kms_server().await;
 

--- a/crate/cli/src/tests/shared/wrap_unwrap.rs
+++ b/crate/cli/src/tests/shared/wrap_unwrap.rs
@@ -18,7 +18,7 @@ use kms_test_server::{start_default_test_kms_server, TestsContext};
 use tempfile::TempDir;
 
 use crate::{
-    error::CliError,
+    error::{result::CliResult, CliError},
     tests::{
         cover_crypt::master_key_pair::create_cc_master_key_pair,
         elliptic_curve::create_key_pair::create_ec_key_pair,
@@ -39,7 +39,7 @@ pub fn wrap(
     wrap_key_b64: Option<String>,
     wrap_key_id: Option<String>,
     wrap_key_file: Option<PathBuf>,
-) -> Result<String, CliError> {
+) -> CliResult<String> {
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
     cmd.env(KMS_CLI_CONF_ENV, cli_conf_path);
 
@@ -92,7 +92,7 @@ pub fn unwrap(
     unwrap_key_b64: Option<String>,
     unwrap_key_id: Option<String>,
     unwrap_key_file: Option<PathBuf>,
-) -> Result<(), CliError> {
+) -> CliResult<()> {
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
     cmd.env(KMS_CLI_CONF_ENV, cli_conf_path);
 
@@ -130,7 +130,7 @@ pub fn unwrap(
 }
 
 #[tokio::test]
-pub async fn test_password_wrap_import() -> Result<(), CliError> {
+pub async fn test_password_wrap_import() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
 
     // CC
@@ -158,7 +158,7 @@ pub fn password_wrap_import_test(
     ctx: &TestsContext,
     sub_command: &str,
     private_key_id: &str,
-) -> Result<(), CliError> {
+) -> CliResult<()> {
     let temp_dir = TempDir::new()?;
 
     // Export

--- a/crate/cli/src/tests/symmetric/create_key.rs
+++ b/crate/cli/src/tests/symmetric/create_key.rs
@@ -11,7 +11,7 @@ use kms_test_server::start_default_test_kms_server;
 
 use super::SUB_COMMAND;
 use crate::{
-    error::CliError,
+    error::{result::CliResult, CliError},
     tests::{
         utils::{extract_uids::extract_uid, recover_cmd_logs},
         PROG_NAME,
@@ -25,7 +25,7 @@ pub(crate) fn create_symmetric_key(
     wrap_key_b64: Option<&str>,
     algorithm: Option<&str>,
     tags: &[&str],
-) -> Result<String, CliError> {
+) -> CliResult<String> {
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
     cmd.env(KMS_CLI_CONF_ENV, cli_conf_path);
 
@@ -63,7 +63,7 @@ pub(crate) fn create_symmetric_key(
 }
 
 #[tokio::test]
-pub(crate) async fn test_create_symmetric_key() -> Result<(), CliError> {
+pub(crate) async fn test_create_symmetric_key() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
     let mut rng = CsRng::from_entropy();
     let mut key = vec![0u8; 32];

--- a/crate/cli/src/tests/symmetric/encrypt_decrypt.rs
+++ b/crate/cli/src/tests/symmetric/encrypt_decrypt.rs
@@ -7,7 +7,7 @@ use tempfile::TempDir;
 
 use super::SUB_COMMAND;
 use crate::{
-    error::CliError,
+    error::{result::CliResult, CliError},
     tests::{symmetric::create_key::create_symmetric_key, utils::recover_cmd_logs, PROG_NAME},
 };
 
@@ -18,7 +18,7 @@ pub(crate) fn encrypt(
     symmetric_key_id: &str,
     output_file: Option<&str>,
     authentication_data: Option<&str>,
-) -> Result<(), CliError> {
+) -> CliResult<()> {
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
     cmd.env(KMS_CLI_CONF_ENV, cli_conf_path);
 
@@ -48,7 +48,7 @@ pub(crate) fn decrypt(
     symmetric_key_id: &str,
     output_file: Option<&str>,
     authentication_data: Option<&str>,
-) -> Result<(), CliError> {
+) -> CliResult<()> {
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
     cmd.env(KMS_CLI_CONF_ENV, cli_conf_path);
 
@@ -72,13 +72,13 @@ pub(crate) fn decrypt(
 }
 
 #[tokio::test]
-async fn test_encrypt_decrypt_with_ids() -> Result<(), CliError> {
+async fn test_encrypt_decrypt_with_ids() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
     let key_id = create_symmetric_key(&ctx.owner_client_conf_path, None, None, None, &[])?;
     run_encrypt_decrypt_test(&ctx.owner_client_conf_path, &key_id)
 }
 
-pub(crate) fn run_encrypt_decrypt_test(cli_conf_path: &str, key_id: &str) -> Result<(), CliError> {
+pub(crate) fn run_encrypt_decrypt_test(cli_conf_path: &str, key_id: &str) -> CliResult<()> {
     // create a temp dir
     let tmp_dir = TempDir::new()?;
     let tmp_path = tmp_dir.path();
@@ -132,7 +132,7 @@ pub(crate) fn run_encrypt_decrypt_test(cli_conf_path: &str, key_id: &str) -> Res
 }
 
 #[tokio::test]
-async fn test_encrypt_decrypt_with_tags() -> Result<(), CliError> {
+async fn test_encrypt_decrypt_with_tags() -> CliResult<()> {
     // create a temp dir
     let tmp_dir = TempDir::new()?;
     let tmp_path = tmp_dir.path();

--- a/crate/server/src/config/command_line/clap_config.rs
+++ b/crate/server/src/config/command_line/clap_config.rs
@@ -91,6 +91,6 @@ impl fmt::Debug for ClapConfig {
             "Microsoft Double Key Encryption URL",
             &self.ms_dke_service_url,
         );
-        x.finish()
+        x.finish_non_exhaustive()
     }
 }

--- a/crate/server/src/core/kms.rs
+++ b/crate/server/src/core/kms.rs
@@ -663,7 +663,7 @@ impl KMS {
     /// The user is encoded in the JWT `Authorization` header
     /// If the header is not present, the user is extracted from the client certificate
     /// If the client certificate is not present, the user is extracted from the configuration file
-    pub fn get_user(&self, req_http: HttpRequest) -> KResult<String> {
+    pub fn get_user(&self, req_http: &HttpRequest) -> KResult<String> {
         let default_username = self.params.default_username.clone();
 
         if self.params.force_default_username {

--- a/crate/server/src/database/cached_sqlite_struct.rs
+++ b/crate/server/src/database/cached_sqlite_struct.rs
@@ -59,7 +59,7 @@ impl fmt::Debug for KMSSqliteCacheItem {
             .field("closed", &self.closed)
             .field("closed_at", &self.closed_at)
             .field("freeable_cache_index", &self.freeable_cache_index)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/crate/server/src/database/redis/objects_db.rs
+++ b/crate/server/src/database/redis/objects_db.rs
@@ -105,10 +105,10 @@ pub(crate) struct ObjectsDB {
 }
 
 impl ObjectsDB {
-    pub(crate) fn new(mgr: ConnectionManager, db_key: SymmetricKey<DB_KEY_LENGTH>) -> Self {
+    pub(crate) fn new(mgr: ConnectionManager, db_key: &SymmetricKey<DB_KEY_LENGTH>) -> Self {
         Self {
             mgr,
-            dem: Aes256Gcm::new(&db_key),
+            dem: Aes256Gcm::new(db_key),
             rng: Mutex::new(CsRng::from_entropy()),
         }
     }

--- a/crate/server/src/database/redis/redis_with_findex.rs
+++ b/crate/server/src/database/redis/redis_with_findex.rs
@@ -80,7 +80,7 @@ impl RedisWithFindex {
 
         let client = redis::Client::open(redis_url)?;
         let mgr = ConnectionManager::new(client).await?;
-        let objects_db = Arc::new(ObjectsDB::new(mgr.clone(), db_key));
+        let objects_db = Arc::new(ObjectsDB::new(mgr.clone(), &db_key));
         let findex =
             Arc::new(FindexRedis::connect_with_manager(mgr.clone(), objects_db.clone()).await?);
         let permissions_db = PermissionsDB::new(findex.clone(), label);

--- a/crate/server/src/database/tests/additional_redis_findex_tests.rs
+++ b/crate/server/src/database/tests/additional_redis_findex_tests.rs
@@ -54,7 +54,7 @@ pub(crate) async fn test_objects_db() -> KResult<()> {
     let mgr = ConnectionManager::new(client).await?;
 
     let db_key = SymmetricKey::new(&mut rng);
-    let o_db = ObjectsDB::new(mgr.clone(), db_key);
+    let o_db = ObjectsDB::new(mgr.clone(), &db_key);
 
     // single upsert - get - delete
     let uid = "test_objects_db";

--- a/crate/server/src/database/tests/tagging_tests.rs
+++ b/crate/server/src/database/tests/tagging_tests.rs
@@ -23,6 +23,9 @@ use crate::{
     result::KResult,
 };
 
+const USER_GET: &str = "user_get";
+const USER_DECRYPT: &str = "user_decrypt";
+
 pub(crate) async fn tags<DB: Database>(
     db_and_params: &(DB, Option<ExtraDatabaseParams>),
     verify_attributes: bool,
@@ -183,7 +186,6 @@ pub(crate) async fn tags<DB: Database>(
     assert_eq!(res.len(), 0);
 
     // grant the Get access right to USER_GET
-    const USER_GET: &str = "user_get";
     db.grant_access(
         &uid,
         USER_GET,
@@ -193,7 +195,6 @@ pub(crate) async fn tags<DB: Database>(
     .await?;
 
     // grant the Decrypt access right to USER_DECRYPT
-    const USER_DECRYPT: &str = "user_decrypt";
     db.grant_access(
         &uid,
         USER_DECRYPT,

--- a/crate/server/src/kms_server.rs
+++ b/crate/server/src/kms_server.rs
@@ -239,7 +239,7 @@ pub async fn prepare_kms_server(
                 "When using Google client-side encryption, an identity provider used to \
                  authenticate Google Workspace users must be configured.",
             )?,
-            authorization: google_cse::jwt_authorization_config(jwks_manager),
+            authorization: google_cse::jwt_authorization_config(&jwks_manager),
             kacls_url: kms_server.params.google_cse_kacls_url.clone().context(
                 "The Google Workspace Client Side Encryption KACLS URL must be provided",
             )?,

--- a/crate/server/src/lib.rs
+++ b/crate/server/src/lib.rs
@@ -2,6 +2,34 @@
 //! since it is declared, all the modules in other Files
 //! will be resolved against the lib. So everything is exported
 
+#![deny(
+    nonstandard_style,
+    refining_impl_trait,
+    future_incompatible,
+    keyword_idents,
+    let_underscore,
+    rust_2024_compatibility,
+    clippy::all,
+    clippy::suspicious,
+    clippy::complexity,
+    clippy::perf,
+    clippy::style,
+    clippy::pedantic,
+    clippy::cargo
+)]
+#![allow(
+    clippy::module_name_repetitions,
+    clippy::similar_names,
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::too_many_lines,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_truncation,
+    clippy::cargo_common_metadata,
+    clippy::multiple_crate_versions
+)]
+
 pub mod config;
 pub mod core;
 pub mod database;

--- a/crate/server/src/routes/access.rs
+++ b/crate/server/src/routes/access.rs
@@ -24,7 +24,7 @@ pub(crate) async fn list_owned_objects(
     let _enter = span.enter();
 
     let database_params = kms.get_sqlite_enc_secrets(&req)?;
-    let user = kms.get_user(req)?;
+    let user = kms.get_user(&req)?;
     info!(user = user, "GET /access/owned {user}");
 
     let list = kms
@@ -45,7 +45,7 @@ pub(crate) async fn list_access_rights_obtained(
     let _enter = span.enter();
 
     let database_params = kms.get_sqlite_enc_secrets(&req)?;
-    let user = kms.get_user(req)?;
+    let user = kms.get_user(&req)?;
     info!(user = user, "GET /access/granted {user}");
 
     let list = kms
@@ -67,7 +67,7 @@ pub(crate) async fn list_accesses(
 
     let object_id = UniqueIdentifier::TextString(object_id.to_owned().0);
     let database_params = kms.get_sqlite_enc_secrets(&req)?;
-    let user = kms.get_user(req)?;
+    let user = kms.get_user(&req)?;
     info!(user = user, "GET /accesses/{object_id} {user}");
 
     let list = kms
@@ -89,7 +89,7 @@ pub(crate) async fn grant_access(
 
     let access = access.into_inner();
     let database_params = kms.get_sqlite_enc_secrets(&req)?;
-    let user = kms.get_user(req)?;
+    let user = kms.get_user(&req)?;
     info!(
         user = user,
         access = access.to_string(),
@@ -120,7 +120,7 @@ pub(crate) async fn revoke_access(
 
     let access = access.into_inner();
     let database_params = kms.get_sqlite_enc_secrets(&req)?;
-    let user = kms.get_user(req)?;
+    let user = kms.get_user(&req)?;
     info!(
         user = user,
         access = access.to_string(),

--- a/crate/server/src/routes/google_cse/jwt.rs
+++ b/crate/server/src/routes/google_cse/jwt.rs
@@ -59,7 +59,9 @@ fn jwt_authorization_config_application(
 }
 
 /// Fetch the JWT authorization configuration for Google CSE 'drive' and 'meet'
-pub fn jwt_authorization_config(jwks_manager: Arc<JwksManager>) -> HashMap<String, Arc<JwtConfig>> {
+pub fn jwt_authorization_config(
+    jwks_manager: &Arc<JwksManager>,
+) -> HashMap<String, Arc<JwtConfig>> {
     APPLICATIONS
         .iter()
         .map(|app| {
@@ -311,7 +313,7 @@ mod tests {
             std::env::set_var("KMS_GOOGLE_CSE_DRIVE_JWKS_URI", JWKS_URI);
             std::env::set_var("KMS_GOOGLE_CSE_DRIVE_JWT_ISSUER", JWT_ISSUER_URI); // the token has been issued by Google Accounts (post request)
         }
-        let jwt_authorization_config = jwt_authorization_config(jwks_manager);
+        let jwt_authorization_config = jwt_authorization_config(&jwks_manager);
         tracing::trace!("{jwt_authorization_config:#?}");
 
         let (authorization_token, jwt_headers) = decode_jwt_authorization_token(

--- a/crate/server/src/routes/google_cse/mod.rs
+++ b/crate/server/src/routes/google_cse/mod.rs
@@ -26,7 +26,7 @@ struct CseErrorReply {
 }
 
 impl CseErrorReply {
-    fn from(e: KmsError) -> Self {
+    fn from(e: &KmsError) -> Self {
         Self {
             code: e.status_code().as_u16(),
             message: "A CSE request to the Cosmian KMS failed".to_string(),
@@ -56,7 +56,7 @@ pub(crate) async fn get_status(
     req: HttpRequest,
     kms: Data<Arc<KMSServer>>,
 ) -> KResult<Json<operations::StatusResponse>> {
-    info!("GET /google_cse/status {}", kms.get_user(req)?);
+    info!("GET /google_cse/status {}", kms.get_user(&req)?);
     Ok(Json(operations::get_status()))
 }
 
@@ -194,7 +194,7 @@ pub(crate) async fn wrap(
         .map(Json)
     {
         Ok(wrap_response) => HttpResponse::Ok().json(wrap_response),
-        Err(e) => CseErrorReply::from(e).into(),
+        Err(e) => CseErrorReply::from(&e).into(),
     }
 }
 
@@ -222,7 +222,7 @@ pub(crate) async fn unwrap(
         .map(Json)
     {
         Ok(wrap_response) => HttpResponse::Ok().json(wrap_response),
-        Err(e) => CseErrorReply::from(e).into(),
+        Err(e) => CseErrorReply::from(&e).into(),
     }
 }
 
@@ -249,7 +249,7 @@ pub(crate) async fn private_key_sign(
         .map(Json)
     {
         Ok(response) => HttpResponse::Ok().json(response),
-        Err(e) => CseErrorReply::from(e).into(),
+        Err(e) => CseErrorReply::from(&e).into(),
     }
 }
 
@@ -276,6 +276,6 @@ pub(crate) async fn private_key_decrypt(
         .map(Json)
     {
         Ok(response) => HttpResponse::Ok().json(response),
-        Err(e) => CseErrorReply::from(e).into(),
+        Err(e) => CseErrorReply::from(&e).into(),
     }
 }

--- a/crate/server/src/routes/kmip.rs
+++ b/crate/server/src/routes/kmip.rs
@@ -30,7 +30,7 @@ pub(crate) async fn kmip(
     let ttlv = serde_json::from_str::<TTLV>(&body)?;
 
     let database_params = kms.get_sqlite_enc_secrets(&req_http)?;
-    let user = kms.get_user(req_http)?;
+    let user = kms.get_user(&req_http)?;
     info!(target: "kmip", user=user, tag=ttlv.tag.as_str(), "POST /kmip. Request: {:?} {}", ttlv.tag.as_str(), user);
 
     let ttlv = handle_ttlv(&kms, &ttlv, &user, database_params.as_ref()).await?;

--- a/crate/server/src/routes/mod.rs
+++ b/crate/server/src/routes/mod.rs
@@ -66,7 +66,7 @@ pub(crate) async fn add_new_database(
     req: HttpRequest,
     kms: Data<Arc<KMSServer>>,
 ) -> KResult<Json<String>> {
-    info!("GET /new_database {}", kms.get_user(req)?);
+    info!("GET /new_database {}", kms.get_user(&req)?);
     Ok(Json(kms.add_new_database().await?))
 }
 
@@ -76,6 +76,6 @@ pub(crate) async fn get_version(
     req: HttpRequest,
     kms: Data<Arc<KMSServer>>,
 ) -> KResult<Json<String>> {
-    info!("GET /version {}", kms.get_user(req)?);
+    info!("GET /version {}", kms.get_user(&req)?);
     Ok(Json(crate_version!().to_string()))
 }

--- a/crate/server/src/routes/ms_dke/mod.rs
+++ b/crate/server/src/routes/ms_dke/mod.rs
@@ -89,7 +89,7 @@ pub(crate) async fn version(
     req_http: HttpRequest,
     kms: Data<Arc<KMSServer>>,
 ) -> KResult<Json<String>> {
-    info!("GET /version {}", kms.get_user(req_http)?);
+    info!("GET /version {}", kms.get_user(&req_http)?);
     Ok(Json(crate_version!().to_string()))
 }
 
@@ -118,7 +118,7 @@ pub(crate) async fn get_key(
 
 async fn _get_key(key_tag: &str, req_http: HttpRequest, kms: &Arc<KMSServer>) -> KResult<KeyData> {
     let database_params = kms.get_sqlite_enc_secrets(&req_http)?;
-    let user = kms.get_user(req_http)?;
+    let user = kms.get_user(&req_http)?;
     let dke_service_url = kms
         .params
         .ms_dke_service_url
@@ -225,7 +225,7 @@ async fn _decrypt(
     kms: &Arc<KMSServer>,
 ) -> KResult<DecryptedData> {
     let database_params = kms.get_sqlite_enc_secrets(&req_http)?;
-    let user = kms.get_user(req_http)?;
+    let user = kms.get_user(&req_http)?;
     let decrypt_request = Decrypt {
         unique_identifier: Some(UniqueIdentifier::TextString(
             serde_json::to_string(&vec![key_tag, "_sk"]).map_err(|e| kms_error!(e))?,

--- a/crate/server/src/tests/google_cse/utils.rs
+++ b/crate/server/src/tests/google_cse/utils.rs
@@ -64,7 +64,7 @@ pub(crate) async fn google_cse_auth() -> KResult<GoogleCseConfig> {
 
     Ok(GoogleCseConfig {
         authentication: vec![jwt_config].into(),
-        authorization: google_cse::jwt_authorization_config(jwks_manager),
+        authorization: google_cse::jwt_authorization_config(&jwks_manager),
         kacls_url: "http://0.0.0.0:9998/google_cse".to_string(),
     })
 }

--- a/crate/server/src/tests/ms_dke/mod.rs
+++ b/crate/server/src/tests/ms_dke/mod.rs
@@ -4,8 +4,8 @@ use cosmian_kmip::kmip::{
     kmip_objects::{Object, ObjectType},
     kmip_operations::{Decrypt, DecryptResponse, Import, ImportResponse},
     kmip_types::{
-        CryptographicAlgorithm, CryptographicParameters, HashingAlgorithm, KeyFormatType,
-        PaddingMethod, UniqueIdentifier,
+        Attributes, CryptographicAlgorithm, CryptographicParameters, HashingAlgorithm,
+        KeyFormatType, PaddingMethod, UniqueIdentifier,
     },
 };
 
@@ -62,7 +62,7 @@ async fn decrypt_data_test() -> KResult<()> {
         object_type: ObjectType::PrivateKey,
         replace_existing: Some(true),
         key_wrap_type: None,
-        attributes: Default::default(),
+        attributes: Attributes::default(),
         object: Object::PublicKey {
             key_block: KeyBlock {
                 key_format_type: KeyFormatType::PKCS8,

--- a/crate/test_server/src/test_server.rs
+++ b/crate/test_server/src/test_server.rs
@@ -178,7 +178,7 @@ fn generate_server_params(
         db: DBConfig {
             database_type: Some("sqlite-enc".to_string()),
             clear_database: true,
-            ..Default::default()
+            ..DBConfig::default()
         },
         http: if use_https {
             if use_client_cert {
@@ -189,7 +189,7 @@ fn generate_server_params(
                     ),
                     https_p12_password: Some("password".to_string()),
                     authority_cert_file: Some(root_dir.join("certificates/server/ca.crt")),
-                    ..Default::default()
+                    ..HttpConfig::default()
                 }
             } else {
                 HttpConfig {
@@ -198,16 +198,16 @@ fn generate_server_params(
                         root_dir.join("certificates/server/kmserver.acme.com.p12"),
                     ),
                     https_p12_password: Some("password".to_string()),
-                    ..Default::default()
+                    ..HttpConfig::default()
                 }
             }
         } else {
             HttpConfig {
                 port,
-                ..Default::default()
+                ..HttpConfig::default()
             }
         },
-        ..Default::default()
+        ..ClapConfig::default()
     };
     ServerParams::try_from(clap_config)
         .map_err(|e| ClientError::Default(format!("failed initializing the server config: {e}")))


### PR DESCRIPTION
add by default, on `ckms` and `cosmian_kms_server` this clippy config:
```
#![deny(
    nonstandard_style,
    refining_impl_trait,
    future_incompatible,
    keyword_idents,
  
  let_underscore,
    rust_2024_compatibility,
    clippy::all,
    clippy::suspicious,
    clippy::complexity,
    clippy::perf,
    clippy::style,
    clippy::pedantic,
    clippy::cargo
)]
```

Also replace in `ckms` all occurences of `Result<Something, CliError>` by `CliResult<Something>`