### PR TITLE
fix: replace Debug derive trait of KMIP Object by a custom Display impl

### DIFF
--- a/crate/cli/src/actions/cover_crypt/decrypt.rs
+++ b/crate/cli/src/actions/cover_crypt/decrypt.rs
@@ -87,7 +87,7 @@ impl DecryptAction {
             }),
         );
 
-        tracing::debug!("{decrypt_request:?}");
+        tracing::debug!("{decrypt_request}");
 
         // Query the KMS with your kmip data and get the key pair ids
         let decrypt_response = kms_rest_client

--- a/crate/cli/src/actions/cover_crypt/encrypt.rs
+++ b/crate/cli/src/actions/cover_crypt/encrypt.rs
@@ -91,7 +91,7 @@ impl EncryptAction {
             }),
         )?;
 
-        tracing::debug!("{encrypt_request:?}");
+        tracing::debug!("{encrypt_request}");
 
         // Query the KMS with your kmip data and get the key pair ids
         let encrypt_response = kms_rest_client

--- a/crate/cli/src/tests/shared/import_export_wrapping.rs
+++ b/crate/cli/src/tests/shared/import_export_wrapping.rs
@@ -254,10 +254,7 @@ fn test_import_export_wrap_private_key(
                 .is_none()
         );
         unwrap_key_block(wrapped_private_key.key_block_mut()?, unwrapping_key)?;
-        assert_eq!(
-            wrapped_private_key.key_block()?.key_value,
-            private_key.key_block()?.key_value
-        );
+        assert!(wrapped_private_key.key_block()?.key_value == private_key.key_block()?.key_value);
     }
 
     // test the unwrapping on import
@@ -281,19 +278,19 @@ fn test_import_export_wrap_private_key(
             ..Default::default()
         })?;
         let re_exported_key = read_object_from_json_ttlv_file(&re_exported_key_file)?;
-        assert_eq!(
-            re_exported_key.key_block()?.key_value.key_material,
-            private_key.key_block()?.key_value.key_material
+        assert!(
+            re_exported_key.key_block()?.key_value.key_material
+                == private_key.key_block()?.key_value.key_material
         );
-        assert_eq!(
+        assert!(
             re_exported_key
                 .key_block()?
                 .attributes()?
-                .get_link(LinkType::PublicKeyLink),
-            private_key
-                .key_block()?
-                .attributes()?
                 .get_link(LinkType::PublicKeyLink)
+                == private_key
+                    .key_block()?
+                    .attributes()?
+                    .get_link(LinkType::PublicKeyLink)
         );
         assert!(re_exported_key.key_wrapping_data().is_none());
     }
@@ -320,9 +317,8 @@ fn test_import_export_wrap_private_key(
             ..Default::default()
         })?;
         let exported_unwrapped_key = read_object_from_json_ttlv_file(&exported_unwrapped_key_file)?;
-        assert_eq!(
-            exported_unwrapped_key.key_block()?.key_value,
-            private_key.key_block()?.key_value
+        assert!(
+            exported_unwrapped_key.key_block()?.key_value == private_key.key_block()?.key_value
         );
         assert!(exported_unwrapped_key.key_wrapping_data().is_none());
     }

--- a/crate/client/src/import_utils.rs
+++ b/crate/client/src/import_utils.rs
@@ -29,7 +29,7 @@ pub async fn import_object<'a, T: IntoIterator<Item = impl AsRef<str>>>(
     trace!("import_object: unique_identifier: {unique_identifier}");
     // cache the object type
     let object_type = object.object_type();
