### PR TITLE
feat: make keys non revokable

### DIFF
--- a/crate/cli/src/actions/symmetric/keys/create_key.rs
+++ b/crate/cli/src/actions/symmetric/keys/create_key.rs
@@ -80,7 +80,7 @@ pub struct CreateKeyAction {
 
     /// The unique id of the key; a random uuid
     /// is generated if not specified.
-    #[clap(long, required = false)]
+    #[clap(required = false)]
     pub(crate) key_id: Option<String>,
 }
 

--- a/crate/cli/src/actions/symmetric/keys/create_key.rs
+++ b/crate/cli/src/actions/symmetric/keys/create_key.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use base64::{engine::general_purpose, Engine as _};
 use clap::{Parser, ValueEnum};
 use cosmian_kms_client::{
@@ -16,13 +18,26 @@ use crate::{
     error::result::{CliResult, CliResultHelper},
 };
 
-#[derive(ValueEnum, Debug, Clone, Copy)]
+#[derive(ValueEnum, Debug, Clone, Copy, Default)]
 pub(crate) enum SymmetricAlgorithm {
     #[cfg(not(feature = "fips"))]
     Chacha20,
+    #[default]
     Aes,
     Sha3,
     Shake,
+}
+
+impl Display for SymmetricAlgorithm {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            #[cfg(not(feature = "fips"))]
+            Self::Chacha20 => write!(f, "chacha20"),
+            Self::Aes => write!(f, "aes"),
+            Self::Sha3 => write!(f, "sha3"),
+            Self::Shake => write!(f, "shake"),
+        }
+    }
 }
 
 /// Create a new symmetric key
@@ -33,7 +48,7 @@ pub(crate) enum SymmetricAlgorithm {
 /// If no options are specified, a fresh 256-bit AES key will be created.
 ///
 /// Tags can later be used to retrieve the key. Tags are optional.
-#[derive(Parser)]
+#[derive(Parser, Default)]
 #[clap(verbatim_doc_comment)]
 pub struct CreateKeyAction {
     /// The length of the generated random key or salt in bits.
@@ -43,11 +58,11 @@ pub struct CreateKeyAction {
         group = "key",
         default_value = "256"
     )]
-    number_of_bits: Option<usize>,
+    pub(crate) number_of_bits: Option<usize>,
 
     /// The symmetric key bytes or salt as a base 64 string
     #[clap(long = "bytes-b64", short = 'k', required = false, group = "key")]
-    wrap_key_b64: Option<String>,
+    pub(crate) wrap_key_b64: Option<String>,
 
     /// The algorithm
     #[clap(
@@ -56,17 +71,17 @@ pub struct CreateKeyAction {
         required = false,
         default_value = "aes"
     )]
-    algorithm: SymmetricAlgorithm,
+    pub(crate) algorithm: SymmetricAlgorithm,
 
     /// The tag to associate with the key.
     /// To specify multiple tags, use the option multiple times.
     #[clap(long = "tag", short = 't', value_name = "TAG")]
-    tags: Vec<String>,
+    pub(crate) tags: Vec<String>,
 
     /// The unique id of the key; a random uuid
     /// is generated if not specified.
-    #[clap(required = false)]
-    key_id: Option<String>,
+    #[clap(long, required = false)]
+    pub(crate) key_id: Option<String>,
 }
 
 impl CreateKeyAction {

--- a/crate/cli/src/actions/symmetric/keys/mod.rs
+++ b/crate/cli/src/actions/symmetric/keys/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     error::result::CliResult,
 };
 
-mod create_key;
+pub(crate) mod create_key;
 mod destroy_key;
 mod rekey;
 mod revoke_key;

--- a/crate/cli/src/actions/symmetric/mod.rs
+++ b/crate/cli/src/actions/symmetric/mod.rs
@@ -9,7 +9,7 @@ use crate::error::result::CliResult;
 
 mod decrypt;
 mod encrypt;
-mod keys;
+pub(crate) mod keys;
 
 /// Manage symmetric keys. Encrypt and decrypt data.
 #[derive(Parser)]

