### PR TITLE
Guard on size of ciphertexts for BulkData

### DIFF
--- a/crate/kmip/src/crypto/wrap/unwrap_key.rs
+++ b/crate/kmip/src/crypto/wrap/unwrap_key.rs
@@ -160,6 +160,9 @@ pub(crate) fn unwrap(
             if block_cipher_mode == Some(BlockCipherMode::GCM) {
                 // unwrap using aes Gcm
                 let len = ciphertext.len();
+                if len < TAG_LENGTH + NONCE_LENGTH {
+                    kmip_bail!("Invalid wrapped key - insufficient length.");
+                }
                 let aead = SymCipher::Aes256Gcm;
                 let nonce = &ciphertext[..NONCE_LENGTH];
                 let wrapped_key_bytes = &ciphertext[NONCE_LENGTH..len - TAG_LENGTH];


### PR DESCRIPTION
Lack of guard on ciphertext size may get KMS server panicking

```
Oct 10 16:21:00 kms-snowflake-test.europe-west4-a.c.cosmian-public.internal cosmian_kms[236300]: thread 'actix-server worker 5' panicked at crate/server/src/core/operations/decrypt.rs:197:21:
Oct 10 16:21:00 kms-snowflake-test.europe-west4-a.c.cosmian-public.internal cosmian_kms[236300]: slice index starts at 12 but ends at 3
Oct 10 16:21:00 kms-snowflake-test.europe-west4-a.c.cosmian-public.internal cosmian_kms[236300]: stack backtrace:
Oct 10 16:21:00 kms-snowflake-test.europe-west4-a.c.cosmian-public.internal cosmian_kms[236300]:    0:     0x56ca9a69175a - <unknown>
Oct 10 16:21:00 kms-snowflake-test.europe-west4-a.c.cosmian-public.internal cosmian_kms[236300]:    1:     0x56ca999fefab - <unknown>
```