-    trace!("import_object: object: {object:?}");
+    trace!("import_object: object: {object}");
 
     let (key_wrap_type, mut attributes) = if object_type == ObjectType::Certificate {
         // add the tags to the attributes

--- a/crate/client/src/kms_rest_client.rs
+++ b/crate/client/src/kms_rest_client.rs
@@ -1,5 +1,4 @@
 use std::{
-    fmt::Debug,
     fs::File,
     io::{BufReader, Read},
     sync::Arc,
@@ -641,10 +640,9 @@ impl KmsClient {
 
     pub async fn post_ttlv<O, R>(&self, kmip_request: &O) -> Result<R, ClientError>
     where
-        O: Serialize + Debug,
+        O: Serialize,
         R: serde::de::DeserializeOwned + Sized + 'static,
     {
-        trace!("kmip_request: {:?}", kmip_request);
         let endpoint = "/kmip/2_1";
         let server_url = format!("{}{endpoint}", self.server_url);
         let mut request = self.client.post(&server_url);

--- a/crate/kmip/src/crypto/cover_crypt/secret_key.rs
+++ b/crate/kmip/src/crypto/cover_crypt/secret_key.rs
@@ -153,7 +153,7 @@ impl TryFrom<&KeyBlock> for CoverCryptSymmetricKey {
             other => {
                 return Err(KmipError::InvalidKmipObject(
                     ErrorReason::Invalid_Object_Type,
-                    format!("Invalid key material for an CoverCrypt secret key: {other:?}"),
+                    format!("Invalid key material for an CoverCrypt secret key: {other}"),
                 ))
             }
         })

--- a/crate/kmip/src/crypto/cover_crypt/user_key.rs
+++ b/crate/kmip/src/crypto/cover_crypt/user_key.rs
@@ -49,7 +49,7 @@ pub(crate) fn unwrap_user_decryption_key_object(
         x => {
             return Err(KmipError::InvalidKmipObject(
                 ErrorReason::Invalid_Object_Type,
-                format!("Invalid Key Material for the CoverCrypt User Decryption Key: {x:?}"),
+                format!("Invalid Key Material for the CoverCrypt User Decryption Key: {x}"),
             ))
         }
     };

--- a/crate/kmip/src/crypto/rsa/operation.rs
+++ b/crate/kmip/src/crypto/rsa/operation.rs
@@ -116,7 +116,7 @@ pub fn to_rsa_public_key(
             key_wrapping_data: None,
         },
     };
-    trace!("to_rsa_public_key: output object: {:?}", output);
+    trace!("to_rsa_public_key: output object: {output}");
     output
 }
 

--- a/crate/kmip/src/crypto/wrap/unwrap_key.rs
+++ b/crate/kmip/src/crypto/wrap/unwrap_key.rs
@@ -125,7 +125,7 @@ pub(crate) fn unwrap(
     aad: Option<&[u8]>,
 ) -> Result<Zeroizing<Vec<u8>>, KmipError> {
     debug!(
-        "decrypt_bytes: with object: {:?} on ciphertext length: {}",
+        "decrypt_bytes: with object: {} on ciphertext length: {}",
         unwrapping_key,
         ciphertext.len()
     );

--- a/crate/kmip/src/crypto/wrap/wrap_key.rs
+++ b/crate/kmip/src/crypto/wrap/wrap_key.rs
@@ -196,7 +196,7 @@ pub(crate) fn wrap(
         | Object::PrivateKey { key_block }
         | Object::PublicKey { key_block }
         | Object::SymmetricKey { key_block } => {
-            debug!("wrap: key_block: {:?}", key_block);
+            debug!("wrap: key_block: {}", key_block);
             // wrap the wrapping key if necessary
             if key_block.key_wrapping_data.is_some() {
                 kmip_bail!("unable to wrap key: wrapping key is wrapped and that is not supported")

--- a/crate/kmip/src/kmip/kmip_objects.rs
+++ b/crate/kmip/src/kmip/kmip_objects.rs
@@ -1,4 +1,4 @@
-use std::convert::TryFrom;
+use std::{convert::TryFrom, fmt::Display};
 
 use clap::ValueEnum;
 use num_bigint_dig::BigUint;
@@ -34,7 +34,7 @@ use crate::{
 ///
 /// Order matters: `SecretData` will be deserialized as a `PrivateKey` if it
 /// appears after despite the presence of `secret_data_type`
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Eq, PartialEq)]
 #[serde(untagged)]
 pub enum Object {
     /// A Managed Cryptographic Object that is a digital certificate.
@@ -128,6 +128,70 @@ pub enum Object {
         #[serde(rename = "KeyBlock")]
         key_block: KeyBlock,
     },
+}
+
+impl Display for Object {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Certificate {
+                certificate_type,
+                certificate_value,
+            } => write!(
+                f,
+                "Certificate(certificate_type: {certificate_type:?}, certificate_value: \
+                 {certificate_value:?})"
+            ),
+            Self::CertificateRequest {
+                certificate_request_type,
+                certificate_request_value,
+            } => write!(
+                f,
+                "CertificateRequest(certificate_request_type: {certificate_request_type:?}, \
+                 certificate_request_value: {certificate_request_value:?})"
+            ),
+            Self::OpaqueObject {
+                opaque_data_type,
+                opaque_data_value,
+            } => write!(
+                f,
+                "OpaqueObject(opaque_data_type: {opaque_data_type:?}, opaque_data_value: \
+                 {opaque_data_value:?})"
+            ),
+            Self::PGPKey {
+                pgp_key_version,
+                key_block,
+            } => write!(
+                f,
+                "PGPKey(pgp_key_version: {pgp_key_version:?}, key_block: {key_block})"
+            ),
+            Self::SecretData {
+                secret_data_type,
+                key_block,
+            } => write!(
+                f,
+                "SecretData(secret_data_type: {secret_data_type:?}, key_block: {key_block})"
+            ),
+            Self::SplitKey {
+                split_key_parts,
+                key_part_identifier,
+                split_key_threshold,
+                split_key_method,
+                prime_field_size,
+                key_block,
+            } => write!(
+                f,
+                "SplitKey(split_key_parts: {split_key_parts:?}, key_part_identifier: \
+                 {key_part_identifier:?}, split_key_threshold: {split_key_threshold:?}, \
+                 split_key_method: {split_key_method:?}, prime_field_size: {prime_field_size:?}, \
+                 key_block: {key_block})"
+            ),
+            Self::PrivateKey { key_block } => write!(f, "PrivateKey(key_block: {key_block})"),
+            Self::PublicKey { key_block } => write!(f, "PublicKey(key_block: {key_block})"),
+            Self::SymmetricKey { key_block } => {
+                write!(f, "SymmetricKey(key_block: {key_block})")
+            }
+        }
+    }
 }
 
 impl Object {

--- a/crate/kmip/src/kmip/kmip_operations.rs
+++ b/crate/kmip/src/kmip/kmip_operations.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::fmt::{self, Display};
 
 use cloudproof::reexport::crypto_core::bytes_ser_de::{Deserializer, Serializer};
 use serde::{
@@ -103,7 +103,7 @@ pub enum Direction {
     Response,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, PartialEq, Eq)]
 #[serde(untagged)]
 #[allow(clippy::large_enum_variant)]
 pub enum Operation {
@@ -141,6 +141,87 @@ pub enum Operation {
     DestroyResponse(DestroyResponse),
     Validate(Validate),
     ValidateResponse(ValidateResponse),
+}
+
+impl Display for Operation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Import(import) => write!(f, "Import({import})"),
+            Self::ImportResponse(import_response) => {
+                write!(f, "ImportResponse({import_response})")
+            }
+            Self::Certify(certify) => write!(f, "Certify({certify})"),
+            Self::CertifyResponse(certify_response) => {
+                write!(f, "CertifyResponse({certify_response})")
+            }
+            Self::Create(create) => write!(f, "Create({create})"),
+            Self::CreateResponse(create_response) => {
+                write!(f, "CreateResponse({create_response})")
+            }
+            Self::CreateKeyPair(create_key_pair) => {
+                write!(f, "CreateKeyPair({create_key_pair})")
+            }
+            Self::CreateKeyPairResponse(create_key_pair_response) => {
+                write!(f, "CreateKeyPairResponse({create_key_pair_response})")
+            }
+            Self::Export(export) => write!(f, "Export({export})"),
+            Self::ExportResponse(export_response) => {
+                write!(f, "ExportResponse({export_response})")
+            }
+            Self::Get(get) => write!(f, "Get({get})"),
+            Self::GetResponse(get_response) => write!(f, "GetResponse({get_response})"),
+            Self::GetAttributes(get_attributes) => {
+                write!(f, "GetAttributes({get_attributes})")
+            }
+            Self::GetAttributesResponse(get_attributes_response) => {
+                write!(f, "GetAttributesResponse({get_attributes_response})")
+            }
+            Self::SetAttribute(set_attribute) => write!(f, "SetAttribute({set_attribute})"),
+            Self::SetAttributeResponse(set_attribute_response) => {
+                write!(f, "SetAttributeResponse({set_attribute_response})")
+            }
+            Self::DeleteAttribute(delete_attribute) => {
+                write!(f, "DeleteAttribute({delete_attribute})")
+            }
+            Self::DeleteAttributeResponse(delete_attribute_response) => {
+                write!(f, "DeleteAttributeResponse({delete_attribute_response})")
+            }
+            Self::Encrypt(encrypt) => write!(f, "Encrypt({encrypt})"),
+            Self::EncryptResponse(encrypt_response) => {
+                write!(f, "EncryptResponse({encrypt_response})")
+            }
+            Self::Decrypt(decrypt) => write!(f, "Decrypt({decrypt})"),
+            Self::DecryptResponse(decrypt_response) => {
+                write!(f, "DecryptResponse({decrypt_response})")
+            }
+            Self::Locate(locate) => write!(f, "Locate({locate})"),
+            Self::LocateResponse(locate_response) => {
+                write!(f, "LocateResponse({locate_response})")
+            }
+            Self::Revoke(revoke) => write!(f, "Revoke({revoke})"),
+            Self::RevokeResponse(revoke_response) => {
+                write!(f, "RevokeResponse({revoke_response})")
+            }
+            Self::ReKey(re_key) => write!(f, "ReKey({re_key})"),
+            Self::ReKeyResponse(re_key_response) => {
+                write!(f, "ReKeyResponse({re_key_response})")
+            }
+            Self::ReKeyKeyPair(re_key_key_pair) => {
+                write!(f, "ReKeyKeyPair({re_key_key_pair})")
+            }
+            Self::ReKeyKeyPairResponse(re_key_key_pair_response) => {
+                write!(f, "ReKeyKeyPairResponse({re_key_key_pair_response})")
+            }
+            Self::Destroy(destroy) => write!(f, "Destroy({destroy})"),
+            Self::DestroyResponse(destroy_response) => {
+                write!(f, "DestroyResponse({destroy_response})")
+            }
+            Self::Validate(validate) => write!(f, "Validate({validate})"),
+            Self::ValidateResponse(validate_response) => {
+                write!(f, "ValidateResponse({validate_response})")
+            }
+        }
+    }
 }
 
 impl Operation {
@@ -242,7 +323,7 @@ impl Operation {
 /// assigned by the server. The server SHALL copy the Unique Identifier returned
 /// by this operations into the ID Placeholder variable.
 /// `https://docs.oasis-open.org/kmip/kmip-spec/v2.1/os/kmip-spec-v2.1-os.html#_Toc57115657`
-#[derive(Debug, Serialize, PartialEq, Eq)]
+#[derive(Serialize, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub struct Import {
     /// The Unique Identifier of the object to be imported
@@ -264,6 +345,22 @@ pub struct Import {
     pub attributes: Attributes,
     /// The object being imported. The object and attributes MAY be wrapped.
     pub object: Object,
+}
+
+impl Display for Import {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Import {{ unique_identifier: {}, object_type: {}, replace_existing: {:?}, \
+             key_wrap_type: {:?}, attributes: {:?}, object: {} }}",
+            self.unique_identifier,
+            self.object_type,
+            self.replace_existing,
+            self.key_wrap_type,
+            self.attributes,
+            self.object
+        )
+    }
 }
 
 /// Deserialization needs to be handwritten because the
@@ -386,6 +483,16 @@ pub struct ImportResponse {
     pub unique_identifier: UniqueIdentifier,
 }
 
+impl Display for ImportResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "ImportResponse {{ unique_identifier: {} }}",
+            self.unique_identifier
+        )
+    }
+}
+
 /// This request is used to generate a Certificate object for a public key. This
 /// request supports the certification of a new public key, as well as the
 /// certification of a public key that has already been certified (i.e.,
@@ -413,7 +520,7 @@ pub struct ImportResponse {
 /// into the ID Placeholder variable. If the information in the Certificate
 /// Request conflicts with the attributes specified in the Attributes, then the
 /// information in the Certificate Request takes precedence.
-#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub struct Certify {
     // The Unique Identifier of the Public Key or the Certificate Request being certified. If
@@ -437,11 +544,36 @@ pub struct Certify {
     pub protection_storage_masks: Option<ProtectionStorageMasks>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+impl Display for Certify {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Certify {{ unique_identifier: {:?}, certificate_request_type: {:?}, \
+             certificate_request_value: {:?}, attributes: {:?}, protection_storage_masks: {:?} }}",
+            self.unique_identifier,
+            self.certificate_request_type,
+            self.certificate_request_value,
+            self.attributes,
+            self.protection_storage_masks
+        )
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub struct CertifyResponse {
     /// The Unique Identifier of the newly created object.
     pub unique_identifier: UniqueIdentifier,
+}
+
+impl Display for CertifyResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "CertifyResponse {{ unique_identifier: {} }}",
+            self.unique_identifier
+        )
+    }
 }
 
 /// This operation requests the server to generate a new symmetric key or
@@ -451,7 +583,7 @@ pub struct CertifyResponse {
 /// Cryptographic Length, etc.). The response contains the Unique Identifier of
 /// the created object. The server SHALL copy the Unique Identifier returned by
 /// this operation into the ID Placeholder variable.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub struct Create {
     /// Determines the type of object to be created.
@@ -464,6 +596,16 @@ pub struct Create {
     pub protection_storage_masks: Option<ProtectionStorageMasks>,
 }
 
+impl Display for Create {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Create {{ object_type: {}, attributes: {:?}, protection_storage_masks: {:?} }}",
+            self.object_type, self.attributes, self.protection_storage_masks
+        )
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub struct CreateResponse {
@@ -471,6 +613,16 @@ pub struct CreateResponse {
     pub object_type: ObjectType,
     /// The Unique Identifier of the newly created object.
     pub unique_identifier: UniqueIdentifier,
+}
+
+impl Display for CreateResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "CreateResponse {{ object_type: {}, unique_identifier: {} }}",
+            self.object_type, self.unique_identifier
+        )
+    }
 }
 
 /// This operation requests the server to generate a new public/private key pair