--- a/crate/cli/src/tests/access.rs
+++ b/crate/cli/src/tests/access.rs
@@ -7,7 +7,7 @@ use tracing::trace;
 
 use super::{symmetric::create_key::create_symmetric_key, utils::recover_cmd_logs};
 use crate::{
-    actions::symmetric::DataEncryptionAlgorithm,
+    actions::symmetric::{keys::create_key::CreateKeyAction, DataEncryptionAlgorithm},
     error::{result::CliResult, CliError},
     tests::{
         shared::{destroy, export_key, revoke, ExportKeyParams},
@@ -20,7 +20,7 @@ pub(crate) const SUB_COMMAND: &str = "access-rights";
 
 /// Generates a symmetric key
 fn gen_key(cli_conf_path: &str) -> CliResult<String> {
-    create_symmetric_key(cli_conf_path, None, None, None, &[])
+    create_symmetric_key(cli_conf_path, CreateKeyAction::default())
 }
 
 /// Grants access to a user

--- a/crate/cli/src/tests/attributes/test_set_attribute.rs
+++ b/crate/cli/src/tests/attributes/test_set_attribute.rs
@@ -11,6 +11,7 @@ use crate::{
         attributes::{SetOrDeleteAttributes, VendorAttributeCli},
         certificates::Algorithm,
         shared::utils::{build_usage_mask_from_key_usage, KeyUsage},
+        symmetric::keys::create_key::CreateKeyAction,
     },
     error::result::CliResult,
     tests::{
@@ -319,7 +320,7 @@ async fn test_set_attribute_ckms() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
 
     // AES 256 bit key
-    let uid = create_symmetric_key(&ctx.owner_client_conf_path, None, None, None, &[])?;
+    let uid = create_symmetric_key(&ctx.owner_client_conf_path, CreateKeyAction::default())?;
     check_set_delete_attributes(&uid, ctx)?;
 
     // Certify the CSR without issuer i.e. self signed

--- a/crate/cli/src/tests/auth_tests.rs
+++ b/crate/cli/src/tests/auth_tests.rs
@@ -13,6 +13,7 @@ use tracing::{info, trace};
 
 use super::utils::recover_cmd_logs;
 use crate::{
+    actions::symmetric::keys::create_key::CreateKeyAction,
     error::result::CliResult,
     tests::{
         access::SUB_COMMAND,
@@ -33,7 +34,8 @@ fn run_owned_cli_command(owner_client_conf_path: &str) {
 
 fn create_api_token(ctx: &TestsContext) -> CliResult<(String, String)> {
     // Create and export an API token
-    let api_token_id = create_symmetric_key(&ctx.owner_client_conf_path, None, None, None, &[])?;
+    let api_token_id =
+        create_symmetric_key(&ctx.owner_client_conf_path, CreateKeyAction::default())?;
     trace!("Symmetric key created of unique identifier: {api_token_id:?}");
 
     // Export as default (JsonTTLV with Raw Key Format Type)
@@ -80,6 +82,7 @@ pub(crate) async fn test_all_authentications() -> CliResult<()> {
             api_token_id: None,
             api_token: None,
         },
+        None,
     )
     .await?;
     run_owned_cli_command(&ctx.owner_client_conf_path);
@@ -106,6 +109,7 @@ pub(crate) async fn test_all_authentications() -> CliResult<()> {
             api_token_id: None,
             api_token: None,
         },
+        None,
     )
     .await?;
     run_owned_cli_command(&ctx.owner_client_conf_path);
@@ -123,6 +127,7 @@ pub(crate) async fn test_all_authentications() -> CliResult<()> {
             api_token_id: None,
             api_token: None,
         },
+        None,
     )
     .await?;
     run_owned_cli_command(&ctx.owner_client_conf_path);
@@ -140,6 +145,7 @@ pub(crate) async fn test_all_authentications() -> CliResult<()> {
             api_token_id: Some("my_bad_token_id".to_owned()),
             api_token: Some("my_bad_token".to_owned()),
         },
+        None,
     )
     .await?;
     run_owned_cli_command(&ctx.owner_client_conf_path);
@@ -157,6 +163,7 @@ pub(crate) async fn test_all_authentications() -> CliResult<()> {
             api_token_id: Some(api_token_id),
             api_token: Some(api_token),
         },
+        None,
     )
     .await?;
     run_owned_cli_command(&ctx.owner_client_conf_path);
@@ -179,6 +186,7 @@ pub(crate) async fn test_all_authentications() -> CliResult<()> {
                 api_token_id: None,
                 api_token: None,
             },
+            None,
         )
         .await?;
         run_owned_cli_command(&ctx.owner_client_conf_path);
@@ -196,6 +204,7 @@ pub(crate) async fn test_all_authentications() -> CliResult<()> {
                 api_token_id: Some("my_bad_token_id".to_string()),
                 api_token: Some("my_bad_token".to_string()),
             },
+            None,
         )
         .await?;
         run_owned_cli_command(&ctx.owner_client_conf_path);
@@ -216,6 +225,7 @@ pub(crate) async fn test_all_authentications() -> CliResult<()> {
                 api_token_id: Some("my_bad_token_id".to_string()),
                 api_token: Some("my_bad_token".to_string()),
             },
+            None,
         )
         .await?;
         run_owned_cli_command(&ctx.owner_client_conf_path);