@@ -487,7 +639,7 @@ pub struct CreateResponse {
 /// Private Key pointing to the Private Key. The response contains the Unique
 /// Identifiers of both created objects. The ID Placeholder value SHALL be set
 /// to the Unique Identifier of the Private Key
-#[derive(Debug, Deserialize, Serialize, Default, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub struct CreateKeyPair {
     /// Specifies desired attributes to be associated with the new object that
@@ -516,6 +668,23 @@ pub struct CreateKeyPair {
     pub public_protection_storage_masks: Option<ProtectionStorageMasks>,
 }
 
+impl Display for CreateKeyPair {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "CreateKeyPair {{ common_attributes: {:?}, private_key_attributes: {:?}, \
+             public_key_attributes: {:?}, common_protection_storage_masks: {:?}, \
+             private_protection_storage_masks: {:?}, public_protection_storage_masks: {:?} }}",
+            self.common_attributes,
+            self.private_key_attributes,
+            self.public_key_attributes,
+            self.common_protection_storage_masks,
+            self.private_protection_storage_masks,
+            self.public_protection_storage_masks
+        )
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub struct CreateKeyPairResponse {
@@ -523,6 +692,17 @@ pub struct CreateKeyPairResponse {
     pub private_key_unique_identifier: UniqueIdentifier,
     /// The Unique Identifier of the newly created public key object.
     pub public_key_unique_identifier: UniqueIdentifier,
+}
+
+impl Display for CreateKeyPairResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "CreateKeyPairResponse {{ private_key_unique_identifier: {}, \
+             public_key_unique_identifier: {} }}",
+            self.private_key_unique_identifier, self.public_key_unique_identifier
+        )
+    }
 }
 
 #[allow(non_camel_case_types)]
@@ -593,7 +773,7 @@ pub struct DeriveKey {
 /// SHALL not be returned in the response.
 /// The server SHALL copy the Unique Identifier returned by this operations
 /// into the ID Placeholder variable.
-#[derive(Debug, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub struct Export {
     /// Determines the object being requested. If omitted, then the ID
@@ -612,6 +792,21 @@ pub struct Export {
     /// Specifies keys and other information for wrapping the returned object.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub key_wrapping_specification: Option<KeyWrappingSpecification>,
+}
+
+impl Display for Export {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Export {{ unique_identifier: {:?}, key_format_type: {:?}, key_wrap_type: {:?}, \
+             key_compression_type: {:?}, key_wrapping_specification: {:?} }}",
+            self.unique_identifier,
+            self.key_format_type,
+            self.key_wrap_type,
+            self.key_compression_type,
+            self.key_wrapping_specification
+        )
+    }
 }
 
 impl Export {
@@ -688,13 +883,24 @@ impl From<Get> for Export {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub struct ExportResponse {
     pub object_type: ObjectType,
     pub unique_identifier: UniqueIdentifier,
     pub attributes: Attributes,
     pub object: Object,
+}
+
+impl Display for ExportResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "ExportResponse {{ object_type: {}, unique_identifier: {}, attributes: {:?}, object: \
+             {} }}",
+            self.object_type, self.unique_identifier, self.attributes, self.object
+        )
+    }
 }
 
 /// This operation requests that the server returns the Managed Object specified by its Unique Identifier.
@@ -746,6 +952,21 @@ pub struct Get {
     /// Specifies keys and other information for wrapping the returned object.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub key_wrapping_specification: Option<KeyWrappingSpecification>,
+}
+
+impl Display for Get {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Get {{ unique_identifier: {:?}, key_format_type: {:?}, key_wrap_type: {:?}, \
+             key_compression_type: {:?}, key_wrapping_specification: {:?} }}",
+            self.unique_identifier,
+            self.key_format_type,
+            self.key_wrap_type,
+            self.key_compression_type,
+            self.key_wrapping_specification
+        )
+    }
 }
 
 impl Get {
@@ -826,12 +1047,22 @@ impl From<&str> for Get {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub struct GetResponse {
     pub object_type: ObjectType,
     pub unique_identifier: UniqueIdentifier,
     pub object: Object,
+}
+
+impl Display for GetResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "GetResponse {{ object_type: {}, unique_identifier: {}, object: {} }}",
+            self.object_type, self.unique_identifier, self.object
+        )
+    }
 }
 
 impl From<ExportResponse> for GetResponse {
@@ -844,7 +1075,7 @@ impl From<ExportResponse> for GetResponse {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub struct GetAttributes {
     /// Determines the object whose attributes
@@ -861,6 +1092,17 @@ pub struct GetAttributes {
     )]
     pub attribute_references: Option<Vec<AttributeReference>>,
 }
+
+impl Display for GetAttributes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "GetAttributes {{ unique_identifier: {:?}, attribute_references: {:?} }}",
+            self.unique_identifier, self.attribute_references
+        )
+    }
+}
+
 impl From<String> for GetAttributes {
     fn from(uid: String) -> Self {
         Self {
@@ -880,7 +1122,7 @@ impl From<&str> for GetAttributes {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub struct GetAttributesResponse {
     /// The Unique Identifier of the object
@@ -889,7 +1131,17 @@ pub struct GetAttributesResponse {
     pub attributes: Attributes,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+impl Display for GetAttributesResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "GetAttributesResponse {{ unique_identifier: {}, attributes: {:?} }}",
+            self.unique_identifier, self.attributes
+        )
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub struct SetAttribute {
     /// The Unique Identifier of the object. If omitted, then the ID Placeholder value is used by the server as the Unique Identifier.
@@ -899,14 +1151,34 @@ pub struct SetAttribute {
     pub new_attribute: Attribute,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+impl Display for SetAttribute {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "SetAttribute {{ unique_identifier: {:?}, new_attribute: {} }}",
+            self.unique_identifier, self.new_attribute
+        )
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub struct SetAttributeResponse {
     /// The Unique Identifier of the object
     pub unique_identifier: UniqueIdentifier,
 }
 
-#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+impl Display for SetAttributeResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "SetAttributeResponse {{ unique_identifier: {} }}",
+            self.unique_identifier
+        )
+    }
+}
+
+#[derive(Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub struct DeleteAttribute {
     /// Determines the object whose attributes are being deleted. If omitted, then the ID Placeholder value is used by the server as the Unique Identifier.
@@ -923,14 +1195,35 @@ pub struct DeleteAttribute {
     pub attribute_references: Option<Vec<AttributeReference>>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+impl Display for DeleteAttribute {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "DeleteAttribute {{ unique_identifier: {:?}, current_attribute: {:?}, \
+             attribute_references: {:?} }}",
+            self.unique_identifier, self.current_attribute, self.attribute_references
+        )
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub struct DeleteAttributeResponse {
     /// The Unique Identifier of the object
     pub unique_identifier: UniqueIdentifier,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default, PartialEq, Eq, Clone)]
+impl Display for DeleteAttributeResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "DeleteAttributeResponse {{ unique_identifier: {} }}",
+            self.unique_identifier
+        )
+    }
+}
+
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Clone)]
 #[serde(rename_all = "PascalCase")]
 pub struct Encrypt {
     /// The Unique Identifier of the Managed
@@ -980,7 +1273,26 @@ pub struct Encrypt {
     pub authenticated_encryption_additional_data: Option<Vec<u8>>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+impl Display for Encrypt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Encrypt {{ unique_identifier: {:?}, cryptographic_parameters: {:?}, data: {:?}, \
+             iv_counter_nonce: {:?}, correlation_value: {:?}, init_indicator: {:?}, \
+             final_indicator: {:?}, authenticated_encryption_additional_data: {:?} }}",
+            self.unique_identifier,
+            self.cryptographic_parameters,
+            self.data,
+            self.iv_counter_nonce,
+            self.correlation_value,
+            self.init_indicator,
+            self.final_indicator,
+            self.authenticated_encryption_additional_data
+        )
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub struct EncryptResponse {
     /// The Unique Identifier of the Managed
@@ -1014,7 +1326,22 @@ pub struct EncryptResponse {
     pub authenticated_encryption_tag: Option<Vec<u8>>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default, PartialEq, Eq, Clone)]
+impl Display for EncryptResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "EncryptResponse {{ unique_identifier: {}, data: {:?}, iv_counter_nonce: {:?}, \
+             correlation_value: {:?}, authenticated_encryption_tag: {:?} }}",
+            self.unique_identifier,
+            self.data,
+            self.iv_counter_nonce,
+            self.correlation_value,
+            self.authenticated_encryption_tag
+        )
+    }
+}
+
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Clone)]
 #[serde(rename_all = "PascalCase")]
 pub struct Decrypt {
     /// The Unique Identifier of the Managed
@@ -1073,6 +1400,27 @@ pub struct Decrypt {
     pub authenticated_encryption_tag: Option<Vec<u8>>,
 }
 
+impl Display for Decrypt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Decrypt {{ unique_identifier: {:?}, cryptographic_parameters: {:?}, data: {:?}, \
+             iv_counter_nonce: {:?}, correlation_value: {:?}, init_indicator: {:?}, \
+             final_indicator: {:?}, authenticated_encryption_additional_data: {:?}, \
+             authenticated_encryption_tag: {:?} }}",
+            self.unique_identifier,
+            self.cryptographic_parameters,
+            self.data,
+            self.iv_counter_nonce,
+            self.correlation_value,
+            self.init_indicator,
+            self.final_indicator,
+            self.authenticated_encryption_additional_data,
+            self.authenticated_encryption_tag
+        )
+    }
+}
+
 /// When decrypting data with Cover Crypt we can have some
 /// additional metadata stored inside the header and encrypted
 /// with de DEM. We need to return these data to the user but
@@ -1122,7 +1470,7 @@ impl TryFrom<&[u8]> for DecryptedData {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub struct DecryptResponse {
     /// The Unique Identifier of the Managed
@@ -1138,6 +1486,16 @@ pub struct DecryptResponse {
     /// cryptographic operations.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub correlation_value: Option<Vec<u8>>,
+}
+
+impl Display for DecryptResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "DecryptResponse {{ unique_identifier: {}, data: {:?}, correlation_value: {:?} }}",
+            self.unique_identifier, self.data, self.correlation_value
+        )
+    }
 }
 
 /// This operation requests that the server search for one or more Managed
@@ -1223,7 +1581,7 @@ pub struct DecryptResponse {
 /// Mask field includes the Destroyed Storage indicator. The server SHALL NOT
 /// return unique identifiers for objects that are archived unless the Storage
 /// Status Mask field includes the Archived Storage indicator.
-#[derive(Debug, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub struct Locate {
     /// An Integer object that indicates the maximum number of object
@@ -1248,7 +1606,22 @@ pub struct Locate {
     pub attributes: Attributes,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+impl Display for Locate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Locate {{ maximum_items: {:?}, offset_items: {:?}, storage_status_mask: {:?}, \
+             object_group_member: {:?}, attributes: {:?} }}",
+            self.maximum_items,
+            self.offset_items,
+            self.storage_status_mask,
+            self.object_group_member,
+            self.attributes
+        )
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq)]
 pub struct LocateResponse {
     /// An Integer object that indicates the number of object identifiers that
     /// satisfy the identification criteria specified in the request. A server
@@ -1261,6 +1634,16 @@ pub struct LocateResponse {
     /// The Unique Identifier of the located objects.
     #[serde(skip_serializing_if = "Option::is_none", rename = "UniqueIdentifier")]
     pub unique_identifiers: Option<Vec<UniqueIdentifier>>,
+}
+
+impl Display for LocateResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "LocateResponse {{ located_items: {:?}, unique_identifiers: {:?} }}",
+            self.located_items, self.unique_identifiers
+        )
+    }
 }
 
 /// This operation requests the server to revoke a Managed Cryptographic Object
@@ -1278,7 +1661,7 @@ pub struct LocateResponse {
 /// If the revocation reason is neither "key
 /// compromise" nor "CA compromise", the object is placed into the "deactivated"
 /// state, and the Deactivation Date is set to the current date and time.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub struct Revoke {
     /// Determines the object being revoked. If omitted, then the ID Placeholder
@@ -1294,11 +1677,32 @@ pub struct Revoke {
     pub compromise_occurrence_date: Option<u64>, // epoch millis
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+impl Display for Revoke {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Revoke {{ unique_identifier: {:?}, revocation_reason: {:?}, \
+             compromise_occurrence_date: {:?} }}",
+            self.unique_identifier, self.revocation_reason, self.compromise_occurrence_date
+        )
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub struct RevokeResponse {
     /// The Unique Identifier of the object.
     pub unique_identifier: UniqueIdentifier,
+}
+
+impl Display for RevokeResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "RevokeResponse {{ unique_identifier: {} }}",
+            self.unique_identifier
+        )
+    }
 }
 
 /// This request is used to generate a replacement key for an existing symmetric key. It is analogous to the Create operation, except that attributes of the replacement key are copied from the existing key, with the exception of the attributes listed in Re-key Attribute Requirements.
@@ -1312,7 +1716,7 @@ pub struct RevokeResponse {
 /// For the existing key, the server SHALL create a Link attribute of Link Type Replacement Object pointing to the replacement key. For the replacement key, the server SHALL create a Link attribute of Link Type Replaced Key pointing to the existing key.
 ///
 /// An Offset MAY be used to indicate the difference between the Initial Date and the Activation Date of the replacement key. If no Offset is specified, the Activation Date, Process Start Date, Protect Stop Date and Deactivation Date values are copied from the existing key.
-#[derive(Debug, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub struct ReKey {
     // Determines the existing Symmetric Key being re-keyed. If omitted, then the ID Placeholder value is used by the server as the Unique Identifier.
@@ -1333,11 +1737,32 @@ pub struct ReKey {
     pub protection_storage_masks: Option<ProtectionStorageMasks>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+impl Display for ReKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "ReKey {{ unique_identifier: {:?}, offset: {:?}, attributes: {:?}, \
+             protection_storage_masks: {:?} }}",
+            self.unique_identifier, self.offset, self.attributes, self.protection_storage_masks
+        )
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub struct ReKeyResponse {
     // The Unique Identifier of the newly created replacement Private Key object.
     pub unique_identifier: UniqueIdentifier,
+}
+
+impl Display for ReKeyResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "ReKeyResponse {{ unique_identifier: {} }}",
+            self.unique_identifier
+        )
+    }
 }
 
 /// This request is used to generate a replacement key pair for an existing
@@ -1365,7 +1790,7 @@ pub struct ReKeyResponse {
 /// key pair. If Offset is set and dates exist for the existing key pair, then
 /// the dates of the replacement key pair SHALL be set based on the dates of the
 /// existing key pair as follows
-#[derive(Debug, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub struct ReKeyKeyPair {
     // Determines the existing Asymmetric key pair to be re-keyed.  If omitted, then the ID
@@ -1406,7 +1831,27 @@ pub struct ReKeyKeyPair {
     pub public_protection_storage_masks: Option<ProtectionStorageMasks>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+impl Display for ReKeyKeyPair {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "ReKeyKeyPair {{ private_key_unique_identifier: {:?}, offset: {:?}, \
+             common_attributes: {:?}, private_key_attributes: {:?}, public_key_attributes: {:?}, \
+             common_protection_storage_masks: {:?}, private_protection_storage_masks: {:?}, \
+             public_protection_storage_masks: {:?} }}",
+            self.private_key_unique_identifier,
+            self.offset,
+            self.common_attributes,
+            self.private_key_attributes,
+            self.public_key_attributes,
+            self.common_protection_storage_masks,
+            self.private_protection_storage_masks,
+            self.public_protection_storage_masks
+        )
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub struct ReKeyKeyPairResponse {
     // The Unique Identifier of the newly created replacement Private Key object.
@@ -1415,7 +1860,18 @@ pub struct ReKeyKeyPairResponse {
     pub public_key_unique_identifier: UniqueIdentifier,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+impl Display for ReKeyKeyPairResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "ReKeyKeyPairResponse {{ private_key_unique_identifier: {}, \
+             public_key_unique_identifier: {} }}",
+            self.private_key_unique_identifier, self.public_key_unique_identifier
+        )
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub struct Destroy {
     /// Determines the object being destroyed. If omitted, then the ID
@@ -1424,12 +1880,33 @@ pub struct Destroy {
     pub unique_identifier: Option<UniqueIdentifier>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+impl Display for Destroy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Destroy {{ unique_identifier: {:?} }}",
+            self.unique_identifier
+        )
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub struct DestroyResponse {
     /// The Unique Identifier of the object.
     pub unique_identifier: UniqueIdentifier,
 }
+
+impl Display for DestroyResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "DestroyResponse {{ unique_identifier: {} }}",
+            self.unique_identifier
+        )
+    }
+}
+
 /// This operation requests the server to validate a certificate chain and return
 /// information on its validity. Only a single certificate chain SHALL be
 /// included in each request.
@@ -1443,7 +1920,7 @@ pub struct DestroyResponse {
 /// Likewise, the order in which the supplied certificate chain is validated and
 /// the specification of trust anchors used to terminate validation are also
 /// controlled by the server.
-#[derive(Debug, Serialize, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Serialize, Clone, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub struct Validate {
     /// One or more Certificates.
@@ -1458,12 +1935,32 @@ pub struct Validate {
     pub validity_time: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+impl Display for Validate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Validate {{ certificate: {:?}, unique_identifier: {:?}, validity_time: {:?} }}",
+            self.certificate, self.unique_identifier, self.validity_time
+        )
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub struct ValidateResponse {
     /// An Enumeration object indicating whether the certificate chain is valid,
     /// invalid, or unknown.
     pub validity_indicator: ValidityIndicator,
+}
+
+impl Display for ValidateResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "ValidateResponse {{ validity_indicator: {:?} }}",
+            self.validity_indicator
+        )
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/crate/kmip/src/kmip/kmip_types.rs
+++ b/crate/kmip/src/kmip/kmip_types.rs
@@ -1328,6 +1328,39 @@ pub enum Attribute {
     VendorAttributes(Vec<VendorAttribute>),
 }
 
+impl Display for Attribute {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ActivationDate(activation_date) => {
+                write!(f, "ActivationDate: {activation_date}")
+            }
+            Self::CryptographicAlgorithm(crypto_algorithm) => {
+                write!(f, "CryptographicAlgorithm: {crypto_algorithm}")
+            }
+            Self::CryptographicLength(crypto_length) => {
+                write!(f, "CryptographicLength: {crypto_length}")
+            }
+            Self::CryptographicParameters(crypto_parameters) => {
+                write!(f, "CryptographicParameters: {crypto_parameters:?}")
+            }
+            Self::CryptographicDomainParameters(crypto_domain_parameters) => {
+                write!(
+                    f,
+                    "CryptographicDomainParameters: {crypto_domain_parameters:?}"
+                )
+            }
+            Self::CryptographicUsageMask(crypto_usage_mask) => {
+                write!(f, "CryptographicUsageMask: {crypto_usage_mask:?}")
+            }
+            Self::Links(links) => write!(f, "Links: {links:?}"),
+            Self::State(state) => write!(f, "State: {state}"),
+            Self::VendorAttributes(vendor_attributes) => {
+                write!(f, "VendorAttributes: {vendor_attributes:?}")
+            }
+        }
+    }
+}
+
 impl Serialize for Attribute {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/crate/kmip/src/kmip/ttlv/tests/mod.rs
+++ b/crate/kmip/src/kmip/ttlv/tests/mod.rs
@@ -413,7 +413,7 @@ fn test_key_material_vec_deserialization() {
     };
     let km_: KeyMaterial = from_ttlv(&ttlv).unwrap();
     let km = KeyMaterial::TransparentSymmetricKey { key: bytes };
-    assert_eq!(km, km_);
+    assert!(km == km_);
 }
 
 #[test]