--- a/crate/cli/src/tests/cover_crypt/rekey.rs
+++ b/crate/cli/src/tests/cover_crypt/rekey.rs
@@ -6,7 +6,7 @@ use kms_test_server::start_default_test_kms_server;
 use tempfile::TempDir;
 
 use crate::{
-    actions::shared::utils::KeyUsage,
+    actions::{shared::utils::KeyUsage, symmetric::keys::create_key::CreateKeyAction},
     error::{result::CliResult, CliError},
     tests::{
         cover_crypt::{
@@ -123,7 +123,7 @@ async fn test_rekey_error() -> CliResult<()> {
     let tmp_path = tmp_dir.path();
     // create a symmetric key
     let symmetric_key_id =
-        create_symmetric_key(&ctx.owner_client_conf_path, None, None, None, &[])?;
+        create_symmetric_key(&ctx.owner_client_conf_path, CreateKeyAction::default())?;
     // export a wrapped key
     let exported_wrapped_key_file = tmp_path.join("exported_wrapped_master_private.key");
     export_key(ExportKeyParams {

--- a/crate/cli/src/tests/new_database.rs
+++ b/crate/cli/src/tests/new_database.rs
@@ -12,6 +12,7 @@ use tempfile::TempDir;
 use tracing::info;
 
 use crate::{
+    actions::symmetric::keys::create_key::CreateKeyAction,
     error::result::CliResult,
     tests::{
         shared::{export_key, ExportKeyParams},
@@ -134,11 +135,12 @@ async fn test_multiple_databases() -> CliResult<()> {
             api_token_id: None,
             api_token: None,
         },
+        None,
     )
     .await?;
 
     // create a symmetric key in the default encrypted database
-    let key_1 = create_symmetric_key(&ctx.owner_client_conf_path, None, None, None, &[])?;
+    let key_1 = create_symmetric_key(&ctx.owner_client_conf_path, CreateKeyAction::default())?;
     // export the key 1
     // Export
     export_key(ExportKeyParams {
@@ -163,7 +165,7 @@ async fn test_multiple_databases() -> CliResult<()> {
         .expect("Can't write the new conf");
 
     // create a symmetric key in the default encrypted database
-    let key_2 = create_symmetric_key(&ctx.owner_client_conf_path, None, None, None, &[])?;
+    let key_2 = create_symmetric_key(&ctx.owner_client_conf_path, CreateKeyAction::default())?;
     // export the key 1
     // Export
     export_key(ExportKeyParams {

--- a/crate/cli/src/tests/shared/destroy.rs
+++ b/crate/cli/src/tests/shared/destroy.rs
@@ -11,6 +11,7 @@ use crate::tests::cover_crypt::{
     master_key_pair::create_cc_master_key_pair, user_decryption_keys::create_user_decryption_key,
 };
 use crate::{
+    actions::symmetric::keys::create_key::CreateKeyAction,
     cli_bail,
     error::{result::CliResult, CliError},
     tests::{
@@ -87,7 +88,7 @@ async fn test_destroy_symmetric_key() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
 
     // syn
-    let key_id = create_symmetric_key(&ctx.owner_client_conf_path, None, None, None, &[])?;
+    let key_id = create_symmetric_key(&ctx.owner_client_conf_path, CreateKeyAction::default())?;
 
     // destroy should not work when not revoked
     assert!(destroy(&ctx.owner_client_conf_path, "sym", &key_id).is_err());

--- a/crate/cli/src/tests/shared/export.rs
+++ b/crate/cli/src/tests/shared/export.rs
@@ -29,7 +29,7 @@ use crate::tests::cover_crypt::{
 #[cfg(not(feature = "fips"))]
 use crate::tests::elliptic_curve::create_key_pair::create_ec_key_pair;
 use crate::{
-    actions::shared::ExportKeyFormat,
+    actions::{shared::ExportKeyFormat, symmetric::keys::create_key::CreateKeyAction},
     error::{result::CliResult, CliError},
     tests::{
         rsa::create_key_pair::create_rsa_4096_bits_key_pair,
@@ -119,7 +119,7 @@ pub(crate) async fn test_export_sym() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
 
     // generate a symmetric key
-    let key_id = create_symmetric_key(&ctx.owner_client_conf_path, None, None, None, &[])?;
+    let key_id = create_symmetric_key(&ctx.owner_client_conf_path, CreateKeyAction::default())?;
 
     // Export as default (JsonTTLV with Raw Key Format Type)
     export_key(ExportKeyParams {
@@ -181,7 +181,7 @@ pub(crate) async fn test_export_sym_allow_revoked() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
 
     // generate a symmetric key
-    let key_id = create_symmetric_key(&ctx.owner_client_conf_path, None, None, None, &[])?;
+    let key_id = create_symmetric_key(&ctx.owner_client_conf_path, CreateKeyAction::default())?;
     // Export
     export_key(ExportKeyParams {
         cli_conf_path: ctx.owner_client_conf_path.clone(),
@@ -207,7 +207,7 @@ pub(crate) async fn test_export_wrapped() -> CliResult<()> {
         create_rsa_4096_bits_key_pair(&ctx.owner_client_conf_path, &[])?;
 
     // generate a symmetric key
-    let sym_key_id = create_symmetric_key(&ctx.owner_client_conf_path, None, None, None, &[])?;
+    let sym_key_id = create_symmetric_key(&ctx.owner_client_conf_path, CreateKeyAction::default())?;
 
     // Export wrapped key with symmetric key as default (JsonTTLV with Raw Key Format Type)
     export_key(ExportKeyParams {

--- a/crate/cli/src/tests/shared/export_import.rs
+++ b/crate/cli/src/tests/shared/export_import.rs
@@ -4,6 +4,7 @@ use tempfile::TempDir;
 use tracing::{debug, trace};
 
 use crate::{
+    actions::symmetric::keys::create_key::CreateKeyAction,
     error::result::CliResult,
     tests::{
         shared::{export_key, import_key, ExportKeyParams, ImportKeyParams},
@@ -23,9 +24,9 @@ pub(crate) async fn test_wrap_export_import() -> CliResult<()> {
     let key_file = wrap_key_path.to_str().unwrap().to_string();
 
     let sym_wrapping_key_id =
-        create_symmetric_key(&ctx.owner_client_conf_path, None, None, None, &[])?;
+        create_symmetric_key(&ctx.owner_client_conf_path, CreateKeyAction::default())?;
 
-    let key_id = create_symmetric_key(&ctx.owner_client_conf_path, None, None, None, &[])?;
+    let key_id = create_symmetric_key(&ctx.owner_client_conf_path, CreateKeyAction::default())?;
 
     // Export and import the key with different block cipher modes
     for block_cipher_mode in [BlockCipherMode::GCM, BlockCipherMode::NISTKeyWrap] {

--- a/crate/cli/src/tests/shared/import.rs
+++ b/crate/cli/src/tests/shared/import.rs
@@ -144,6 +144,8 @@ pub(crate) async fn test_import_cover_crypt() -> CliResult<()> {
 #[cfg(not(feature = "fips"))]
 #[tokio::test]
 pub(crate) async fn test_generate_export_import() -> CliResult<()> {
+    use crate::actions::symmetric::keys::create_key::CreateKeyAction;
+
     cosmian_logger::log_utils::log_init(Some("cosmian_kms_server=debug,cosmian_kms_utils=debug"));
     let ctx = start_default_test_kms_server().await;
 
@@ -172,7 +174,7 @@ pub(crate) async fn test_generate_export_import() -> CliResult<()> {
     )?;
 
     // generate a symmetric key
-    let key_id = create_symmetric_key(&ctx.owner_client_conf_path, None, None, None, &[])?;
+    let key_id = create_symmetric_key(&ctx.owner_client_conf_path, CreateKeyAction::default())?;
     export_import_test(
         &ctx.owner_client_conf_path,
         "sym",

--- a/crate/cli/src/tests/shared/import_export_wrapping.rs
+++ b/crate/cli/src/tests/shared/import_export_wrapping.rs
@@ -15,7 +15,6 @@ use cosmian_kms_client::{
             },
         },
     },
-    kmip::extra::tagging::EMPTY_TAGS,
     read_object_from_json_ttlv_file, write_kmip_object_to_file,
 };
 use kms_test_server::start_default_test_kms_server;
@@ -24,13 +23,13 @@ use tracing::{debug, trace};
 
 use super::ExportKeyParams;
 use crate::{
-    actions::shared::utils::KeyUsage,
+    actions::{shared::utils::KeyUsage, symmetric::keys::create_key::CreateKeyAction},
     error::result::CliResult,
     tests::{
         cover_crypt::master_key_pair::create_cc_master_key_pair,
         elliptic_curve,
         shared::{export::export_key, import::import_key, ImportKeyParams},
-        symmetric,
+        symmetric::create_key::create_symmetric_key,
     },
 };
 
@@ -88,13 +87,7 @@ pub(crate) async fn test_import_export_wrap_rfc_5649() -> CliResult<()> {
     )?;
 
     // test sym
-    let key_id = symmetric::create_key::create_symmetric_key(
-        &ctx.owner_client_conf_path,
-        None,
-        None,
-        None,
-        &EMPTY_TAGS,
-    )?;
+    let key_id = create_symmetric_key(&ctx.owner_client_conf_path, CreateKeyAction::default())?;
     test_import_export_wrap_private_key(
         &ctx.owner_client_conf_path,
         "sym",
@@ -178,13 +171,7 @@ pub(crate) async fn test_import_export_wrap_ecies() -> CliResult<()> {
     )?;
 
     debug!("testing symmetric keys");
-    let key_id = symmetric::create_key::create_symmetric_key(
-        &ctx.owner_client_conf_path,
-        None,
-        None,
-        None,
-        &EMPTY_TAGS,
-    )?;
+    let key_id = create_symmetric_key(&ctx.owner_client_conf_path, CreateKeyAction::default())?;
     test_import_export_wrap_private_key(
         &ctx.owner_client_conf_path,
         "sym",

--- a/crate/cli/src/tests/shared/locate.rs
+++ b/crate/cli/src/tests/shared/locate.rs
@@ -13,6 +13,7 @@ use crate::tests::{
     },
 };
 use crate::{
+    actions::symmetric::keys::create_key::CreateKeyAction,
     error::{result::CliResult, CliError},
     tests::{
         elliptic_curve::create_key_pair::create_ec_key_pair,
@@ -305,8 +306,13 @@ pub(crate) async fn test_locate_symmetric_key() -> CliResult<()> {
     let ctx = start_default_test_kms_server_with_cert_auth().await;
 
     // generate a new key
-    let key_id =
-        create_symmetric_key(&ctx.owner_client_conf_path, None, None, None, &["test_sym"])?;
+    let key_id = create_symmetric_key(
+        &ctx.owner_client_conf_path,
+        CreateKeyAction {
+            tags: vec!["test_sym".to_string()],
+            ..Default::default()
+        },
+    )?;
 
     // Locate with Tags
     let ids = locate(

--- a/crate/cli/src/tests/shared/wrap_unwrap.rs
+++ b/crate/cli/src/tests/shared/wrap_unwrap.rs
@@ -19,6 +19,7 @@ use tempfile::TempDir;
 
 use super::ExportKeyParams;
 use crate::{
+    actions::symmetric::keys::create_key::CreateKeyAction,
     error::{result::CliResult, CliError},
     tests::{
         cover_crypt::master_key_pair::create_cc_master_key_pair,
@@ -149,7 +150,7 @@ pub(crate) async fn test_password_wrap_import() -> CliResult<()> {
     password_wrap_import_test(ctx, "ec", &private_key_id)?;
 
     // sym
-    let key_id = create_symmetric_key(&ctx.owner_client_conf_path, None, None, None, &[])?;
+    let key_id = create_symmetric_key(&ctx.owner_client_conf_path, CreateKeyAction::default())?;
     password_wrap_import_test(ctx, "sym", &key_id)?;
 
     Ok(())

--- a/crate/cli/src/tests/symmetric/create_key.rs
+++ b/crate/cli/src/tests/symmetric/create_key.rs
@@ -6,11 +6,12 @@ use cloudproof::reexport::crypto_core::{
     reexport::rand_core::{RngCore, SeedableRng},
     CsRng,
 };
-use cosmian_kms_client::{kmip::extra::tagging::EMPTY_TAGS, KMS_CLI_CONF_ENV};
+use cosmian_kms_client::KMS_CLI_CONF_ENV;
 use kms_test_server::start_default_test_kms_server;
 
 use super::SUB_COMMAND;
 use crate::{
+    actions::symmetric::keys::create_key::{CreateKeyAction, SymmetricAlgorithm},
     error::{result::CliResult, CliError},
     tests::{
         utils::{extract_uids::extract_uid, recover_cmd_logs},
@@ -21,29 +22,28 @@ use crate::{
 /// Create a symmetric key via the CLI
 pub(crate) fn create_symmetric_key(
     cli_conf_path: &str,
-    number_of_bits: Option<usize>,
-    wrap_key_b64: Option<&str>,
-    algorithm: Option<&str>,
-    tags: &[&str],
+    action: CreateKeyAction,
 ) -> CliResult<String> {
     let mut cmd = Command::cargo_bin(PROG_NAME)?;
     cmd.env(KMS_CLI_CONF_ENV, cli_conf_path);
 
-    let mut args = vec!["keys", "create"];
+    let mut args = vec!["keys".to_owned(), "create".to_owned()];
     let num_s;
-    if let Some(number_of_bits) = number_of_bits {
+    if let Some(number_of_bits) = action.number_of_bits {
         num_s = number_of_bits.to_string();
-        args.extend(vec!["--number-of-bits", &num_s]);
+        args.extend(vec!["--number-of-bits".to_owned(), num_s]);
     }
-    if let Some(wrap_key_b64) = wrap_key_b64 {
-        args.extend(vec!["--bytes-b64", wrap_key_b64]);
+    if let Some(wrap_key_b64) = action.wrap_key_b64.clone() {
+        args.extend(vec!["--bytes-b64".to_owned(), wrap_key_b64]);
     }
-    if let Some(algorithm) = algorithm {
-        args.extend(vec!["--algorithm", algorithm]);
+    args.extend(vec!["--algorithm".to_owned(), action.algorithm.to_string()]);
+    if let Some(key_id) = action.key_id.clone() {
+        args.extend(vec!["--key-id".to_owned(), key_id]);
     }
+
     // add tags
-    for tag in tags {
-        args.push("--tag");
+    for tag in action.tags {
+        args.push("--tag".to_owned());
         args.push(tag);
     }
     cmd.arg(SUB_COMMAND).args(args);
@@ -71,24 +71,24 @@ pub(crate) async fn test_create_symmetric_key() -> CliResult<()> {
     // AES
     {
         // AES 256 bit key
-        create_symmetric_key(&ctx.owner_client_conf_path, None, None, None, &[])?;
+        create_symmetric_key(&ctx.owner_client_conf_path, CreateKeyAction::default())?;
         // AES 128 bit key
         create_symmetric_key(
             &ctx.owner_client_conf_path,
-            Some(128),
-            None,
-            None,
-            &EMPTY_TAGS,
+            CreateKeyAction {
+                number_of_bits: Some(128),
+                ..Default::default()
+            },
         )?;
         //  AES 256 bit key from a base64 encoded key
         rng.fill_bytes(&mut key);
         let key_b64 = general_purpose::STANDARD.encode(&key);
         create_symmetric_key(
             &ctx.owner_client_conf_path,
-            None,
-            Some(&key_b64),
-            None,
-            &EMPTY_TAGS,
+            CreateKeyAction {
+                wrap_key_b64: Some(key_b64),
+                ..Default::default()
+            },
         )?;
     }
 
@@ -97,18 +97,19 @@ pub(crate) async fn test_create_symmetric_key() -> CliResult<()> {
         // ChaCha20 256 bit key
         create_symmetric_key(
             &ctx.owner_client_conf_path,
-            None,
-            None,
-            Some("chacha20"),
-            &EMPTY_TAGS,
+            CreateKeyAction {
+                algorithm: SymmetricAlgorithm::Chacha20,
+                ..Default::default()
+            },
         )?;
         // ChaCha20 128 bit key
         create_symmetric_key(
             &ctx.owner_client_conf_path,
-            Some(128),
-            None,
-            Some("chacha20"),
-            &EMPTY_TAGS,
+            CreateKeyAction {
+                number_of_bits: Some(128),
+                algorithm: SymmetricAlgorithm::Chacha20,
+                ..Default::default()
+            },
         )?;
         //  ChaCha20 256 bit key from a base64 encoded key
         let mut rng = CsRng::from_entropy();
@@ -117,10 +118,11 @@ pub(crate) async fn test_create_symmetric_key() -> CliResult<()> {
         let key_b64 = general_purpose::STANDARD.encode(&key);
         create_symmetric_key(
             &ctx.owner_client_conf_path,
-            None,
-            Some(&key_b64),
-            Some("chacha20"),
-            &EMPTY_TAGS,
+            CreateKeyAction {
+                wrap_key_b64: Some(key_b64),
+                algorithm: SymmetricAlgorithm::Chacha20,
+                ..Default::default()
+            },
         )?;
     }
 
@@ -129,39 +131,43 @@ pub(crate) async fn test_create_symmetric_key() -> CliResult<()> {
         // ChaCha20 256 bit salt
         create_symmetric_key(
             &ctx.owner_client_conf_path,
-            None,
-            None,
-            Some("sha3"),
-            &EMPTY_TAGS,
+            CreateKeyAction {
+                algorithm: SymmetricAlgorithm::Sha3,
+                ..Default::default()
+            },
         )?;
         // ChaCha20 salts
         create_symmetric_key(
             &ctx.owner_client_conf_path,
-            Some(224),
-            None,
-            Some("sha3"),
-            &EMPTY_TAGS,
+            CreateKeyAction {
+                number_of_bits: Some(224),
+                algorithm: SymmetricAlgorithm::Sha3,
+                ..Default::default()
+            },
         )?;
         create_symmetric_key(
             &ctx.owner_client_conf_path,
-            Some(256),
-            None,
-            Some("sha3"),
-            &EMPTY_TAGS,
+            CreateKeyAction {
+                number_of_bits: Some(256),
+                algorithm: SymmetricAlgorithm::Sha3,
+                ..Default::default()
+            },
         )?;
         create_symmetric_key(
             &ctx.owner_client_conf_path,
-            Some(384),
-            None,
-            Some("sha3"),
-            &EMPTY_TAGS,
+            CreateKeyAction {
+                number_of_bits: Some(384),
+                algorithm: SymmetricAlgorithm::Sha3,
+                ..Default::default()
+            },
         )?;
         create_symmetric_key(
             &ctx.owner_client_conf_path,
-            Some(512),
-            None,
-            Some("sha3"),
-            &EMPTY_TAGS,
+            CreateKeyAction {
+                number_of_bits: Some(512),
+                algorithm: SymmetricAlgorithm::Sha3,
+                ..Default::default()
+            },
         )?;
         //  ChaCha20 256 bit salt from a base64 encoded salt
         let mut rng = CsRng::from_entropy();
@@ -170,10 +176,11 @@ pub(crate) async fn test_create_symmetric_key() -> CliResult<()> {
         let key_b64 = general_purpose::STANDARD.encode(&salt);
         create_symmetric_key(
             &ctx.owner_client_conf_path,
-            None,
-            Some(&key_b64),
-            Some("sha3"),
-            &EMPTY_TAGS,
+            CreateKeyAction {
+                wrap_key_b64: Some(key_b64),
+                algorithm: SymmetricAlgorithm::Sha3,
+                ..Default::default()
+            },
         )?;
     }
     Ok(())

--- a/crate/cli/src/tests/symmetric/create_key.rs
+++ b/crate/cli/src/tests/symmetric/create_key.rs
@@ -38,7 +38,7 @@ pub(crate) fn create_symmetric_key(
     }
     args.extend(vec!["--algorithm".to_owned(), action.algorithm.to_string()]);
     if let Some(key_id) = action.key_id.clone() {
-        args.extend(vec!["--key-id".to_owned(), key_id]);
+        args.extend(vec![key_id]);
     }
 
     // add tags

--- a/crate/cli/src/tests/symmetric/encrypt_decrypt.rs
+++ b/crate/cli/src/tests/symmetric/encrypt_decrypt.rs
@@ -7,7 +7,10 @@ use tempfile::TempDir;
 
 use super::SUB_COMMAND;
 use crate::{
-    actions::symmetric::{DataEncryptionAlgorithm, KeyEncryptionAlgorithm},
+    actions::symmetric::{
+        keys::create_key::{CreateKeyAction, SymmetricAlgorithm},
+        DataEncryptionAlgorithm, KeyEncryptionAlgorithm,
+    },
     error::{result::CliResult, CliError},
     tests::{symmetric::create_key::create_symmetric_key, utils::recover_cmd_logs, PROG_NAME},
 };
@@ -196,10 +199,11 @@ async fn test_aes_gcm_server_side() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
     let dek = create_symmetric_key(
         &ctx.owner_client_conf_path,
-        Some(256),
-        None,
-        Some("aes"),
-        &[],
+        CreateKeyAction {
+            algorithm: SymmetricAlgorithm::Aes,
+            number_of_bits: Some(256),
+            ..Default::default()
+        },
     )?;
     run_encrypt_decrypt_test(
         &ctx.owner_client_conf_path,
@@ -215,10 +219,11 @@ async fn test_aes_xts_server_side() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
     let dek = create_symmetric_key(
         &ctx.owner_client_conf_path,
-        Some(512),
-        None,
-        Some("aes"),
-        &[],
+        CreateKeyAction {
+            algorithm: SymmetricAlgorithm::Aes,
+            number_of_bits: Some(512),
+            ..Default::default()
+        },
     )?;
     run_encrypt_decrypt_test(
         &ctx.owner_client_conf_path,
@@ -235,10 +240,11 @@ async fn test_aes_gcm_siv_server_side() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
     let dek = create_symmetric_key(
         &ctx.owner_client_conf_path,
-        Some(256),
-        None,
-        Some("aes"),
-        &[],
+        CreateKeyAction {
+            algorithm: SymmetricAlgorithm::Aes,
+            number_of_bits: Some(256),
+            ..Default::default()
+        },
     )?;
     run_encrypt_decrypt_test(
         &ctx.owner_client_conf_path,
@@ -255,10 +261,11 @@ async fn test_chacha20_poly1305_server_side() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
     let dek = create_symmetric_key(
         &ctx.owner_client_conf_path,
-        Some(256),
-        None,
-        Some("chacha20"),
-        &[],
+        CreateKeyAction {
+            algorithm: SymmetricAlgorithm::Chacha20,
+            number_of_bits: Some(256),
+            ..Default::default()
+        },
     )?;
     run_encrypt_decrypt_test(
         &ctx.owner_client_conf_path,
@@ -277,8 +284,13 @@ async fn test_encrypt_decrypt_with_tags() -> CliResult<()> {
     let tmp_path = tmp_dir.path();
 
     let ctx = start_default_test_kms_server().await;
-    let _key_id =
-        create_symmetric_key(&ctx.owner_client_conf_path, None, None, None, &["tag_sym"])?;
+    let _key_id = create_symmetric_key(
+        &ctx.owner_client_conf_path,
+        CreateKeyAction {
+            tags: vec!["tag_sym".to_owned()],
+            ..Default::default()
+        },
+    )?;
 
     let input_file = PathBuf::from("test_data/plain.txt");
     let output_file = tmp_path.join("plain.enc");
@@ -337,10 +349,11 @@ async fn test_aes_gcm_aes_gcm_client_side() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
     let kek = create_symmetric_key(
         &ctx.owner_client_conf_path,
-        Some(256),
-        None,
-        Some("aes"),
-        &[],
+        CreateKeyAction {
+            algorithm: SymmetricAlgorithm::Aes,
+            number_of_bits: Some(256),
+            ..Default::default()
+        },
     )?;
     run_encrypt_decrypt_test(
         &ctx.owner_client_conf_path,
@@ -358,10 +371,11 @@ async fn test_aes_gcm_aes_xts_client_side() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
     let kek = create_symmetric_key(
         &ctx.owner_client_conf_path,
-        Some(256),
-        None,
-        Some("aes"),
-        &[],
+        CreateKeyAction {
+            algorithm: SymmetricAlgorithm::Aes,
+            number_of_bits: Some(256),
+            ..Default::default()
+        },
     )?;
     run_encrypt_decrypt_test(
         &ctx.owner_client_conf_path,
@@ -380,10 +394,11 @@ async fn test_aes_gcm_chacha20_client_side() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
     let kek = create_symmetric_key(
         &ctx.owner_client_conf_path,
-        Some(256),
-        None,
-        Some("aes"),
-        &[],
+        CreateKeyAction {
+            algorithm: SymmetricAlgorithm::Aes,
+            number_of_bits: Some(256),
+            ..Default::default()
+        },
     )?;
     run_encrypt_decrypt_test(
         &ctx.owner_client_conf_path,
@@ -401,10 +416,11 @@ async fn test_rfc5649_aes_gcm_client_side() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
     let kek = create_symmetric_key(
         &ctx.owner_client_conf_path,
-        Some(256),
-        None,
-        Some("aes"),
-        &[],
+        CreateKeyAction {
+            algorithm: SymmetricAlgorithm::Aes,
+            number_of_bits: Some(256),
+            ..Default::default()
+        },
     )?;
     run_encrypt_decrypt_test(
         &ctx.owner_client_conf_path,

--- a/crate/cli/src/tests/symmetric/rekey.rs
+++ b/crate/cli/src/tests/symmetric/rekey.rs
@@ -7,6 +7,7 @@ use tempfile::TempDir;
 
 use super::SUB_COMMAND;
 use crate::{
+    actions::symmetric::keys::create_key::CreateKeyAction,
     error::{result::CliResult, CliError},
     tests::{
         shared::{export_key, ExportKeyParams},
@@ -55,10 +56,10 @@ pub(crate) async fn test_rekey_symmetric_key() -> CliResult<()> {
     // AES 256 bit key
     let id = create_symmetric_key(
         &ctx.owner_client_conf_path,
-        Some(AES_KEY_SIZE),
-        None,
-        None,
-        &[],
+        CreateKeyAction {
+            number_of_bits: Some(AES_KEY_SIZE),
+            ..Default::default()
+        },
     )?;
 
     // Export as default (JsonTTLV with Raw Key Format Type)

--- a/crate/server/src/config/command_line/clap_config.rs
+++ b/crate/server/src/config/command_line/clap_config.rs
@@ -21,6 +21,7 @@ impl Default for ClapConfig {
             ms_dke_service_url: None,
             telemetry: TelemetryConfig::default(),
             info: false,
+            non_revokable_key_id: None,
         }
     }
 }
@@ -73,6 +74,10 @@ pub struct ClapConfig {
     /// Print the server configuration information and exit
     #[clap(long, default_value = "false")]
     pub info: bool,
+
+    /// The non-revokable keys ID used for demo purposes
+    #[clap(long, hide = true)]
+    pub non_revokable_key_id: Option<Vec<String>>,
 }
 
 impl fmt::Debug for ClapConfig {
@@ -98,6 +103,7 @@ impl fmt::Debug for ClapConfig {
         );
         let x = x.field("telemetry", &self.telemetry);
         let x = x.field("info", &self.info);
+        let x = x.field("non_revokable_key_id", &self.non_revokable_key_id);
         x.finish()
     }
 }

--- a/crate/server/src/config/params/server_params.rs
+++ b/crate/server/src/config/params/server_params.rs
@@ -57,6 +57,9 @@ pub struct ServerParams {
     ///
     /// The URL should be something like <https://cse.my_domain.com/ms_dke>
     pub ms_dke_service_url: Option<String>,
+
+    /// The non-revokable keys ID used for demo purposes
+    pub non_revokable_key_id: Option<Vec<String>>,
 }
 
 /// Represents the server parameters.
@@ -106,6 +109,7 @@ impl ServerParams {
             api_token_id: conf.http.api_token_id,
             google_cse_kacls_url: conf.google_cse_kacls_url,
             ms_dke_service_url: conf.ms_dke_service_url,
+            non_revokable_key_id: conf.non_revokable_key_id,
         })
     }
 
@@ -177,6 +181,7 @@ impl fmt::Debug for ServerParams {
         };
         let x = x.field("ms_dke_service_url", &self.ms_dke_service_url);
         let x = x.field("api_token_id", &self.api_token_id);
+        let x = x.field("non_revokable_key_id", &self.non_revokable_key_id);
         x.finish()
     }
 }
@@ -199,6 +204,7 @@ impl Clone for ServerParams {
             api_token_id: self.api_token_id.clone(),
             google_cse_kacls_url: self.google_cse_kacls_url.clone(),
             ms_dke_service_url: self.ms_dke_service_url.clone(),
+            non_revokable_key_id: self.non_revokable_key_id.clone(),
         }
     }
 }

--- a/crate/server/src/main.rs
+++ b/crate/server/src/main.rs
@@ -213,6 +213,7 @@ mod tests {
                 quiet: false,
             },
             info: false,
+            non_revokable_key_id: None,
         };
 
         let toml_string = r#"

--- a/crate/test_server/src/lib.rs
+++ b/crate/test_server/src/lib.rs
@@ -1,7 +1,8 @@
 pub use cosmian_kms_server::config::{DBConfig, DEFAULT_SQLITE_PATH};
 pub use test_server::{
     generate_invalid_conf, start_default_test_kms_server,
-    start_default_test_kms_server_with_cert_auth, start_test_server_with_options,
+    start_default_test_kms_server_with_cert_auth,
+    start_default_test_kms_server_with_non_revokable_key_ids, start_test_server_with_options,
     AuthenticationOptions, TestsContext,
 };
 

--- a/documentation/docs/cli/main_commands.md
+++ b/documentation/docs/cli/main_commands.md
@@ -1756,7 +1756,8 @@ Create, destroy, import, and export symmetric keys
 Create a new symmetric key
 
 ### Usage
-`ckms sym keys create [options]`
+`ckms sym keys create [options] [KEY_ID]
+`
 ### Arguments
 `--number-of-bits [-l] <NUMBER_OF_BITS>` The length of the generated random key or salt in bits
 
@@ -1768,7 +1769,7 @@ Possible values:  `"chacha20", "aes", "sha3", "shake"` [default: `"aes"`]
 
 `--tag [-t] <TAG>` The tag to associate with the key. To specify multiple tags, use the option multiple times
 
-`--key-id <KEY_ID>` The unique id of the key; a random uuid is generated if not specified
+` <KEY_ID>` The unique id of the key; a random uuid is generated if not specified
 
 
 

--- a/documentation/docs/cli/main_commands.md
+++ b/documentation/docs/cli/main_commands.md
@@ -1756,8 +1756,7 @@ Create, destroy, import, and export symmetric keys
 Create a new symmetric key
 
 ### Usage
-`ckms sym keys create [options] [KEY_ID]
-`
+`ckms sym keys create [options]`
 ### Arguments
 `--number-of-bits [-l] <NUMBER_OF_BITS>` The length of the generated random key or salt in bits
 
@@ -1769,7 +1768,7 @@ Possible values:  `"chacha20", "aes", "sha3", "shake"` [default: `"aes"`]
 
 `--tag [-t] <TAG>` The tag to associate with the key. To specify multiple tags, use the option multiple times
 
-` <KEY_ID>` The unique id of the key; a random uuid is generated if not specified
+`--key-id <KEY_ID>` The unique id of the key; a random uuid is generated if not specified
 
 
 


### PR DESCRIPTION
- Server: 
  - add a clap option with `non revokable key ids`
  - on revoke operation, dismiss the revoke operation on key id found in those `non revokable key ids` list

- CLI:
  - add test to check revocation  
  -  on create symmetric key, change behavior and add key_id as argument (seems to be more consistent with other commands)
  - reuse CreateKeyAction on tests (to simplify test functions arguments and to benefit of the key_id on sym key creation) 