@@ -454,7 +454,7 @@ fn test_key_material_big_int_deserialization() {
     let ttlv_ = to_ttlv(&km).unwrap();
     assert_eq!(ttlv, ttlv_);
     let km_: KeyMaterial = from_ttlv(&ttlv_).unwrap();
-    assert_eq!(km, km_);
+    assert!(km == km_);
 }
 
 #[test]
@@ -468,7 +468,7 @@ fn test_big_int_deserialization() {
     };
     let j = serde_json::to_value(&km).unwrap();
     let km_: KeyMaterial = serde_json::from_value(j).unwrap();
-    assert_eq!(km, km_);
+    assert!(km == km_);
 }
 
 #[test]
@@ -480,14 +480,11 @@ fn test_des_aes_key() {
     let o: Object = serde_json::from_value(json).unwrap();
     // Deserialization cannot make the difference
     // between a `SymmetricKey` or a `PrivateKey`
-    assert_eq!(
-        aes_key(key_bytes),
-        Object::post_fix(ObjectType::SymmetricKey, o)
-    );
+    assert!(aes_key(key_bytes) == Object::post_fix(ObjectType::SymmetricKey, o));
 
     let ttlv = aes_key_ttlv(key_bytes);
     let rec: Object = from_ttlv(&ttlv).unwrap();
-    assert_eq!(aes_key(key_bytes), rec);
+    assert!(aes_key(key_bytes) == rec);
 }
 
 #[test]
@@ -497,11 +494,11 @@ fn test_aes_key_block() {
     //
     let json = serde_json::to_value(aes_key_block(key_bytes)).unwrap();
     let kv: KeyBlock = serde_json::from_value(json).unwrap();
-    assert_eq!(aes_key_block(key_bytes), kv);
+    assert!(aes_key_block(key_bytes) == kv);
     //
     let ttlv = aes_key_block_ttlv(key_bytes);
     let rec: KeyBlock = from_ttlv(&ttlv).unwrap();
-    assert_eq!(aes_key_block(key_bytes), rec);
+    assert!(aes_key_block(key_bytes) == rec);
 }
 
 #[test]
@@ -511,11 +508,11 @@ fn test_aes_key_value() {
     //
     let json = serde_json::to_value(aes_key_value(key_bytes)).unwrap();
     let kv: KeyValue = serde_json::from_value(json).unwrap();
-    assert_eq!(aes_key_value(key_bytes), kv);
+    assert!(aes_key_value(key_bytes) == kv);
 
     let ttlv = aes_key_value_ttlv(key_bytes);
     let rec: KeyValue = from_ttlv(&ttlv).unwrap();
-    assert_eq!(aes_key_value(key_bytes), rec);
+    assert!(aes_key_value(key_bytes) == rec);
 }
 
 #[test]
@@ -524,7 +521,7 @@ fn test_aes_key_material() {
     let key_bytes: &[u8] = b"this_is_a_test";
     let ttlv = aes_key_material_ttlv(key_bytes);
     let rec: KeyMaterial = from_ttlv(&ttlv).unwrap();
-    assert_eq!(aes_key_material(key_bytes), rec);
+    assert!(aes_key_material(key_bytes) == rec);
 }
 
 #[test]
@@ -647,7 +644,7 @@ fn test_byte_string_key_material() {
     };
     let ttlv = to_ttlv(&key_value).unwrap();
     let key_value_: KeyValue = from_ttlv(&ttlv).unwrap();
-    assert_eq!(key_value, key_value_);
+    assert!(key_value == key_value_);
 }
 
 #[test]
@@ -657,10 +654,7 @@ fn test_aes_key_full() {
     let aes_key = aes_key(key_bytes);
     let ttlv = to_ttlv(&aes_key).unwrap();
     let aes_key_: Object = from_ttlv(&ttlv).unwrap();
-    assert_eq!(
-        aes_key,
-        Object::post_fix(ObjectType::SymmetricKey, aes_key_)
-    );
+    assert!(aes_key == Object::post_fix(ObjectType::SymmetricKey, aes_key_));
 }
 
 #[test]
@@ -741,10 +735,7 @@ fn test_issue_deserialize_object_with_empty_attributes() {
     let object_: Object = serialize_deserialize(&object).unwrap();
     match object_ {
         Object::SymmetricKey { key_block } => {
-            assert_eq!(
-                get_key_block().key_value.key_material,
-                key_block.key_value.key_material
-            );
+            assert!(get_key_block().key_value.key_material == key_block.key_value.key_material);
         }
         _ => panic!("wrong object type"),
     }
@@ -832,12 +823,12 @@ pub(crate) fn test_message_request() {
     assert_eq!(req_.items[0].operation, OperationEnumeration::Encrypt);
     let Operation::Encrypt(encrypt) = &req_.items[0].request_payload else {
         panic!(
-            "not an encrypt operation's request payload: {:?}",
+            "not an encrypt operation's request payload: {}",
             req_.items[0]
         );
     };
     assert_eq!(encrypt.data, Some(Zeroizing::from(b"to be enc".to_vec())));
-    assert_eq!(req, req_);
+    assert!(req == req_);
 }
 
 #[test]
@@ -926,7 +917,7 @@ pub(crate) fn test_message_response() {
         decrypt.unique_identifier,
         UniqueIdentifier::TextString("id_12345".to_owned())
     );
-    assert_eq!(res, res_);
+    assert!(res == res_);
 }
 
 #[test]
@@ -1296,10 +1287,7 @@ fn test_serialization_set_attribute() -> KmipResult<()> {
     trace!("set_attribute: {:#?}", set_attribute);
 
     let set_attribute_deserialized: SetAttribute = from_ttlv(&set_attribute)?;
-    trace!(
-        "set_attribute_deserialized: {:?}",
-        set_attribute_deserialized
-    );
+    trace!("set_attribute_deserialized: {}", set_attribute_deserialized);
 
     Ok(())
 }

--- a/crate/kmip/src/lib.rs
+++ b/crate/kmip/src/lib.rs
@@ -37,6 +37,7 @@
     clippy::unseparated_literal_suffix,
     clippy::map_err_ignore,
     clippy::redundant_clone,
+    // clippy::use_debug,
 )]
 #![allow(
     clippy::module_name_repetitions,

--- a/crate/kmip/src/openssl/private_key.rs
+++ b/crate/kmip/src/openssl/private_key.rs
@@ -50,7 +50,7 @@ use crate::{
 pub fn kmip_private_key_to_openssl(private_key: &Object) -> Result<PKey<Private>, KmipError> {
     let key_block = match private_key {
         Object::PrivateKey { key_block } => key_block,
-        x => kmip_bail!("Invalid Object: {:?}. KMIP Private Key expected", x),
+        x => kmip_bail!("Invalid Object: {}. KMIP Private Key expected", x),
     };
     let pk: PKey<Private> = match key_block.key_format_type {
         KeyFormatType::PKCS1 => {
@@ -160,7 +160,7 @@ pub fn kmip_private_key_to_openssl(private_key: &Object) -> Result<PKey<Private>
                 other => ec_private_key_from_scalar(d, *other)?,
             },
             x => kmip_bail!(
-                "KMIP key to openssl: invalid Transparent EC private key material: {:?}: \
+                "KMIP key to openssl: invalid Transparent EC private key material: {}: \
                  TransparentECPrivateKey expected",
                 x
             ),

--- a/crate/kmip/src/openssl/public_key.rs
+++ b/crate/kmip/src/openssl/public_key.rs
@@ -53,10 +53,10 @@ use crate::{
 /// * `PKey<Public>` - The openssl Public key
 ///
 pub fn kmip_public_key_to_openssl(public_key: &Object) -> Result<PKey<Public>, KmipError> {
-    trace!("kmip_public_key_to_openssl: {:?}", public_key);
+    trace!("kmip_public_key_to_openssl: {}", public_key);
     let key_block = match public_key {
         Object::PublicKey { key_block } => key_block,
-        x => kmip_bail!("Invalid Object: {:?}. KMIP Public Key expected", x),
+        x => kmip_bail!("Invalid Object: {}. KMIP Public Key expected", x),
     };
     // Convert the key to the default storage format: SPKI DER (RFC 5480)
     let pk: PKey<Public> = match key_block.key_format_type {
@@ -87,7 +87,7 @@ pub fn kmip_public_key_to_openssl(public_key: &Object) -> Result<PKey<Public>, K
             }
             invalid_key_material => kmip_bail!(
                 "Invalid Transparent RSA public key material: expected TransparentRSAPublicKey \
-                 but got: {:?} ",
+                 but got: {} ",
                 invalid_key_material
             ),
         },

--- a/crate/pkcs11/provider/src/kms_object.rs
+++ b/crate/pkcs11/provider/src/kms_object.rs
@@ -8,14 +8,13 @@ use cosmian_kmip::kmip::{
 };
 use cosmian_kms_client::{batch_export_objects, ClientConf, ExportObjectParams, KmsClient};
 use cosmian_pkcs11_module::traits::EncryptionAlgorithm;
-use tracing::{debug, trace};
+use tracing::debug;
 use zeroize::Zeroizing;
 
 use crate::error::Pkcs11Error;
 
 /// A wrapper around a KMS KMIP object.
 #[allow(dead_code)]
-#[derive(Debug)]
 pub(crate) struct KmsObject {
     pub object: Object,
     pub attributes: Attributes,
@@ -72,10 +71,9 @@ pub(crate) async fn get_kms_objects_async(
         },
     )
     .await?;
-    trace!("Found objects: {:?}", responses);
+    // trace!("Found objects: {}", responses);
     let mut results = vec![];
-    for response in responses {
-        let (object, attributes) = response.map_err(Pkcs11Error::ServerError)?;
+    for (object, attributes) in responses {
         let other_tags = attributes
             .get_tags()
             .into_iter()

--- a/crate/pkcs11/provider/src/pkcs11_certificate.rs
+++ b/crate/pkcs11/provider/src/pkcs11_certificate.rs
@@ -37,7 +37,7 @@ impl TryFrom<KmsObject> for Pkcs11Certificate {
                 )),
             },
             o => Err(Pkcs11Error::ServerError(format!(
-                "Invalid KMS Object for a certificate: {o:?}"
+                "Invalid KMS Object for a certificate: {o}"
             ))),
         }
     }

--- a/crate/pkcs11/provider/src/tests.rs
+++ b/crate/pkcs11/provider/src/tests.rs
@@ -9,6 +9,7 @@ use cosmian_kmip::{
 use cosmian_kms_client::{import_object, KmsClient};
 use cosmian_pkcs11_module::traits::Backend;
 use kms_test_server::start_default_test_kms_server;
+use tracing::debug;
 
 use crate::{backend::CkmsBackend, error::Pkcs11Error, kms_object::get_kms_objects_async};
 
@@ -59,6 +60,7 @@ fn initialize_backend() -> Result<CkmsBackend, Pkcs11Error> {
 
 async fn create_keys(kms_client: &KmsClient) -> Result<(), Pkcs11Error> {
     let vol1 = create_symmetric_key_kmip_object(&[1, 2, 3, 4], CryptographicAlgorithm::AES)?;
+    debug!("vol1: {}", vol1);
     let _vol1_id = import_object(
         kms_client,
         Some("vol1".to_owned()),

--- a/crate/server/src/core/operations/certify/mod.rs
+++ b/crate/server/src/core/operations/certify/mod.rs
@@ -105,7 +105,7 @@ pub(crate) async fn certify(
         Subject::PublicKeyAndSubjectName(unique_identifier, from_public_key, _) => {
             trace!(
                 "Certify PublicKeyAndSubjectName:{unique_identifier} : public key: \
-                 {from_public_key:?}"
+                 {from_public_key}"
             );
             // update the public key attributes with a link to the certificate
             let mut public_key_attributes = from_public_key.attributes;
@@ -146,8 +146,7 @@ pub(crate) async fn certify(
         }
         Subject::KeypairAndSubjectName(unique_identifier, mut keypair_data, _) => {
             trace!(
-                "Certify KeypairAndSubjectName:{unique_identifier} : keypair data: \
-                 {keypair_data:?}"
+                "Certify KeypairAndSubjectName:{unique_identifier} : keypair data: {keypair_data}"
             );
             // update the private key attributes with the public key identifier
             keypair_data.private_key_object.attributes_mut()?.set_link(

--- a/crate/server/src/core/operations/certify/subject.rs
+++ b/crate/server/src/core/operations/certify/subject.rs
@@ -1,4 +1,7 @@
-use std::collections::HashSet;
+use std::{
+    collections::HashSet,
+    fmt::{self, Display, Formatter},
+};
 
 use cosmian_kmip::{
     kmip::{
@@ -15,7 +18,6 @@ use openssl::{
 use crate::{database::object_with_metadata::ObjectWithMetadata, kms_error, result::KResult};
 
 /// This holds `KeyPair` information when one is created for the subject
-#[derive(Debug)]
 pub(crate) struct KeyPairData {
     pub(crate) private_key_id: UniqueIdentifier,
     pub(crate) private_key_object: Object,
@@ -23,6 +25,22 @@ pub(crate) struct KeyPairData {
     pub(crate) public_key_id: UniqueIdentifier,
     pub(crate) public_key_object: Object,
     pub(crate) public_key_tags: HashSet<String>,
+}
+
+impl Display for KeyPairData {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "KeyPairData {{ private_key_id: {}, private_key_object: {}, private_key_tags: {:?}, \
+             public_key_id: {}, public_key_object: {}, public_key_tags: {:?} }}",
+            self.private_key_id,
+            self.private_key_object,
+            self.private_key_tags,
+            self.public_key_id,
+            self.public_key_object,
+            self.public_key_tags
+        )
+    }
 }
 
 /// The party that gets signed by the issuer and gets the certificate

--- a/crate/server/src/core/operations/decrypt.rs
+++ b/crate/server/src/core/operations/decrypt.rs
@@ -123,7 +123,7 @@ async fn get_key(
             true
         })
         .collect::<Vec<ObjectWithMetadata>>();
-    trace!("get_key: owm_s: {:?}", owm_s);
+    trace!("get_key: owm_s: number of results: {}", owm_s.len());
 
     // there can only be one key
     let mut owm = owm_s.pop().ok_or_else(|| {

--- a/crate/server/src/core/operations/destroy.rs
+++ b/crate/server/src/core/operations/destroy.rs
@@ -181,7 +181,7 @@ async fn destroy_key_core(
     };
 
     // the KMIP specs mandates that e KeyMaterial be destroyed
-    trace!("destroy: object: {object:?}");
+    trace!("destroy: object: {object}");
     let attributes = if let Object::Certificate { .. } = object {
         trace!("Certificate destroying");
         Attributes::default()

--- a/crate/server/src/core/operations/encrypt.rs
+++ b/crate/server/src/core/operations/encrypt.rs
@@ -180,7 +180,10 @@ async fn get_key(
         })
         .collect::<Vec<ObjectWithMetadata>>();
 
-    trace!("operations::encrypt: key owm_s: {:?}", owm_s);
+    trace!(
+        "operations::encrypt: key owm_s: number of results: {}",
+        owm_s.len()
+    );
     // there can only be one key
     let mut owm = owm_s
         .pop()

--- a/crate/server/src/core/operations/export_utils.rs
+++ b/crate/server/src/core/operations/export_utils.rs
@@ -581,7 +581,7 @@ async fn process_symmetric_key(
     params: Option<&ExtraDatabaseParams>,
 ) -> KResult<()> {
     trace!(
-        "process_symmetric_key: object_with_metadata: {:?}",
+        "process_symmetric_key: object_with_metadata: {}",
         object_with_metadata
     );
     let object_type = object_with_metadata.object.object_type();

--- a/crate/server/src/core/operations/import.rs
+++ b/crate/server/src/core/operations/import.rs
@@ -43,7 +43,7 @@ pub(crate) async fn import(
     owner: &str,
     params: Option<&ExtraDatabaseParams>,
 ) -> KResult<ImportResponse> {
-    trace!("Entering import KMIP operation: {:?}", request);
+    trace!("Entering import KMIP operation: {}", request);
     // Unique identifiers starting with `[` are reserved for queries on tags
     // see tagging
     // For instance, a request for unique identifier `[tag1]` will

--- a/crate/server/src/core/operations/locate.rs
+++ b/crate/server/src/core/operations/locate.rs
@@ -19,7 +19,7 @@ pub(crate) async fn locate(
     user: &str,
     params: Option<&ExtraDatabaseParams>,
 ) -> KResult<LocateResponse> {
-    trace!("Locate request: {:?}", request);
+    trace!("Locate request: {}", request);
     // Find all the objects that match the attributes
     let uids_attrs = kms
         .db

--- a/crate/server/src/core/operations/message.rs
+++ b/crate/server/src/core/operations/message.rs
@@ -25,7 +25,7 @@ pub(crate) async fn message(
     owner: &str,
     params: Option<&ExtraDatabaseParams>,
 ) -> KResult<MessageResponse> {
-    trace!("Entering message KMIP operation: {request:#?}");
+    trace!("Entering message KMIP operation: {request}");
 
     let mut response_items = Vec::new();
     for item_request in request.items {

--- a/crate/server/src/core/operations/validate.rs
+++ b/crate/server/src/core/operations/validate.rs
@@ -74,7 +74,7 @@ pub(crate) async fn validate_operation(
     user: &str,
     params: Option<&ExtraDatabaseParams>,
 ) -> KResult<ValidateResponse> {
-    trace!("Validate: {:?}", request);
+    trace!("Validate: {}", request);
 
     debug!("Get input certificates as bytes");
     let (certificates, certificates_number) = match (request.unique_identifier, request.certificate)

--- a/crate/server/src/database/database_trait.rs
+++ b/crate/server/src/database/database_trait.rs
@@ -185,7 +185,6 @@ pub(crate) trait Database {
 }
 
 /// An atomic operation on the database
-#[derive(Debug)]
 #[allow(dead_code)]
 pub(crate) enum AtomicOperation {
     /// Create (uid, object, attributes, tags) - the state will be active

--- a/crate/server/src/database/mod.rs
+++ b/crate/server/src/database/mod.rs
@@ -83,7 +83,7 @@ lazy_static! {
 /// When using JSON serialization, the Object is untagged
 /// and looses its type information, so we have to keep
 /// the `ObjectType`. See `Object` and `post_fix()` for details
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize)]
 pub(crate) struct DBObject {
     pub(crate) object_type: ObjectType,
     pub(crate) object: Object,

--- a/crate/server/src/database/object_with_metadata.rs
+++ b/crate/server/src/database/object_with_metadata.rs
@@ -1,3 +1,5 @@
+use std::fmt::{self, Display, Formatter};
+
 use cosmian_kmip::kmip::{
     kmip_objects::Object,
     kmip_operations::ErrorReason,
@@ -12,7 +14,7 @@ use super::{state_from_string, DBObject};
 use crate::{error::KmsError, result::KResultHelper};
 
 /// An object with its metadata such as permissions and state
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Serialize)]
 pub(crate) struct ObjectWithMetadata {
     pub(crate) id: String,
     pub(crate) object: Object,
@@ -20,6 +22,17 @@ pub(crate) struct ObjectWithMetadata {
     pub(crate) state: StateEnumeration,
     pub(crate) permissions: Vec<ObjectOperationType>,
     pub(crate) attributes: Attributes,
+}
+
+impl Display for ObjectWithMetadata {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "ObjectWithMetadata {{ id: {}, object: {}, owner: {}, state: {}, permissions: {:?}, \
+             attributes: {:?} }}",
+            self.id, self.object, self.owner, self.state, self.permissions, self.attributes
+        )
+    }
 }
 
 impl TryFrom<&PgRow> for ObjectWithMetadata {

--- a/crate/server/src/database/redis/objects_db.rs
+++ b/crate/server/src/database/redis/objects_db.rs
@@ -48,7 +48,7 @@ pub(crate) fn keywords_from_attributes(attributes: &Attributes) -> HashSet<Keywo
     keywords
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub(crate) struct RedisDbObject {
     #[serde(rename = "o")]
     pub(crate) object: Object,

--- a/crate/server/src/database/redis/redis_with_findex.rs
+++ b/crate/server/src/database/redis/redis_with_findex.rs
@@ -582,7 +582,6 @@ impl Database for RedisWithFindex {
 
         // fetch the corresponding objects
         let redis_db_objects = self.objects_db.objects_get(&uids).await?;
-        trace!("find: redis_db_objects: {:?}", redis_db_objects);
         Ok(redis_db_objects
             .into_iter()
             .filter(|(uid, redis_db_object)| {

--- a/crate/server/src/database/sqlite.rs
+++ b/crate/server/src/database/sqlite.rs
@@ -617,7 +617,7 @@ pub(crate) async fn upsert_(
     executor: &mut Transaction<'_, Sqlite>,
 ) -> KResult<()> {
     trace!(
-        "Upserting in DB: {uid}\n   object: {object:?}\n   attributes: {attributes:?}\n    tags: \
+        "Upserting in DB: {uid}\n   object: {object}\n   attributes: {attributes:?}\n    tags: \
          {tags:?}\n    state: {state:?}\n    owner: {owner}"
     );
     let object_json = serde_json::to_value(DBObject {

--- a/crate/server/src/database/tests/database_tests.rs
+++ b/crate/server/src/database/tests/database_tests.rs
@@ -269,7 +269,7 @@ pub(crate) async fn upsert<DB: Database>(
     match objs_.len() {
         1 => {
             assert_eq!(StateEnumeration::Active, objs_[0].state);
-            assert_eq!(&symmetric_key, &objs_[0].object);
+            assert!(symmetric_key == objs_[0].object);
         }
         _ => kms_bail!("There should be only one object"),
     }
@@ -381,7 +381,7 @@ pub(crate) async fn crud<DB: Database>(
     match objs_.len() {
         1 => {
             assert_eq!(StateEnumeration::Active, objs_[0].state);
-            assert_eq!(&symmetric_key, &objs_[0].object);
+            assert!(symmetric_key == objs_[0].object);
         }
         _ => kms_bail!("There should be only one object. Found {}", objs_.len()),
     }
@@ -437,7 +437,7 @@ pub(crate) async fn crud<DB: Database>(
     match objs_.len() {
         1 => {
             assert_eq!(StateEnumeration::Deactivated, objs_[0].state);
-            assert_eq!(&symmetric_key, &objs_[0].object);
+            assert!(symmetric_key == objs_[0].object);
         }
         _ => kms_bail!("There should be only one object"),
     }

--- a/crate/server/src/database/tests/find_attributes_test.rs
+++ b/crate/server/src/database/tests/find_attributes_test.rs
@@ -74,7 +74,7 @@ pub(crate) async fn find_attributes<DB: Database>(
     match objs_.len() {
         1 => {
             assert_eq!(StateEnumeration::Active, objs_[0].state);
-            assert_eq!(&symmetric_key, &objs_[0].object);
+            assert!(symmetric_key == objs_[0].object);
             assert_eq!(
                 objs_[0].object.attributes()?.link.as_ref().unwrap()[0].linked_object_identifier,
                 LinkedObjectIdentifier::TextString("foo".to_owned())

--- a/crate/server/src/database/tests/json_access_test.rs
+++ b/crate/server/src/database/tests/json_access_test.rs
@@ -66,7 +66,7 @@ pub(crate) async fn json_access<DB: Database>(
     match objs_.len() {
         1 => {
             assert_eq!(StateEnumeration::Active, objs_[0].state);
-            assert_eq!(&symmetric_key, &objs_[0].object);
+            assert!(symmetric_key == objs_[0].object);
         }
         _ => kms_bail!("There should be one object"),
     }

--- a/crate/server/src/database/tests/owner_test.rs
+++ b/crate/server/src/database/tests/owner_test.rs
@@ -61,7 +61,7 @@ pub(crate) async fn owner<DB: Database>(
         0 => kms_bail!("There should be an object"),
         1 => {
             assert_eq!(StateEnumeration::Active, objs_[0].state);
-            assert_eq!(&symmetric_key, &objs_[0].object);
+            assert!(symmetric_key == objs_[0].object);
         }
         _ => kms_bail!("There should be only one object"),
     }
@@ -106,7 +106,7 @@ pub(crate) async fn owner<DB: Database>(
         0 => kms_bail!("There should be an object"),
         1 => {
             assert_eq!(StateEnumeration::Active, objs_[0].state);
-            assert_eq!(&symmetric_key, &objs_[0].object);
+            assert!(symmetric_key == objs_[0].object);
         }
         _ => kms_bail!("There should be only one object"),
     }
@@ -172,7 +172,7 @@ pub(crate) async fn owner<DB: Database>(
         0 => kms_bail!("There should be an object"),
         1 => {
             assert_eq!(StateEnumeration::Active, objs_[0].state);
-            assert_eq!(&symmetric_key, &objs_[0].object);
+            assert!(symmetric_key == objs_[0].object);
         }
         _ => kms_bail!("There should be only one object"),
     }
@@ -188,7 +188,7 @@ pub(crate) async fn owner<DB: Database>(
         0 => kms_bail!("There should be an object"),
         1 => {
             assert_eq!(StateEnumeration::Active, objs_[0].state);
-            assert_eq!(&symmetric_key, &objs_[0].object);
+            assert!(symmetric_key == objs_[0].object);
         }
         _ => kms_bail!("There should be only one object"),
     }

--- a/crate/server/src/database/tests/tagging_tests.rs
+++ b/crate/server/src/database/tests/tagging_tests.rs
@@ -82,7 +82,7 @@ pub(crate) async fn tags<DB: Database>(
     assert_eq!(res.len(), 1);
     let owm = res[0].clone();
     assert_eq!(StateEnumeration::Active, owm.state);
-    assert_eq!(&symmetric_key, &owm.object);
+    assert!(symmetric_key == owm.object);
     let tags = db.retrieve_tags(&owm.id, db_params).await?;
     assert_eq!(tags.len(), 2);
     assert!(tags.contains("tag1"));

--- a/crate/server/src/lib.rs
+++ b/crate/server/src/lib.rs
@@ -40,6 +40,7 @@
     clippy::unseparated_literal_suffix,
     clippy::map_err_ignore,
     clippy::redundant_clone,
+    // clippy::use_debug,
 )]
 #![allow(
     clippy::module_name_repetitions,

--- a/crate/server/src/tests/cover_crypt_tests/integration_tests.rs
+++ b/crate/server/src/tests/cover_crypt_tests/integration_tests.rs
@@ -286,7 +286,7 @@ async fn integration_tests_use_ids_no_tags() -> KResult<()> {
         None,
     );
     let post_ttlv_decrypt: KResult<DecryptResponse> = test_utils::post(&app, &request).await;
-    post_ttlv_decrypt.unwrap_err();
+    assert!(post_ttlv_decrypt.is_err());
 
     // decrypt
     let request = build_decryption_request(
@@ -328,7 +328,7 @@ async fn integration_tests_use_ids_no_tags() -> KResult<()> {
         None,
     );
     let post_ttlv_decrypt: KResult<DecryptResponse> = test_utils::post(&app, &request).await;
-    post_ttlv_decrypt.unwrap_err();
+    assert!(post_ttlv_decrypt.is_err());
 
     //
     // Add new Attributes
@@ -428,7 +428,7 @@ async fn integration_tests_use_ids_no_tags() -> KResult<()> {
         }),
     )?;
     let encrypt_response: KResult<EncryptResponse> = test_utils::post(&app, &request).await;
-    encrypt_response.unwrap_err();
+    assert!(encrypt_response.is_err());
 
     //
     // Delete attribute
@@ -457,7 +457,7 @@ async fn integration_tests_use_ids_no_tags() -> KResult<()> {
         }),
     )?;
     let encrypt_response: KResult<EncryptResponse> = test_utils::post(&app, &request).await;
-    encrypt_response.unwrap_err();
+    assert!(encrypt_response.is_err());
 
     //
     // Destroy user decryption key

--- a/crate/server/src/tests/cover_crypt_tests/integration_tests_tags.rs
+++ b/crate/server/src/tests/cover_crypt_tests/integration_tests_tags.rs
@@ -303,7 +303,7 @@ async fn integration_tests_with_tags() -> KResult<()> {
         None,
     );
     let post_ttlv_decrypt: KResult<DecryptResponse> = test_utils::post(&app, &request).await;
-    post_ttlv_decrypt.unwrap_err();
+    assert!(post_ttlv_decrypt.is_err());
 
     // decrypt
     let request = build_decryption_request(

--- a/crate/server/src/tests/cover_crypt_tests/unit_tests.rs
+++ b/crate/server/src/tests/cover_crypt_tests/unit_tests.rs
@@ -215,7 +215,7 @@ async fn test_cover_crypt_keys() -> KResult<()> {
             kms_bail!("The object at uid: {usk_uid} is not a CC user decryption key");
         }
     };
-    debug!("ABE kms_uk: {:?}", recovered_kms_uk_key_block);
+    debug!("ABE kms_uk: {}", recovered_kms_uk_key_block);
 
     Ok(())
 }
@@ -312,7 +312,7 @@ async fn test_abe_encrypt_decrypt() -> KResult<()> {
             None,
         )
         .await;
-    er.unwrap_err();
+    assert!(er.is_err());
 
     // encrypt a resource FIN + Secret
     let secret_authentication_data = b"cc the uid secret".to_vec();
@@ -355,7 +355,7 @@ async fn test_abe_encrypt_decrypt() -> KResult<()> {
             None,
         )
         .await;
-    er.unwrap_err();
+    assert!(er.is_err());
 
     // Create a user decryption key MKG | FIN + secret
     let secret_mkg_fin_access_policy = "(Department::MKG || Department::FIN) && Level::secret";
@@ -416,7 +416,7 @@ async fn test_abe_encrypt_decrypt() -> KResult<()> {
             None,
         )
         .await;
-    dr.unwrap_err();
+    assert!(dr.is_err());
 
     // decrypt resource FIN + Secret
     let dr = kms
@@ -459,7 +459,7 @@ async fn test_abe_encrypt_decrypt() -> KResult<()> {
             None,
         )
         .await;
-    dr.unwrap_err();
+    assert!(dr.is_err());
 
     Ok(())
 }

--- a/crate/server/src/tests/google_cse/mod.rs
+++ b/crate/server/src/tests/google_cse/mod.rs
@@ -107,7 +107,7 @@ where
         object,
     };
 
-    tracing::debug!("import request: {import_request:?}");
+    tracing::debug!("import request: {import_request}");
     let response: ImportResponse = test_utils::post(app, import_request).await?;
     tracing::debug!("import response: {response:?}");
 

--- a/crate/server/src/tests/kmip_server_tests.rs
+++ b/crate/server/src/tests/kmip_server_tests.rs
@@ -245,9 +245,9 @@ async fn test_import_wrapped_symmetric_key() -> KResult<()> {
         object: symmetric_key,
     };
 
-    trace!("request: {:?}", request);
+    trace!("request: {}", request);
     let response = kms.import(request, owner, None).await?;
-    trace!("response: {:?}", response);
+    trace!("response: {}", response);
 
     Ok(())
 }
@@ -264,7 +264,7 @@ async fn test_create_transparent_symmetric_key() -> KResult<()> {
     let request =
         symmetric_key_create_request(256, CryptographicAlgorithm::AES, EMPTY_TAGS).unwrap();
 
-    trace!("request: {:?}", request);
+    trace!("request: {}", request);
     let response = kms.create(request, owner, None).await?;
     trace!("response: {:?}", response);
 
@@ -351,7 +351,7 @@ async fn test_database_user_tenant() -> KResult<()> {
             None,
         )
         .await;
-    sk_response.unwrap_err();
+    assert!(sk_response.is_err());
 
     let pk_response = kms
         .get(
@@ -365,7 +365,7 @@ async fn test_database_user_tenant() -> KResult<()> {
             None,
         )
         .await;
-    pk_response.unwrap_err();
+    assert!(pk_response.is_err());
 
     Ok(())
 }

--- a/crate/server/src/tests/test_validate.rs
+++ b/crate/server/src/tests/test_validate.rs
@@ -57,7 +57,7 @@ pub(crate) async fn test_validate_with_certificates_bytes() -> Result<(), KmsErr
         validity_time: None,
     };
     let res = kms.validate(request, owner, None).await;
-    res.unwrap_err();
+    assert!(res.is_err());
     debug!("OK: Validate root/intermediate/leaf1 certificates - invalid (revoked)");
     let request = Validate {
         certificate: Some(
@@ -88,14 +88,15 @@ pub(crate) async fn test_validate_with_certificates_bytes() -> Result<(), KmsErr
         Some("4804152030Z".to_owned())
     };
     let res = kms.validate(request, owner, None).await;
-    res.unwrap_err();
+    assert!(res.is_err());
     debug!("OK: Validate root/intermediate/leaf2 certificates - invalid");
     let request = Validate {
         certificate: Some([leaf2_cert.clone(), root_cert.clone()].to_vec()),
         unique_identifier: None,
         validity_time: None,
     };
-    kms.validate(request, owner, None).await.unwrap_err();
+    let res = kms.validate(request, owner, None).await;
+    assert!(res.is_err());
     debug!("OK: Validate root/leaf2 certificates - missing intermediate");
 
     Result::Ok(())
@@ -200,7 +201,7 @@ pub(crate) async fn test_validate_with_certificates_ids() -> Result<(), KmsError
         validity_time: None,
     };
     let res = kms.validate(request, owner, None).await;
-    res.unwrap_err();
+    assert!(res.is_err());
     debug!("OK: Validate root/intermediate/leaf1 certificates - invalid (revoked)");
 
     // No certificate in chain
@@ -210,7 +211,7 @@ pub(crate) async fn test_validate_with_certificates_ids() -> Result<(), KmsError
         validity_time: None,
     };
     let res = kms.validate(request, owner, None).await;
-    res.unwrap_err();
+    assert!(res.is_err());
 
     // Root and intermediate valid certificates. Leaf valid. Test returns valid.
     let request = Validate {
@@ -253,7 +254,7 @@ pub(crate) async fn test_validate_with_certificates_ids() -> Result<(), KmsError
         Some("4804152030Z".to_owned())
     };
     let res = kms.validate(request, owner, None).await;
-    res.unwrap_err();
+    assert!(res.is_err());
     debug!(
         "OK: Validate root/intermediate/leaf2 certificates - invalid (won't be valid in the \
          future)"
@@ -265,7 +266,8 @@ pub(crate) async fn test_validate_with_certificates_ids() -> Result<(), KmsError
         unique_identifier: Some(vec![res_root.unique_identifier.clone()]),
         validity_time: None,
     };
-    kms.validate(request, owner, None).await.unwrap_err();
+    let res = kms.validate(request, owner, None).await;
+    assert!(res.is_err());
 
     debug!("OK: Validate root/leaf2 certificates - invalid (missing intermediate)");
     // Root certificate not provided. Intermediate and leaf are valid certificates. Return is Invalid.
@@ -274,7 +276,8 @@ pub(crate) async fn test_validate_with_certificates_ids() -> Result<(), KmsError
         unique_identifier: Some([res_intermediate.unique_identifier.clone()].to_vec()),
         validity_time: None,
     };
-    kms.validate(request, owner, None).await.unwrap_err();
+    let res = kms.validate(request, owner, None).await;
+    assert!(res.is_err());
     debug!("OK: Validate root/leaf2 certificates - invalid (missing root)");
 
     Result::Ok(())


### PR DESCRIPTION
- make sure no key content can be displayed for logging purpose by replacing the `Debug` derive trait of KMIP `Object` (and other KMIP types) by a custom Display implementation
- replace log formatting `{:?}` with Display impl `{}`
- something seems to be wrong in `batch_operations` function: simplifying return type from `Result<Vec<Result<Operation, String>>, ClientError>` to `Result<Vec<Operation>, ClientError>`
