### PR TITLE
CLI bench command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1323,6 +1323,7 @@ dependencies = [
  "jwt-simple",
  "kms_test_server",
  "leb128",
+ "num-format",
  "oauth2",
  "openssl",
  "pem",
@@ -2886,6 +2887,16 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
+]
 
 [[package]]
 name = "num-integer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,19 +1,19 @@
 [workspace]
 default-members = ["crate/cli", "crate/server", "crate/pkcs11/provider"]
 members = [
-  "crate/cli",
-  "crate/client",
-  "crate/interfaces",
-  "crate/kmip",
-  "crate/logger",
-  "crate/pyo3",
-  "crate/server",
-  "crate/server_database",
-  "crate/test_server",
-  "crate/pkcs11/module",
-  "crate/pkcs11/provider",
-  "crate/pkcs11/proteccio",
-  "crate/pkcs11/sys",
+    "crate/cli",
+    "crate/client",
+    "crate/interfaces",
+    "crate/kmip",
+    "crate/logger",
+    "crate/pyo3",
+    "crate/server",
+    "crate/server_database",
+    "crate/test_server",
+    "crate/pkcs11/module",
+    "crate/pkcs11/provider",
+    "crate/pkcs11/proteccio",
+    "crate/pkcs11/sys",
 ]
 # Do that if you don't want to enable `dev` feature by default due to the `dev-dependencies` of the cli.
 # For more details, read: https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2
@@ -25,9 +25,9 @@ version = "4.20.0"
 edition = "2021"
 rust-version = "1.71.0"
 authors = [
-  "Bruno Grieder <bruno.grieder@cosmian.com>",
-  "Emmanuel Coste <emmanuel.coste@cosmian.com>",
-  "Hugo Rosenkranz-Costa <hugo.rosenkranz@cosmian.com>",
+    "Bruno Grieder <bruno.grieder@cosmian.com>",
+    "Emmanuel Coste <emmanuel.coste@cosmian.com>",
+    "Hugo Rosenkranz-Costa <hugo.rosenkranz@cosmian.com>",
 ]
 license = "BUSL-1.1" # "Business Source License 1.1"
 license-file = "LICENSE"
@@ -69,6 +69,7 @@ log = { version = "0.4", default-features = false }
 lru = "0.12.5"
 native-tls = "0.2"
 num_cpus = "1.13"
+num-format = "0.4"
 num-bigint-dig = { version = "0.8", default-features = false }
 openssl = { version = "0.10", default-features = false }
 pem = "3.0"

--- a/crate/cli/Cargo.toml
+++ b/crate/cli/Cargo.toml
@@ -25,13 +25,13 @@ fips = ["cosmian_kms_client/fips"]
 actix-web = { workspace = true, features = ["macros"] }
 base64 = { workspace = true }
 clap = { workspace = true, features = [
-  "help",
-  "env",
-  "std",
-  "usage",
-  "error-context",
-  "derive",
-  "cargo",
+    "help",
+    "env",
+    "std",
+    "usage",
+    "error-context",
+    "derive",
+    "cargo",
 ] }
 cloudproof = { workspace = true }
 cosmian_kms_client = { path = "../client" }
@@ -39,9 +39,10 @@ cosmian_logger = { path = "../logger" }
 der = { workspace = true, features = ["pem"] }
 hex = { workspace = true }
 jwt-simple = { version = "0.12", default-features = false, features = [
-  "pure-rust",
+    "pure-rust",
 ] }
 leb128 = { workspace = true }
+num-format = { workspace = true }
 oauth2 = { version = "4.4", features = ["reqwest"] }
 pem = { workspace = true }
 reqwest = { workspace = true }
@@ -90,7 +91,7 @@ features = ["fips"]
 [package.metadata.generate-rpm]
 license = "BUSL-1.1"
 assets = [
-  { source = "target/release/ckms", dest = "/usr/sbin/ckms", mode = "555" },
+    { source = "target/release/ckms", dest = "/usr/sbin/ckms", mode = "555" },
 ]
 auto-req = "no" # do not try to discover .so dependencies
 require-sh = true

--- a/crate/cli/src/actions/bench.rs
+++ b/crate/cli/src/actions/bench.rs
@@ -76,6 +76,8 @@ pub struct BenchAction {
 
 impl BenchAction {
     /// Run the tests
+    /// # Errors
+    /// Returns an error if the server is not reachable or if the keys can't be created.
     #[allow(clippy::print_stdout)]
     pub async fn process(&self, kms_rest_client: Arc<KmsClient>) -> CliResult<()> {
         let version = kms_rest_client
@@ -99,7 +101,7 @@ impl BenchAction {
             .grouping(Grouping::Standard)
             .separator(" ")
             .build()
-            .unwrap();
+            .map_err(|e| CliError::Default(format!("Failed to create the formatter: {e}")))?;
 
         // the data to encrypt
         let data = if self.batch_size == 1 {

--- a/crate/cli/src/actions/bench.rs
+++ b/crate/cli/src/actions/bench.rs
@@ -1,0 +1,405 @@
+use std::{
+    io,
+    io::Write,
+    sync::{atomic::AtomicUsize, Arc, Mutex},
+};
+
+use clap::Parser;
+use cosmian_kms_client::{
+    kmip::{
+        extra::BulkData,
+        kmip_operations::{Decrypt, Encrypt},
+        kmip_types::{
+            BlockCipherMode, CryptographicAlgorithm, CryptographicParameters, UniqueIdentifier,
+        },
+    },
+    KmsClient,
+};
+use num_format::{CustomFormat, Grouping, ToFormattedString};
+use zeroize::Zeroizing;
+
+use crate::{
+    actions::{
+        rsa::keys::{create_key_pair::CreateKeyPairAction, revoke_key::RevokeKeyAction},
+        symmetric::keys::create_key::CreateKeyAction,
+    },
+    error::{
+        result::{CliResult, CliResultHelper},
+        CliError,
+    },
+};
+
+struct EncryptionResult {
+    batch_id: usize,
+    ciphertext: Zeroizing<Vec<u8>>,
+    encryption_time: u128,
+}
+
+struct FinalResult {
+    batch_id: usize,
+    encryption_time: u128,
+    decryption_time: u128,
+}
+
+/// Run a set of bunch to check the server performance
+#[derive(Parser, Debug)]
+pub struct BenchAction {
+    /// The number of parallel threads to use
+    #[clap(long = "number-of-threads", short = 't', default_value = "1")]
+    num_threads: usize,
+
+    /// The size of an encryption/decryption batch
+    /// A size of 1 does not use the `BulkData` API
+    #[clap(long = "batch-size", short = 'b', default_value = "1")]
+    batch_size: usize,
+
+    /// The number of batches to run
+    #[clap(long = "num-batches", short = 'n', default_value = "1")]
+    num_batches: usize,
+
+    /// Use a wrapped key (by a 4096 RSA key) to encrypt the symmetric key
+    #[clap(long = "wrapped-key", short = 'w', default_value = "false")]
+    wrapped_key: bool,
+
+    /// Display batch results details
+    #[clap(long = "verbose", short = 'v', default_value = "false")]
+    verbose: bool,
+}
+
+impl BenchAction {
+    /// Run the tests
+    #[allow(clippy::print_stdout)]
+    pub async fn process(&self, kms_rest_client: Arc<KmsClient>) -> CliResult<()> {
+        let version = kms_rest_client
+            .version()
+            .await
+            .with_context(|| "Can't execute the version query on the kms server")?;
+        println!("Server version: {version}");
+        println!(
+            "Running bench with {} threads, batch size {}, {} batches. Using a wrapped key? {}",
+            self.num_threads, self.batch_size, self.num_batches, self.wrapped_key
+        );
+        let (key_id, _wrapping_key) = self.create_keys(&kms_rest_client).await?;
+
+        // u128 formatter
+        let format = CustomFormat::builder()
+            .grouping(Grouping::Standard)
+            .separator(" ")
+            .build()
+            .unwrap();
+
+        // the data to encrypt
+        let data = if self.batch_size == 1 {
+            Zeroizing::new(vec![1u8; 64])
+        } else {
+            BulkData::new(vec![Zeroizing::new(vec![1u8; 64]); self.batch_size]).serialize()?
+        };
+
+        // Encryption
+        {
+            let mut stdout = io::stdout().lock();
+            write!(stdout, "Encrypting")?;
+            stdout.flush()?;
+        }
+        let amortized_encryption_time = std::time::Instant::now();
+        let counter = Arc::new(AtomicUsize::new(0));
+        let mut handles = Vec::new();
+        for _ in 0..self.num_threads {
+            let kms_rest_client = kms_rest_client.clone();
+            let key_id = key_id.clone();
+            let data = data.clone();
+            let counter = counter.clone();
+            let num_batches = self.num_batches;
+            let handle = tokio::spawn(async move {
+                encrypt(kms_rest_client, key_id, data, counter, num_batches).await
+            });
+            handles.push(handle);
+        }
+
+        let mut encryption_results = Vec::new();
+        for handle in handles {
+            match handle.await {
+                Ok(Ok(results)) => {
+                    encryption_results.extend(results);
+                }
+                Ok(Err(e)) => return Err(e),
+                Err(e) => return Err(CliError::Default(format!("Tokio Error: {e}"))),
+            }
+        }
+        let total_encryption_time_amortized = amortized_encryption_time.elapsed().as_micros();
+        {
+            let mut stdout = io::stdout().lock();
+            writeln!(
+                stdout,
+                ": {}µs",
+                total_encryption_time_amortized.to_formatted_string(&format)
+            )?;
+        }
+
+        // Decryption
+        {
+            let mut stdout = io::stdout().lock();
+            write!(stdout, "Decrypting")?;
+            stdout.flush()?;
+        }
+        let amortized_decryption_time = std::time::Instant::now();
+        let ciphertexts_to_process = Arc::new(Mutex::new(encryption_results));
+        let mut handles = Vec::new();
+        for _ in 0..self.num_threads {
+            let kms_rest_client = kms_rest_client.clone();
+            let key_id = key_id.clone();
+            let ciphertexts_to_process = ciphertexts_to_process.clone();
+            let handle = tokio::spawn(async move {
+                decrypt(kms_rest_client, key_id, ciphertexts_to_process).await
+            });
+            handles.push(handle);
+        }
+
+        let mut final_results = Vec::new();
+        for handle in handles {
+            match handle.await {
+                Ok(Ok(results)) => {
+                    final_results.extend(results);
+                }
+                Ok(Err(e)) => return Err(e),
+                Err(e) => return Err(CliError::Default(format!("Tokio Error: {e}"))),
+            }
+        }
+        let total_decryption_time_amortized = amortized_decryption_time.elapsed().as_micros();
+        {
+            let mut stdout = io::stdout().lock();
+            writeln!(
+                stdout,
+                ": {}µs",
+                total_decryption_time_amortized.to_formatted_string(&format)
+            )?;
+            stdout.flush()?;
+        }
+        // revoke the keys
+        self.revoke_keys(&kms_rest_client, key_id, None).await?;
+
+        // Parse results
+        final_results.sort_by_key(|r| r.batch_id);
+        let mut total_encryption_time = 0_u128;
+        let mut total_decryption_time = 0_u128;
+        if self.verbose {
+            for result in final_results {
+                total_encryption_time += result.encryption_time;
+                total_decryption_time += result.decryption_time;
+                if self.verbose {
+                    println!(
+                        "{}: encryption: {}µs ({}µs/v), decryption: {}µs ({}µs/v)",
+                        result.batch_id,
+                        result.encryption_time.to_formatted_string(&format),
+                        result.encryption_time / (self.batch_size as u128),
+                        result.decryption_time.to_formatted_string(&format),
+                        result.decryption_time / (self.batch_size as u128)
+                    );
+                }
+            }
+        }
+
+        println!(
+            "Encryption time {}µs => {}µs/batch => {}µs/value",
+            total_encryption_time.to_formatted_string(&format),
+            (total_encryption_time / (self.num_batches as u128)).to_formatted_string(&format),
+            total_encryption_time / (self.num_batches * self.batch_size) as u128
+        );
+        println!(
+            "Decryption time {}µs => {}µs/batch => {}µs/value",
+            total_decryption_time.to_formatted_string(&format),
+            (total_decryption_time / self.num_batches as u128).to_formatted_string(&format),
+            total_decryption_time / (self.num_batches * self.batch_size) as u128
+        );
+        println!(
+            "Encryption time amortized {}µs => {}µs/batch => {}µs/value",
+            total_encryption_time_amortized.to_formatted_string(&format),
+            (total_encryption_time_amortized / (self.num_batches as u128))
+                .to_formatted_string(&format),
+            total_encryption_time_amortized / (self.num_batches * self.batch_size) as u128
+        );
+        println!(
+            "Decryption time amortized {}µs => {}µs/batch => {}µs/value",
+            total_decryption_time_amortized.to_formatted_string(&format),
+            (total_decryption_time_amortized / (self.num_batches as u128))
+                .to_formatted_string(&format),
+            total_decryption_time_amortized / (self.num_batches * self.batch_size) as u128
+        );
+
+        Ok(())
+    }
+
+    async fn create_keys(
+        &self,
+        kms_rest_client: &KmsClient,
+    ) -> CliResult<(
+        UniqueIdentifier,
+        Option<(UniqueIdentifier, UniqueIdentifier)>,
+    )> {
+        if self.wrapped_key {
+            // create an RSA key pair
+            let (sk, pk) = CreateKeyPairAction {
+                tags: vec!["bench".to_owned()],
+                ..Default::default()
+            }
+            .run(kms_rest_client)
+            .await?;
+            let kk = CreateKeyAction {
+                number_of_bits: Some(4096),
+                wrapping_key_id: Some(pk.to_string()),
+                tags: vec!["bench".to_owned()],
+                ..Default::default()
+            }
+            .run(kms_rest_client)
+            .await?;
+            return Ok((kk, Some((sk, pk))));
+        }
+        let kk = CreateKeyAction {
+            number_of_bits: Some(256),
+            tags: vec!["bench".to_owned()],
+            ..Default::default()
+        }
+        .run(kms_rest_client)
+        .await?;
+        Ok((kk, None))
+    }
+
+    async fn revoke_keys(
+        &self,
+        kms_rest_client: &KmsClient,
+        symmetric_key: UniqueIdentifier,
+        wrapping_key: Option<(UniqueIdentifier, UniqueIdentifier)>,
+    ) -> CliResult<()> {
+        RevokeKeyAction {
+            revocation_reason: "Bench".to_owned(),
+            key_id: Some(symmetric_key.to_string()),
+            tags: None,
+        }
+        .run(kms_rest_client)
+        .await?;
+        if let Some((sk, pk)) = wrapping_key {
+            RevokeKeyAction {
+                revocation_reason: "Bench".to_owned(),
+                key_id: Some(sk.to_string()),
+                tags: None,
+            }
+            .run(kms_rest_client)
+            .await?;
+            RevokeKeyAction {
+                revocation_reason: "Bench".to_owned(),
+                key_id: Some(pk.to_string()),
+                tags: None,
+            }
+            .run(kms_rest_client)
+            .await?;
+        }
+        Ok(())
+    }
+}
+
+async fn encrypt(
+    kms_rest_client: Arc<KmsClient>,
+    key_id: UniqueIdentifier,
+    data: Zeroizing<Vec<u8>>,
+    counter: Arc<AtomicUsize>,
+    num_batches: usize,
+) -> CliResult<Vec<EncryptionResult>> {
+    let mut results = Vec::new();
+    loop {
+        let next = counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        if next >= num_batches {
+            break;
+        }
+        {
+            let mut stdout = io::stdout().lock();
+            write!(stdout, ".",)?;
+            stdout.flush()?;
+        }
+        let encrypt = Encrypt {
+            unique_identifier: Some(key_id.clone()),
+            cryptographic_parameters: Some(CryptographicParameters {
+                cryptographic_algorithm: Some(CryptographicAlgorithm::AES),
+                block_cipher_mode: Some(BlockCipherMode::GCM),
+                ..Default::default()
+            }),
+            data: Some(data.clone()),
+            ..Default::default()
+        };
+        let start = std::time::Instant::now();
+        let response = kms_rest_client
+            .encrypt(encrypt)
+            .await
+            .with_context(|| "failed encrypting")?;
+        let elapsed = start.elapsed().as_micros();
+        let ciphertext = Zeroizing::new(
+            [
+                response.iv_counter_nonce.unwrap_or_default(),
+                response.data.unwrap_or_default(),
+                response.authenticated_encryption_tag.unwrap_or_default(),
+            ]
+            .concat(),
+        );
+        results.push(EncryptionResult {
+            batch_id: next,
+            ciphertext,
+            encryption_time: elapsed,
+        });
+    }
+    Ok(results)
+}
+
+async fn decrypt(
+    kms_rest_client: Arc<KmsClient>,
+    key_id: UniqueIdentifier,
+    encryptions: Arc<Mutex<Vec<EncryptionResult>>>,
+) -> CliResult<Vec<FinalResult>> {
+    let mut results = Vec::new();
+    loop {
+        let next = encryptions
+            .lock()
+            .expect("could not lock encryption results")
+            .pop();
+        let Some(next) = next else { break };
+        {
+            let mut stdout = io::stdout().lock();
+            write!(stdout, ".",)?;
+            stdout.flush()?;
+        }
+        let (iv, data, tag) = match BulkData::deserialize(next.ciphertext.as_ref()) {
+            Ok(_data) => (None, Some(next.ciphertext.as_slice()), None),
+            Err(_e) => {
+                // Single AES GCM query => split the data
+                let iv_len = 12;
+                let tag_len = 16;
+                let iv = &next.ciphertext[..iv_len];
+                let tag = &next.ciphertext[next.ciphertext.len() - tag_len..];
+                let data = &next.ciphertext[iv_len..next.ciphertext.len() - tag_len];
+                (Some(iv), Some(data), Some(tag))
+            }
+        };
+        let decrypt = Decrypt {
+            unique_identifier: Some(key_id.clone()),
+            cryptographic_parameters: Some(CryptographicParameters {
+                cryptographic_algorithm: Some(CryptographicAlgorithm::AES),
+                block_cipher_mode: Some(BlockCipherMode::GCM),
+                ..Default::default()
+            }),
+            iv_counter_nonce: iv.map(Vec::from),
+            data: data.map(Vec::from),
+            authenticated_encryption_tag: tag.map(Vec::from),
+            ..Default::default()
+        };
+        let start = std::time::Instant::now();
+        let _response = kms_rest_client
+            .decrypt(decrypt)
+            .await
+            .with_context(|| "failed encrypting")?;
+        let elapsed = start.elapsed().as_micros();
+        results.push(FinalResult {
+            batch_id: next.batch_id,
+            encryption_time: next.encryption_time,
+            decryption_time: elapsed,
+        });
+    }
+    Ok(results)
+}

--- a/crate/cli/src/actions/bench.rs
+++ b/crate/cli/src/actions/bench.rs
@@ -43,8 +43,8 @@ struct FinalResult {
 
 /// Run a set of benches to check the server performance.
 ///
-/// This command will create a key, encrypt and decrypt a set of data
-/// then revoke the key.
+/// This command will create one or more keys, encrypt and decrypt a set of data
+/// then revoke the keys.
 #[derive(Parser, Debug)]
 pub struct BenchAction {
     /// The number of parallel threads to use

--- a/crate/cli/src/actions/mod.rs
+++ b/crate/cli/src/actions/mod.rs
@@ -1,5 +1,6 @@
 pub mod access;
 pub mod attributes;
+pub mod bench;
 pub mod certificates;
 pub mod console;
 #[cfg(not(feature = "fips"))]

--- a/crate/cli/src/actions/rsa/decrypt.rs
+++ b/crate/cli/src/actions/rsa/decrypt.rs
@@ -76,6 +76,31 @@ pub struct DecryptAction {
 }
 
 impl DecryptAction {
+    /// Runs the decryption process.
+    ///
+    /// This function performs the following steps:
+    /// 1. Reads the file to decrypt.
+    /// 2. Recovers the unique identifier or set of tags for the key.
+    /// 3. Creates the KMIP decryption request.
+    /// 4. Queries the KMS with the KMIP data and retrieves the plaintext.
+    /// 5. Writes the decrypted file to the specified output path.
+    ///
+    /// # Arguments
+    ///
+    /// * `kms_rest_client` - A reference to the KMS client.
+    ///
+    /// # Returns
+    ///
+    /// * `CliResult<()>` - The result of the decryption process.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// * The file to decrypt cannot be read.
+    /// * Neither `--key-id` nor `--tag` is specified.
+    /// * The KMIP decryption request cannot be created.
+    /// * The KMS query fails.
+    /// * The decrypted file cannot be written.
     pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         // Read the file to decrypt
         let data = read_bytes_from_file(&self.input_file)

--- a/crate/cli/src/actions/rsa/encrypt.rs
+++ b/crate/cli/src/actions/rsa/encrypt.rs
@@ -75,6 +75,25 @@ pub struct EncryptAction {
 }
 
 impl EncryptAction {
+    /// Run the encryption action
+    ///
+    /// # Arguments
+    ///
+    /// * `kms_rest_client` - A reference to the KMS client used to perform encryption.
+    ///
+    /// # Results
+    ///
+    /// This function returns a `CliResult<()>` indicating the success or failure of the encryption action.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// * The input file cannot be read.
+    /// * The key ID or tags are not specified.
+    /// * The encryption request cannot be built.
+    /// * The KMS server query fails.
+    /// * The encrypted data is empty.
+    /// * The encrypted file cannot be written.
     pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         // Read the file to encrypt
         let mut data = read_bytes_from_file(&self.input_file)

--- a/crate/cli/src/actions/rsa/keys/create_key_pair.rs
+++ b/crate/cli/src/actions/rsa/keys/create_key_pair.rs
@@ -56,6 +56,22 @@ impl Default for CreateKeyPairAction {
 }
 
 impl CreateKeyPairAction {
+    /// Run the create key pair action
+    ///
+    /// # Arguments
+    ///
+    /// * `kms_rest_client` - A reference to the KMS client used to perform the key pair creation.
+    ///
+    /// # Results
+    ///
+    /// This function returns a `CliResult<(UniqueIdentifier, UniqueIdentifier)>` indicating the success or failure of the key pair creation action.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// * The key pair request cannot be built.
+    /// * The KMS server query fails.
+    /// * The key pair unique identifiers are empty.
     pub async fn run(
         &self,
         kms_rest_client: &KmsClient,

--- a/crate/cli/src/actions/rsa/keys/create_key_pair.rs
+++ b/crate/cli/src/actions/rsa/keys/create_key_pair.rs
@@ -27,25 +27,39 @@ pub struct CreateKeyPairAction {
         value_name = "SIZE_IN_BITS",
         default_value = "4096"
     )]
-    key_size: usize,
+    pub key_size: usize,
 
     /// The tag to associate with the master key pair.
     /// To specify multiple tags, use the option multiple times.
     #[clap(long = "tag", short = 't', value_name = "TAG")]
-    tags: Vec<String>,
+    pub tags: Vec<String>,
 
     /// The unique id of the private key; a random uuid
     /// is generated if not specified.
     #[clap(required = false)]
-    private_key_id: Option<String>,
+    pub private_key_id: Option<String>,
 
     /// Sensitive: if set, the private key will not be exportable
     #[clap(long = "sensitive", default_value = "false")]
-    sensitive: bool,
+    pub sensitive: bool,
+}
+
+impl Default for CreateKeyPairAction {
+    fn default() -> Self {
+        Self {
+            key_size: 4096,
+            tags: Vec::new(),
+            private_key_id: None,
+            sensitive: false,
+        }
+    }
 }
 
 impl CreateKeyPairAction {
-    pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
+    pub async fn run(
+        &self,
+        kms_rest_client: &KmsClient,
+    ) -> CliResult<(UniqueIdentifier, UniqueIdentifier)> {
         let private_key_id = self
             .private_key_id
             .as_ref()
@@ -70,6 +84,9 @@ impl CreateKeyPairAction {
         );
         stdout.write()?;
 
-        Ok(())
+        Ok((
+            private_key_unique_identifier.to_owned(),
+            public_key_unique_identifier.to_owned(),
+        ))
     }
 }

--- a/crate/cli/src/actions/rsa/keys/destroy_key.rs
+++ b/crate/cli/src/actions/rsa/keys/destroy_key.rs
@@ -26,6 +26,22 @@ pub struct DestroyKeyAction {
 }
 
 impl DestroyKeyAction {
+    /// Run the destroy key action
+    ///
+    /// # Arguments
+    ///
+    /// * `kms_rest_client` - A reference to the KMS client used to perform the key destruction.
+    ///
+    /// # Results
+    ///
+    /// This function returns a `CliResult<()>` indicating the success or failure of the key destruction action.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// * Neither `key_id` nor `tags` are specified.
+    /// * The key destruction request fails.
+    /// * The KMS server query fails.
     pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         let id = if let Some(key_id) = &self.key_id {
             key_id.clone()

--- a/crate/cli/src/actions/rsa/keys/mod.rs
+++ b/crate/cli/src/actions/rsa/keys/mod.rs
@@ -27,6 +27,21 @@ pub enum KeysCommands {
 }
 
 impl KeysCommands {
+    /// Process the key command
+    ///
+    /// # Arguments
+    ///
+    /// * `kms_rest_client` - A reference to the KMS client used to perform the key operations.
+    ///
+    /// # Results
+    ///
+    /// This function returns a `CliResult<()>` indicating the success or failure of the key command processing.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// * The specific key action fails.
+    /// * The KMS server query fails.
     pub async fn process(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         match self {
             Self::Create(action) => {

--- a/crate/cli/src/actions/rsa/keys/mod.rs
+++ b/crate/cli/src/actions/rsa/keys/mod.rs
@@ -10,9 +10,9 @@ use crate::{
     error::result::CliResult,
 };
 
-mod create_key_pair;
-mod destroy_key;
-mod revoke_key;
+pub mod create_key_pair;
+pub mod destroy_key;
+pub mod revoke_key;
 
 /// Create, destroy, import, and export RSA key pairs
 #[derive(Subcommand)]
@@ -29,13 +29,27 @@ pub enum KeysCommands {
 impl KeysCommands {
     pub async fn process(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         match self {
-            Self::Create(action) => action.run(kms_rest_client).await?,
-            Self::Export(action) => action.run(kms_rest_client).await?,
-            Self::Import(action) => action.run(kms_rest_client).await?,
-            Self::Wrap(action) => action.run(kms_rest_client).await?,
-            Self::Unwrap(action) => action.run(kms_rest_client).await?,
-            Self::Revoke(action) => action.run(kms_rest_client).await?,
-            Self::Destroy(action) => action.run(kms_rest_client).await?,
+            Self::Create(action) => {
+                action.run(kms_rest_client).await?;
+            }
+            Self::Export(action) => {
+                action.run(kms_rest_client).await?;
+            }
+            Self::Import(action) => {
+                action.run(kms_rest_client).await?;
+            }
+            Self::Wrap(action) => {
+                action.run(kms_rest_client).await?;
+            }
+            Self::Unwrap(action) => {
+                action.run(kms_rest_client).await?;
+            }
+            Self::Revoke(action) => {
+                action.run(kms_rest_client).await?;
+            }
+            Self::Destroy(action) => {
+                action.run(kms_rest_client).await?;
+            }
         };
 
         Ok(())

--- a/crate/cli/src/actions/rsa/keys/revoke_key.rs
+++ b/crate/cli/src/actions/rsa/keys/revoke_key.rs
@@ -28,6 +28,25 @@ pub struct RevokeKeyAction {
 }
 
 impl RevokeKeyAction {
+    /// Runs the key revocation process.
+    ///
+    /// This function performs the following steps:
+    /// 1. Recovers the unique identifier or set of tags for the key.
+    /// 2. Calls the `revoke` utility function to revoke the key.
+    ///
+    /// # Arguments
+    ///
+    /// * `kms_rest_client` - A reference to the KMS client.
+    ///
+    /// # Returns
+    ///
+    /// * `CliResult<()>` - The result of the revocation process.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// * Neither `--key-id` nor `--tag` is specified.
+    /// * The revocation request fails.
     pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         let id = if let Some(key_id) = &self.key_id {
             key_id.clone()

--- a/crate/cli/src/actions/rsa/keys/revoke_key.rs
+++ b/crate/cli/src/actions/rsa/keys/revoke_key.rs
@@ -14,17 +14,17 @@ use crate::{actions::shared::utils::revoke, cli_bail, error::result::CliResult};
 pub struct RevokeKeyAction {
     /// The reason for the revocation as a string
     #[clap(required = true)]
-    revocation_reason: String,
+    pub(crate) revocation_reason: String,
 
     /// The key unique identifier of the key to revoke.
     /// If not specified, tags should be specified
     #[clap(long = "key-id", short = 'k', group = "key-tags")]
-    key_id: Option<String>,
+    pub(crate) key_id: Option<String>,
 
     /// Tag to use to retrieve the key when no key id is specified.
     /// To specify multiple tags, use the option multiple times.
     #[clap(long = "tag", short = 't', value_name = "TAG", group = "key-tags")]
-    tags: Option<Vec<String>>,
+    pub(crate) tags: Option<Vec<String>>,
 }
 
 impl RevokeKeyAction {

--- a/crate/cli/src/actions/rsa/mod.rs
+++ b/crate/cli/src/actions/rsa/mod.rs
@@ -10,9 +10,9 @@ use cosmian_kms_client::{
 use self::{decrypt::DecryptAction, encrypt::EncryptAction, keys::KeysCommands};
 use crate::error::result::CliResult;
 
-mod decrypt;
-mod encrypt;
-mod keys;
+pub mod decrypt;
+pub mod encrypt;
+pub mod keys;
 
 /// Manage RSA keys. Encrypt and decrypt data using RSA keys.
 #[derive(Parser)]

--- a/crate/cli/src/actions/symmetric/keys/mod.rs
+++ b/crate/cli/src/actions/symmetric/keys/mod.rs
@@ -31,14 +31,30 @@ pub enum KeysCommands {
 impl KeysCommands {
     pub async fn process(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
         match self {
-            Self::Create(action) => action.run(kms_rest_client).await?,
-            Self::ReKey(action) => action.run(kms_rest_client).await?,
-            Self::Export(action) => action.run(kms_rest_client).await?,
-            Self::Import(action) => action.run(kms_rest_client).await?,
-            Self::Wrap(action) => action.run(kms_rest_client).await?,
-            Self::Unwrap(action) => action.run(kms_rest_client).await?,
-            Self::Revoke(action) => action.run(kms_rest_client).await?,
-            Self::Destroy(action) => action.run(kms_rest_client).await?,
+            Self::Create(action) => {
+                action.run(kms_rest_client).await?;
+            }
+            Self::ReKey(action) => {
+                action.run(kms_rest_client).await?;
+            }
+            Self::Export(action) => {
+                action.run(kms_rest_client).await?;
+            }
+            Self::Import(action) => {
+                action.run(kms_rest_client).await?;
+            }
+            Self::Wrap(action) => {
+                action.run(kms_rest_client).await?;
+            }
+            Self::Unwrap(action) => {
+                action.run(kms_rest_client).await?;
+            }
+            Self::Revoke(action) => {
+                action.run(kms_rest_client).await?;
+            }
+            Self::Destroy(action) => {
+                action.run(kms_rest_client).await?;
+            }
         };
 
         Ok(())

--- a/crate/cli/src/main.rs
+++ b/crate/cli/src/main.rs
@@ -1,15 +1,15 @@
-use std::{path::PathBuf, process};
+use std::{path::PathBuf, process, sync::Arc};
 
 use clap::{CommandFactory, Parser, Subcommand};
 #[cfg(not(feature = "fips"))]
 use cosmian_kms_cli::actions::cover_crypt::CovercryptCommands;
 use cosmian_kms_cli::{
     actions::{
-        access::AccessAction, attributes::AttributesCommands, certificates::CertificatesCommands,
-        elliptic_curves::EllipticCurveCommands, google::GoogleCommands, login::LoginAction,
-        logout::LogoutAction, markdown::MarkdownAction, new_database::NewDatabaseAction,
-        rsa::RsaCommands, shared::LocateObjectsAction, symmetric::SymmetricCommands,
-        version::ServerVersionAction,
+        access::AccessAction, attributes::AttributesCommands, bench::BenchAction,
+        certificates::CertificatesCommands, elliptic_curves::EllipticCurveCommands,
+        google::GoogleCommands, login::LoginAction, logout::LogoutAction, markdown::MarkdownAction,
+        new_database::NewDatabaseAction, rsa::RsaCommands, shared::LocateObjectsAction,
+        symmetric::SymmetricCommands, version::ServerVersionAction,
     },
     error::result::CliResult,
 };
@@ -75,6 +75,9 @@ enum CliCommands {
     #[clap(hide = true)]
     Markdown(MarkdownAction),
 
+    #[clap(hide = true)]
+    Bench(BenchAction),
+
     #[command(subcommand)]
     Google(GoogleCommands),
 }
@@ -124,6 +127,7 @@ async fn main_() -> CliResult<()> {
                 CliCommands::ServerVersion(action) => action.process(&kms_rest_client).await?,
                 CliCommands::Attributes(action) => action.process(&kms_rest_client).await?,
                 CliCommands::Google(action) => action.process(&conf_path, &kms_rest_client).await?,
+                CliCommands::Bench(action) => action.process(Arc::new(kms_rest_client)).await?,
                 _ => {
                     tracing::error!("unexpected command");
                 }

--- a/documentation/docs/cli/main_commands.md
+++ b/documentation/docs/cli/main_commands.md
@@ -1,12 +1,15 @@
 *-- This file is auto-generated using the `ckms markdown` command. --*
 
-##  ckms
+## ckms
 
 CLI used to manage the Cosmian KMS.
 
 ### Usage
+
 `ckms <subcommand> [options]`
+
 ### Arguments
+
 `--conf [-c] <CONF>` Configuration file location
 
 `--url <URL>` The URL of the KMS
@@ -15,10 +18,10 @@ CLI used to manage the Cosmian KMS.
 
 Possible values:  `"true", "false"`
 
-`--json <JSON>` Output the JSON KMIP request and response. This is useful to understand JSON POST requests and responses required to programmatically call the KMS on the `/kmip/2_1` endpoint
+`--json <JSON>` Output the JSON KMIP request and response. This is useful to understand JSON POST requests and responses
+required to programmatically call the KMS on the `/kmip/2_1` endpoint
 
 Possible values:  `"true", "false"` [default: `"false"`]
-
 
 ### Subcommands
 
@@ -26,7 +29,8 @@ Possible values:  `"true", "false"` [default: `"false"`]
 
 **`cc`** [[2]](#2-ckms-cc)  Manage Covercrypt keys and policies. Rotate attributes. Encrypt and decrypt data
 
-**`certificates`** [[3]](#3-ckms-certificates)  Manage certificates. Create, import, destroy and revoke. Encrypt and decrypt data
+**`certificates`** [[3]](#3-ckms-certificates)  Manage certificates. Create, import, destroy and revoke. Encrypt and
+decrypt data
 
 **`ec`** [[4]](#4-ckms-ec)  Manage elliptic curve keys. Encrypt and decrypt data using ECIES
 
@@ -34,7 +38,8 @@ Possible values:  `"true", "false"` [default: `"false"`]
 
 **`locate`** [[6]](#6-ckms-locate)  Locate cryptographic objects inside the KMS
 
-**`new-database`** [[7]](#7-ckms-new-database)  Initialize a new user encrypted database and return the secret (`SQLCipher` only).
+**`new-database`** [[7]](#7-ckms-new-database)  Initialize a new user encrypted database and return the secret (
+`SQLCipher` only).
 
 **`rsa`** [[8]](#8-ckms-rsa)  Manage RSA keys. Encrypt and decrypt data using RSA keys
 
@@ -42,13 +47,17 @@ Possible values:  `"true", "false"` [default: `"false"`]
 
 **`sym`** [[10]](#10-ckms-sym)  Manage symmetric keys. Encrypt and decrypt data
 
-**`login`** [[11]](#11-ckms-login)  Login to the Identity Provider of the KMS server using the `OAuth2` authorization code flow.
+**`login`** [[11]](#11-ckms-login)  Login to the Identity Provider of the KMS server using the `OAuth2` authorization
+code flow.
 
 **`logout`** [[12]](#12-ckms-logout)  Logout from the Identity Provider.
 
-**`markdown`** [[13]](#13-ckms-markdown)  Action to auto-generate doc in Markdown format Run `cargo run --bin ckms -- markdown documentation/docs/cli/main_commands.md`
+**`markdown`** [[13]](#13-ckms-markdown)  Action to auto-generate doc in Markdown format Run
+`cargo run --bin ckms -- markdown documentation/docs/cli/main_commands.md`
 
-**`google`** [[14]](#14-ckms-google)  Manage google elements. Handle key pairs and identities from Gmail API
+**`bench`** [[14]](#14-ckms-bench)  Run a set of benches to check the server performance
+
+**`google`** [[15]](#15-ckms-google)  Manage google elements. Handle key pairs and identities from Gmail API
 
 ---
 
@@ -57,6 +66,7 @@ Possible values:  `"true", "false"` [default: `"false"`]
 Manage the users' access rights to the cryptographic objects
 
 ### Usage
+
 `ckms access-rights <subcommand>`
 
 ### Subcommands
@@ -78,16 +88,20 @@ Manage the users' access rights to the cryptographic objects
 Grant another user one or multiple access rights to an object
 
 ### Usage
+
 `ckms access-rights grant [options] <USER>
  <OBJECT_UID>
  <OPERATIONS>...
 `
+
 ### Arguments
+
 ` <USER>` The user identifier to allow
 
 ` <OBJECT_UID>` The object unique identifier stored in the KMS
 
-` <OPERATIONS>` The operations to grant (`create`, `get`, `encrypt`, `decrypt`, `import`, `revoke`, `locate`, `rekey`, `destroy`)
+` <OPERATIONS>` The operations to grant (`create`, `get`, `encrypt`, `decrypt`, `import`, `revoke`, `locate`, `rekey`,
+`destroy`)
 
 
 
@@ -98,16 +112,20 @@ Grant another user one or multiple access rights to an object
 Revoke another user one or multiple access rights to an object
 
 ### Usage
+
 `ckms access-rights revoke [options] <USER>
  <OBJECT_UID>
  <OPERATIONS>...
 `
+
 ### Arguments
+
 ` <USER>` The user to revoke access to
 
 ` <OBJECT_UID>` The object unique identifier stored in the KMS
 
-` <OPERATIONS>` The operations to revoke (`create`, `get`, `encrypt`, `decrypt`, `import`, `revoke`, `locate`, `rekey`, `destroy`)
+` <OPERATIONS>` The operations to revoke (`create`, `get`, `encrypt`, `decrypt`, `import`, `revoke`, `locate`, `rekey`,
+`destroy`)
 
 
 
@@ -118,9 +136,12 @@ Revoke another user one or multiple access rights to an object
 List the access rights granted on an object to other users
 
 ### Usage
+
 `ckms access-rights list [options] <OBJECT_UID>
 `
+
 ### Arguments
+
 ` <OBJECT_UID>` The object unique identifier
 
 
@@ -132,6 +153,7 @@ List the access rights granted on an object to other users
 List the objects owned by the calling user
 
 ### Usage
+
 `ckms access-rights owned`
 
 
@@ -142,6 +164,7 @@ List the objects owned by the calling user
 List the access rights obtained by the calling user
 
 ### Usage
+
 `ckms access-rights obtained`
 
 
@@ -153,13 +176,15 @@ List the access rights obtained by the calling user
 Manage Covercrypt keys and policies. Rotate attributes. Encrypt and decrypt data
 
 ### Usage
+
 `ckms cc <subcommand>`
 
 ### Subcommands
 
 **`keys`** [[2.1]](#21-ckms-cc-keys)  Create, destroy, import, export, and rekey `Covercrypt` master and user keys
 
-**`policy`** [[2.2]](#22-ckms-cc-policy)  Extract, view, or edit policies of existing keys, and create a binary policy from specifications
+**`policy`** [[2.2]](#22-ckms-cc-policy)  Extract, view, or edit policies of existing keys, and create a binary policy
+from specifications
 
 **`encrypt`** [[2.3]](#23-ckms-cc-encrypt)  Encrypt a file using Covercrypt
 
@@ -172,13 +197,16 @@ Manage Covercrypt keys and policies. Rotate attributes. Encrypt and decrypt data
 Create, destroy, import, export, and rekey `Covercrypt` master and user keys
 
 ### Usage
+
 `ckms cc keys <subcommand>`
 
 ### Subcommands
 
-**`create-master-key-pair`** [[2.1.1]](#211-ckms-cc-keys-create-master-key-pair)  Create a new master key pair for a given policy and return the key IDs.
+**`create-master-key-pair`** [[2.1.1]](#211-ckms-cc-keys-create-master-key-pair)  Create a new master key pair for a
+given policy and return the key IDs.
 
-**`create-user-key`** [[2.1.2]](#212-ckms-cc-keys-create-user-key)  Create a new user decryption key given an access policy expressed as a boolean expression.
+**`create-user-key`** [[2.1.2]](#212-ckms-cc-keys-create-user-key)  Create a new user decryption key given an access
+policy expressed as a boolean expression.
 
 **`export`** [[2.1.3]](#213-ckms-cc-keys-export)  Export a key from the KMS
 
@@ -203,13 +231,20 @@ Create, destroy, import, export, and rekey `Covercrypt` master and user keys
 Create a new master key pair for a given policy and return the key IDs.
 
 ### Usage
+
 `ckms cc keys create-master-key-pair [options]`
+
 ### Arguments
-`--policy-specifications [-s] <POLICY_SPECIFICATIONS_FILE>` The JSON policy specifications file to use to generate the master keys. See the inline doc of the `create-master-key-pair` command for details
 
-`--policy-binary [-b] <POLICY_BINARY_FILE>` When not using policy specifications, a policy binary file can be used instead. See the `policy` command, to create this binary file from policy specifications or to extract it from existing keys
+`--policy-specifications [-s] <POLICY_SPECIFICATIONS_FILE>` The JSON policy specifications file to use to generate the
+master keys. See the inline doc of the `create-master-key-pair` command for details
 
-`--tag [-t] <TAG>` The tag to associate with the master key pair. To specify multiple tags, use the option multiple times
+`--policy-binary [-b] <POLICY_BINARY_FILE>` When not using policy specifications, a policy binary file can be used
+instead. See the `policy` command, to create this binary file from policy specifications or to extract it from existing
+keys
+
+`--tag [-t] <TAG>` The tag to associate with the master key pair. To specify multiple tags, use the option multiple
+times
 
 `--sensitive <SENSITIVE>` Sensitive: if set, the private key will not be exportable
 
@@ -224,15 +259,19 @@ Possible values:  `"true", "false"` [default: `"false"`]
 Create a new user decryption key given an access policy expressed as a boolean expression.
 
 ### Usage
+
 `ckms cc keys create-user-key [options] <MASTER_PRIVATE_KEY_ID>
  <ACCESS_POLICY>
 `
+
 ### Arguments
+
 ` <MASTER_PRIVATE_KEY_ID>` The master private key unique identifier
 
 ` <ACCESS_POLICY>` The access policy as a boolean expression combining policy attributes
 
-`--tag [-t] <TAG>` The tag to associate with the user decryption key. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` The tag to associate with the user decryption key. To specify multiple tags, use the option multiple
+times
 
 `--sensitive <SENSITIVE>` Sensitive: if set, the key will not be exportable
 
@@ -247,28 +286,34 @@ Possible values:  `"true", "false"` [default: `"false"`]
 Export a key from the KMS
 
 ### Usage
+
 `ckms cc keys export [options] <KEY_FILE>
 `
+
 ### Arguments
+
 ` <KEY_FILE>` The file to export the key to
 
 `--key-id [-k] <KEY_ID>` The key unique identifier stored in the KMS. If not specified, tags should be specified
 
-`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option
+multiple times
 
 `--key-format [-f] <KEY_FORMAT>` The format of the key
 
- - `json-ttlv` [default]. It should be the format to use to later re-import the key
- - `sec1-pem` and `sec1-der`only apply to NIST EC private keys (Not Curve25519 or X448)
- - `pkcs1-pem` and `pkcs1-der` only apply to RSA private and public keys
- - `pkcs8-pem` and `pkcs8-der` only apply to RSA and EC private keys
- - `spki-pem` and `spki-der` only apply to RSA and EC public keys
- - `raw` returns the raw bytes of
-      - symmetric keys
-      - Covercrypt keys
-      - wrapped keys
+- `json-ttlv` [default]. It should be the format to use to later re-import the key
+- `sec1-pem` and `sec1-der`only apply to NIST EC private keys (Not Curve25519 or X448)
+- `pkcs1-pem` and `pkcs1-der` only apply to RSA private and public keys
+- `pkcs8-pem` and `pkcs8-der` only apply to RSA and EC private keys
+- `spki-pem` and `spki-der` only apply to RSA and EC public keys
+- `raw` returns the raw bytes of
+    - symmetric keys
+    - Covercrypt keys
+    - wrapped keys
 
-Possible values:  `"json-ttlv", "sec1-pem", "sec1-der", "pkcs1-pem", "pkcs1-der", "pkcs8-pem", "pkcs8-der", "spki-pem", "spki-der", "base64", "raw"` [default: `"json-ttlv"`]
+Possible values:
+`"json-ttlv", "sec1-pem", "sec1-der", "pkcs1-pem", "pkcs1-der", "pkcs8-pem", "pkcs8-der", "spki-pem", "spki-der", "base64", "raw"` [default:
+`"json-ttlv"`]
 
 `--unwrap [-u] <UNWRAP>` Unwrap the key if it is wrapped before export
 
@@ -290,7 +335,8 @@ By default, the algorithm used is
 
 Possible values:  `"nist-key-wrap", "aes-gcm", "rsa-pkcs-v15", "rsa-oaep", "rsa-aes-key-wrap"`
 
-`--authenticated-additional-data [-d] <AUTHENTICATED_ADDITIONAL_DATA>` Authenticated encryption additional data Only available for AES GCM wrapping
+`--authenticated-additional-data [-d] <AUTHENTICATED_ADDITIONAL_DATA>` Authenticated encryption additional data Only
+available for AES GCM wrapping
 
 
 
@@ -301,17 +347,21 @@ Possible values:  `"nist-key-wrap", "aes-gcm", "rsa-pkcs-v15", "rsa-oaep", "rsa-
 Import a private or public key in the KMS.
 
 ### Usage
+
 `ckms cc keys import [options] <KEY_FILE>
  [KEY_ID]
 `
+
 ### Arguments
+
 ` <KEY_FILE>` The KMIP JSON TTLV key file
 
 ` <KEY_ID>` The unique id of the key; a random uuid is generated if not specified
 
 `--key-format [-f] <KEY_FORMAT>` The format of the key
 
-Possible values:  `"json-ttlv", "pem", "sec1", "pkcs1-priv", "pkcs1-pub", "pkcs8", "spki", "aes", "chacha20"` [default: `"json-ttlv"`]
+Possible values:  `"json-ttlv", "pem", "sec1", "pkcs1-priv", "pkcs1-pub", "pkcs8", "spki", "aes", "chacha20"` [default:
+`"json-ttlv"`]
 
 `--public-key-id [-p] <PUBLIC_KEY_ID>` For a private key: the corresponding KMS public key id if any
 
@@ -331,9 +381,11 @@ Possible values:  `"true", "false"` [default: `"false"`]
 
 `--key-usage <KEY_USAGE>` For what operations should the key be used
 
-Possible values:  `"sign", "verify", "encrypt", "decrypt", "wrap-key", "unwrap-key", "mac-generate", "mac-verify", "derive-key", "key-agreement", "certificate-sign", "crl-sign", "authenticate", "unrestricted"`
+Possible values:
+`"sign", "verify", "encrypt", "decrypt", "wrap-key", "unwrap-key", "mac-generate", "mac-verify", "derive-key", "key-agreement", "certificate-sign", "crl-sign", "authenticate", "unrestricted"`
 
-`--authenticated-additional-data [-d] <AUTHENTICATED_ADDITIONAL_DATA>` Optional authenticated encryption additional data to use for AES256GCM authenticated encryption unwrapping
+`--authenticated-additional-data [-d] <AUTHENTICATED_ADDITIONAL_DATA>` Optional authenticated encryption additional data
+to use for AES256GCM authenticated encryption unwrapping
 
 
 
@@ -344,15 +396,20 @@ Possible values:  `"sign", "verify", "encrypt", "decrypt", "wrap-key", "unwrap-k
 Locally wrap a key in KMIP JSON TTLV format.
 
 ### Usage
+
 `ckms cc keys wrap [options] <KEY_FILE_IN>
  [KEY_FILE_OUT]
 `
+
 ### Arguments
+
 ` <KEY_FILE_IN>` The KMIP JSON TTLV input key file to wrap
 
 ` <KEY_FILE_OUT>` The KMIP JSON output file. When not specified, the input file is overwritten
 
-`--wrap-password [-p] <WRAP_PASSWORD>` A password to wrap the imported key. This password will be derived into a AES-256 symmetric key. For security reasons, a fresh salt is internally handled and generated by `ckms` and this final AES symmetric key will be displayed only once
+`--wrap-password [-p] <WRAP_PASSWORD>` A password to wrap the imported key. This password will be derived into a AES-256
+symmetric key. For security reasons, a fresh salt is internally handled and generated by `ckms` and this final AES
+symmetric key will be displayed only once
 
 `--wrap-key-b64 [-k] <WRAP_KEY_B64>` A symmetric key as a base 64 string to wrap the imported key
 
@@ -369,17 +426,21 @@ Locally wrap a key in KMIP JSON TTLV format.
 Locally unwrap a key in KMIP JSON TTLV format.
 
 ### Usage
+
 `ckms cc keys unwrap [options] <KEY_FILE_IN>
  [KEY_FILE_OUT]
 `
+
 ### Arguments
+
 ` <KEY_FILE_IN>` The KMIP JSON TTLV input key file to unwrap
 
 ` <KEY_FILE_OUT>` The KMIP JSON output file. When not specified the input file is overwritten
 
 `--unwrap-key-b64 [-k] <UNWRAP_KEY_B64>` A symmetric key as a base 64 string to unwrap the imported key
 
-`--unwrap-key-id [-i] <UNWRAP_KEY_ID>` The id of a unwrapping key in the KMS that will be exported and used to unwrap the key
+`--unwrap-key-id [-i] <UNWRAP_KEY_ID>` The id of a unwrapping key in the KMS that will be exported and used to unwrap
+the key
 
 `--unwrap-key-file [-f] <UNWRAP_KEY_FILE>` A unwrapping key in a KMIP JSON TTLV file used to unwrap the key
 
@@ -392,14 +453,18 @@ Locally unwrap a key in KMIP JSON TTLV format.
 Revoke a Covercrypt master or user decryption key
 
 ### Usage
+
 `ckms cc keys revoke [options] <REVOCATION_REASON>
 `
+
 ### Arguments
+
 ` <REVOCATION_REASON>` The reason for the revocation as a string
 
 `--key-id [-k] <KEY_ID>` The key unique identifier of the key to revoke. If not specified, tags should be specified
 
-`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option
+multiple times
 
 
 
@@ -410,11 +475,15 @@ Revoke a Covercrypt master or user decryption key
 Destroy a Covercrypt master or user decryption key
 
 ### Usage
+
 `ckms cc keys destroy [options]`
+
 ### Arguments
+
 `--key-id [-k] <KEY_ID>` The key unique identifier. If not specified, tags should be specified
 
-`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option
+multiple times
 
 
 
@@ -425,14 +494,19 @@ Destroy a Covercrypt master or user decryption key
 Rekey the master and user keys for a given access policy.
 
 ### Usage
+
 `ckms cc keys rekey [options] <ACCESS_POLICY>
 `
+
 ### Arguments
+
 ` <ACCESS_POLICY>` The access policy to rekey. Example: `department::marketing && level::confidential`
 
-`--key-id [-k] <SECRET_KEY_ID>` The private master key unique identifier stored in the KMS. If not specified, tags should be specified
+`--key-id [-k] <SECRET_KEY_ID>` The private master key unique identifier stored in the KMS. If not specified, tags
+should be specified
 
-`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option
+multiple times
 
 
 
@@ -443,14 +517,19 @@ Rekey the master and user keys for a given access policy.
 Prune the master and user keys for a given access policy.
 
 ### Usage
+
 `ckms cc keys prune [options] <ACCESS_POLICY>
 `
+
 ### Arguments
+
 ` <ACCESS_POLICY>` The access policy to prune. Example: `department::marketing && level::confidential`
 
-`--key-id [-k] <SECRET_KEY_ID>` The private master key unique identifier stored in the KMS. If not specified, tags should be specified
+`--key-id [-k] <SECRET_KEY_ID>` The private master key unique identifier stored in the KMS. If not specified, tags
+should be specified
 
-`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option
+multiple times
 
 
 
@@ -462,27 +541,34 @@ Prune the master and user keys for a given access policy.
 Extract, view, or edit policies of existing keys, and create a binary policy from specifications
 
 ### Usage
+
 `ckms cc policy <subcommand>`
 
 ### Subcommands
 
 **`view`** [[2.2.1]](#221-ckms-cc-policy-view)  View the policy of an existing public or private master key.
 
-**`specs`** [[2.2.2]](#222-ckms-cc-policy-specs)  Extract the policy specifications from a public or private master key to a policy specifications file
+**`specs`** [[2.2.2]](#222-ckms-cc-policy-specs)  Extract the policy specifications from a public or private master key
+to a policy specifications file
 
-**`binary`** [[2.2.3]](#223-ckms-cc-policy-binary)  Extract the policy from a public or private master key to a policy binary file
+**`binary`** [[2.2.3]](#223-ckms-cc-policy-binary)  Extract the policy from a public or private master key to a policy
+binary file
 
 **`create`** [[2.2.4]](#224-ckms-cc-policy-create)  Create a policy binary file from policy specifications
 
-**`add-attribute`** [[2.2.5]](#225-ckms-cc-policy-add-attribute)  Add an attribute to the policy of an existing private master key.
+**`add-attribute`** [[2.2.5]](#225-ckms-cc-policy-add-attribute)  Add an attribute to the policy of an existing private
+master key.
 
-**`remove-attribute`** [[2.2.6]](#226-ckms-cc-policy-remove-attribute)  Remove an attribute from the policy of an existing private master key.
+**`remove-attribute`** [[2.2.6]](#226-ckms-cc-policy-remove-attribute)  Remove an attribute from the policy of an
+existing private master key.
 Permanently removes the ability to use this attribute in both encryptions and decryptions.
 
-**`disable-attribute`** [[2.2.7]](#227-ckms-cc-policy-disable-attribute)  Disable an attribute from the policy of an existing private master key.
+**`disable-attribute`** [[2.2.7]](#227-ckms-cc-policy-disable-attribute)  Disable an attribute from the policy of an
+existing private master key.
 Prevents the encryption of new messages for this attribute while keeping the ability to decrypt existing ciphertexts.
 
-**`rename-attribute`** [[2.2.8]](#228-ckms-cc-policy-rename-attribute)  Rename an attribute in the policy of an existing private master key.
+**`rename-attribute`** [[2.2.8]](#228-ckms-cc-policy-rename-attribute)  Rename an attribute in the policy of an existing
+private master key.
 
 ---
 
@@ -491,11 +577,15 @@ Prevents the encryption of new messages for this attribute while keeping the abi
 View the policy of an existing public or private master key.
 
 ### Usage
+
 `ckms cc policy view [options]`
+
 ### Arguments
+
 `--key-id [-i] <KEY_ID>` The public or private master key ID if the key is stored in the KMS
 
-`--key-file [-f] <KEY_FILE>` If `key-id` is not provided, the file containing the public or private master key in TTLV format
+`--key-file [-f] <KEY_FILE>` If `key-id` is not provided, the file containing the public or private master key in TTLV
+format
 
 `--detailed [-d] <DETAILED>` Show all the policy details rather than just the specifications
 
@@ -510,11 +600,15 @@ Possible values:  `"true", "false"` [default: `"false"`]
 Extract the policy specifications from a public or private master key to a policy specifications file
 
 ### Usage
+
 `ckms cc policy specs [options]`
+
 ### Arguments
+
 `--key-id [-i] <KEY_ID>` The public or private master key ID if the key is stored in the KMS
 
-`--key-file [-f] <KEY_FILE>` If `key-id` is not provided, the file containing the public or private master key in JSON TTLV format
+`--key-file [-f] <KEY_FILE>` If `key-id` is not provided, the file containing the public or private master key in JSON
+TTLV format
 
 `--specifications [-s] <POLICY_SPECS_FILE>` The output policy specifications file
 
@@ -527,11 +621,15 @@ Extract the policy specifications from a public or private master key to a polic
 Extract the policy from a public or private master key to a policy binary file
 
 ### Usage
+
 `ckms cc policy binary [options]`
+
 ### Arguments
+
 `--key-id [-i] <KEY_ID>` The public or private master key ID if the key is stored in the KMS
 
-`--key-file [-f] <KEY_FILE>` If `key-id` is not provided, the file containing the public or private master key in TTLV format
+`--key-file [-f] <KEY_FILE>` If `key-id` is not provided, the file containing the public or private master key in TTLV
+format
 
 `--policy [-p] <POLICY_BINARY_FILE>` The output binary policy file
 
@@ -544,9 +642,13 @@ Extract the policy from a public or private master key to a policy binary file
 Create a policy binary file from policy specifications
 
 ### Usage
+
 `ckms cc policy create [options]`
+
 ### Arguments
-`--specifications [-s] <POLICY_SPECIFICATIONS_FILE>` The policy specifications filename. The policy is expressed as a JSON object describing the Policy axes. See the documentation for details
+
+`--specifications [-s] <POLICY_SPECIFICATIONS_FILE>` The policy specifications filename. The policy is expressed as a
+JSON object describing the Policy axes. See the documentation for details
 
 `--policy [-p] <POLICY_BINARY_FILE>` The output binary policy file generated from the specifications file
 
@@ -559,18 +661,23 @@ Create a policy binary file from policy specifications
 Add an attribute to the policy of an existing private master key.
 
 ### Usage
+
 `ckms cc policy add-attribute [options] <ATTRIBUTE>
 `
+
 ### Arguments
+
 ` <ATTRIBUTE>` The name of the attribute to create. Example: `department::rd`
 
 `--hybridized <HYBRIDIZED>` Set encryption hint for the new attribute to use hybridized keys
 
 Possible values:  `"true", "false"` [default: `"false"`]
 
-`--key-id [-k] <SECRET_KEY_ID>` The private master key unique identifier stored in the KMS. If not specified, tags should be specified
+`--key-id [-k] <SECRET_KEY_ID>` The private master key unique identifier stored in the KMS. If not specified, tags
+should be specified
 
-`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option
+multiple times
 
 
 
@@ -582,14 +689,19 @@ Remove an attribute from the policy of an existing private master key.
 Permanently removes the ability to use this attribute in both encryptions and decryptions.
 
 ### Usage
+
 `ckms cc policy remove-attribute [options] <ATTRIBUTE>
 `
+
 ### Arguments
+
 ` <ATTRIBUTE>` The name of the attribute to remove. Example: `department::marketing`
 
-`--key-id [-k] <SECRET_KEY_ID>` The private master key unique identifier stored in the KMS. If not specified, tags should be specified
+`--key-id [-k] <SECRET_KEY_ID>` The private master key unique identifier stored in the KMS. If not specified, tags
+should be specified
 
-`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option
+multiple times
 
 
 
@@ -601,14 +713,19 @@ Disable an attribute from the policy of an existing private master key.
 Prevents the encryption of new messages for this attribute while keeping the ability to decrypt existing ciphertexts.
 
 ### Usage
+
 `ckms cc policy disable-attribute [options] <ATTRIBUTE>
 `
+
 ### Arguments
+
 ` <ATTRIBUTE>` The name of the attribute to disable. Example: `department::marketing`
 
-`--key-id [-k] <SECRET_KEY_ID>` The private master key unique identifier stored in the KMS. If not specified, tags should be specified
+`--key-id [-k] <SECRET_KEY_ID>` The private master key unique identifier stored in the KMS. If not specified, tags
+should be specified
 
-`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option
+multiple times
 
 
 
@@ -619,17 +736,22 @@ Prevents the encryption of new messages for this attribute while keeping the abi
 Rename an attribute in the policy of an existing private master key.
 
 ### Usage
+
 `ckms cc policy rename-attribute [options] <ATTRIBUTE>
  <NEW_NAME>
 `
+
 ### Arguments
+
 ` <ATTRIBUTE>` The name of the attribute to rename. Example: `department::mkg`
 
 ` <NEW_NAME>` The new name for the attribute. Example: `marketing`
 
-`--key-id [-k] <SECRET_KEY_ID>` The private master key unique identifier stored in the KMS. If not specified, tags should be specified
+`--key-id [-k] <SECRET_KEY_ID>` The private master key unique identifier stored in the KMS. If not specified, tags
+should be specified
 
-`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option
+multiple times
 
 
 
@@ -641,21 +763,27 @@ Rename an attribute in the policy of an existing private master key.
 Encrypt a file using Covercrypt
 
 ### Usage
+
 `ckms cc encrypt [options] <FILE>...
  <ENCRYPTION_POLICY>
 `
+
 ### Arguments
+
 ` <FILE>` The files to encrypt
 
-` <ENCRYPTION_POLICY>` The encryption policy to encrypt the file with Example: "`department::marketing` && `level::confidential`"
+` <ENCRYPTION_POLICY>` The encryption policy to encrypt the file with Example: "`department::marketing` &&
+`level::confidential`"
 
 `--key-id [-k] <KEY_ID>` The public key unique identifier. If not specified, tags should be specified
 
-`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option
+multiple times
 
 `--output-file [-o] <OUTPUT_FILE>` The encrypted output file path
 
-`--authentication-data [-a] <AUTHENTICATION_DATA>` Optional authentication data. This data needs to be provided back for decryption
+`--authentication-data [-a] <AUTHENTICATION_DATA>` Optional authentication data. This data needs to be provided back for
+decryption
 
 
 
@@ -666,14 +794,18 @@ Encrypt a file using Covercrypt
 Decrypt a file using Covercrypt
 
 ### Usage
+
 `ckms cc decrypt [options] <FILE>...
 `
+
 ### Arguments
+
 ` <FILE>` The files to decrypt
 
 `--key-id [-k] <KEY_ID>` The user key unique identifier If not specified, tags should be specified
 
-`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option
+multiple times
 
 `--output-file [-o] <OUTPUT_FILE>` The encrypted output file path
 
@@ -689,6 +821,7 @@ Decrypt a file using Covercrypt
 Manage certificates. Create, import, destroy and revoke. Encrypt and decrypt data
 
 ### Usage
+
 `ckms certificates <subcommand>`
 
 ### Subcommands
@@ -721,13 +854,18 @@ Manage certificates. Create, import, destroy and revoke. Encrypt and decrypt dat
 Issue or renew a X509 certificate
 
 ### Usage
+
 `ckms certificates certify [options]`
+
 ### Arguments
-`--certificate-id [-c] <CERTIFICATE_ID>` The unique identifier of the certificate to issue or renew. If not provided, a random one will be generated when issuing a certificate, or the original one will be used when renewing a certificate
+
+`--certificate-id [-c] <CERTIFICATE_ID>` The unique identifier of the certificate to issue or renew. If not provided, a
+random one will be generated when issuing a certificate, or the original one will be used when renewing a certificate
 
 `--certificate-signing-request [-r] <CERTIFICATE_SIGNING_REQUEST>` The path to a certificate signing request
 
-`--certificate-signing-request-format [-f] <CERTIFICATE_SIGNING_REQUEST_FORMAT>` The format of the certificate signing request
+`--certificate-signing-request-format [-f] <CERTIFICATE_SIGNING_REQUEST_FORMAT>` The format of the certificate signing
+request
 
 Possible values:  `"pem", "der"` [default: `"pem"`]
 
@@ -744,15 +882,20 @@ the subject name to use.
 
 `--algorithm [-a] <ALGORITHM>` The algorithm to use for the keypair generation
 
-Possible values:  `"nist-p192", "nist-p224", "nist-p256", "nist-p384", "nist-p521", "x25519", "ed25519", "x448", "ed448", "rsa1024", "rsa2048", "rsa3072", "rsa4096"` [default: `"rsa4096"`]
+Possible values:
+`"nist-p192", "nist-p224", "nist-p256", "nist-p384", "nist-p521", "x25519", "ed25519", "x448", "ed448", "rsa1024", "rsa2048", "rsa3072", "rsa4096"` [default:
+`"rsa4096"`]
 
-`--issuer-private-key-id [-k] <ISSUER_PRIVATE_KEY_ID>` The unique identifier of the private key of the issuer. A certificate must be linked to that private key if no issuer certificate id is provided
+`--issuer-private-key-id [-k] <ISSUER_PRIVATE_KEY_ID>` The unique identifier of the private key of the issuer. A
+certificate must be linked to that private key if no issuer certificate id is provided
 
-`--issuer-certificate-id [-i] <ISSUER_CERTIFICATE_ID>` The unique identifier of the certificate of the issuer. A private key must be linked to that certificate if no issuer private key id is provided
+`--issuer-certificate-id [-i] <ISSUER_CERTIFICATE_ID>` The unique identifier of the certificate of the issuer. A private
+key must be linked to that certificate if no issuer private key id is provided
 
 `--days [-d] <NUMBER_OF_DAYS>` The requested number of validity days The server may grant a different value
 
-`--certificate-extensions [-e] <CERTIFICATE_EXTENSIONS>` The path to a X509 extension's file, containing a `v3_ca` paragraph
+`--certificate-extensions [-e] <CERTIFICATE_EXTENSIONS>` The path to a X509 extension's file, containing a `v3_ca`
+paragraph
 with the x509 extensions to use. For instance:
 
 `--tag [-t] <TAG>` The tag to associate to the certificate. To specify multiple tags, use the option multiple times
@@ -766,14 +909,19 @@ with the x509 extensions to use. For instance:
 Decrypt a file using the private key of a certificate
 
 ### Usage
+
 `ckms certificates decrypt [options] <FILE>
 `
+
 ### Arguments
+
 ` <FILE>` The file to decrypt
 
-`--key-id [-k] <PRIVATE_KEY_ID>` The private key unique identifier related to certificate If not specified, tags should be specified
+`--key-id [-k] <PRIVATE_KEY_ID>` The private key unique identifier related to certificate If not specified, tags should
+be specified
 
-`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option
+multiple times
 
 `--output-file [-o] <OUTPUT_FILE>` The encrypted output file path
 
@@ -794,18 +942,23 @@ Possible values:  `"ckm-rsa-pkcs", "ckm-rsa-pkcs-oaep", "ckm-rsa-aes-key-wrap"`
 Encrypt a file using the certificate public key
 
 ### Usage
+
 `ckms certificates encrypt [options] <FILE>
 `
+
 ### Arguments
+
 ` <FILE>` The file to encrypt
 
 `--certificate-id [-c] <CERTIFICATE_ID>` The certificate unique identifier. If not specified, tags should be specified
 
-`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option
+multiple times
 
 `--output-file [-o] <OUTPUT_FILE>` The encrypted output file path
 
-`--authentication-data [-a] <AUTHENTICATION_DATA>` Optional authentication data. This data needs to be provided back for decryption
+`--authentication-data [-a] <AUTHENTICATION_DATA>` Optional authentication data. This data needs to be provided back for
+decryption
 
 `--encryption-algorithm [-e] <ENCRYPTION_ALGORITHM>` Optional encryption algorithm.
 This is only available for RSA keys for now.
@@ -822,12 +975,16 @@ Possible values:  `"ckm-rsa-pkcs", "ckm-rsa-pkcs-oaep", "ckm-rsa-aes-key-wrap"`
 Export a certificate from the KMS
 
 ### Usage
+
 `ckms certificates export [options] <CERTIFICATE_FILE>
 `
+
 ### Arguments
+
 ` <CERTIFICATE_FILE>` The file to export the certificate to
 
-`--certificate-id [-c] <UNIQUE_ID>` The certificate unique identifier stored in the KMS; for PKCS#12, provide the private key id
+`--certificate-id [-c] <UNIQUE_ID>` The certificate unique identifier stored in the KMS; for PKCS#12, provide the
+private key id
 If not specified, tags should be specified
 
 `--tag [-t] <TAG>` Tag to use to retrieve the certificate/private key when no unique id is specified.
@@ -859,10 +1016,13 @@ Import one of the following:
 - the Mozilla Common CA Database (CCADB - fetched by the CLI before import) (ccadb)
 
 ### Usage
+
 `ckms certificates import [options] [CERTIFICATE_FILE]
  [CERTIFICATE_ID]
 `
+
 ### Arguments
+
 ` <CERTIFICATE_FILE>` The input file in PEM, KMIP-JSON-TTLV or PKCS#12 format
 
 ` <CERTIFICATE_ID>` The unique id of the leaf certificate; a unique id
@@ -877,7 +1037,8 @@ Possible values:  `"json-ttlv", "pem", "der", "chain", "ccadb", "pkcs12"` [defau
 
 `--public-key-id [-q] <PUBLIC_KEY_ID>` The corresponding public key id if any. Ignored for PKCS12 and CCADB formats
 
-`--issuer-certificate-id [-i] <ISSUER_CERTIFICATE_ID>` The issuer certificate id if any. Ignored for PKCS12 and CCADB formats
+`--issuer-certificate-id [-i] <ISSUER_CERTIFICATE_ID>` The issuer certificate id if any. Ignored for PKCS12 and CCADB
+formats
 
 `--pkcs12-password [-p] <PKCS12_PASSWORD>` PKCS12 password: only available for PKCS12 format
 
@@ -889,7 +1050,8 @@ Possible values:  `"true", "false"` [default: `"false"`]
 
 `--key-usage <KEY_USAGE>` For what operations should the certificate be used
 
-Possible values:  `"sign", "verify", "encrypt", "decrypt", "wrap-key", "unwrap-key", "mac-generate", "mac-verify", "derive-key", "key-agreement", "certificate-sign", "crl-sign", "authenticate", "unrestricted"`
+Possible values:
+`"sign", "verify", "encrypt", "decrypt", "wrap-key", "unwrap-key", "mac-generate", "mac-verify", "derive-key", "key-agreement", "certificate-sign", "crl-sign", "authenticate", "unrestricted"`
 
 
 
@@ -900,14 +1062,19 @@ Possible values:  `"sign", "verify", "encrypt", "decrypt", "wrap-key", "unwrap-k
 Revoke a certificate
 
 ### Usage
+
 `ckms certificates revoke [options] <REVOCATION_REASON>
 `
+
 ### Arguments
+
 ` <REVOCATION_REASON>` The reason for the revocation as a string
 
-`--certificate-id [-c] <CERTIFICATE_ID>` The certificate unique identifier of the certificate to revoke. If not specified, tags should be specified
+`--certificate-id [-c] <CERTIFICATE_ID>` The certificate unique identifier of the certificate to revoke. If not
+specified, tags should be specified
 
-`--tag [-t] <TAG>` Tag to use to retrieve the certificate when no certificate id is specified. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` Tag to use to retrieve the certificate when no certificate id is specified. To specify multiple tags,
+use the option multiple times
 
 
 
@@ -918,11 +1085,15 @@ Revoke a certificate
 Destroy a certificate
 
 ### Usage
+
 `ckms certificates destroy [options]`
+
 ### Arguments
+
 `--certificate-id [-c] <CERTIFICATE_ID>` The certificate unique identifier. If not specified, tags should be specified
 
-`--tag [-t] <TAG>` Tag to use to retrieve the certificate when no certificate id is specified. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` Tag to use to retrieve the certificate when no certificate id is specified. To specify multiple tags,
+use the option multiple times
 
 
 
@@ -933,13 +1104,17 @@ Destroy a certificate
 Validate a certificate
 
 ### Usage
+
 `ckms certificates validate [options]`
+
 ### Arguments
+
 `--certificate [-v] <CERTIFICATE>` One or more Certificates filepath
 
 `--unique-identifier [-k] <UNIQUE_IDENTIFIER>` One or more Unique Identifiers of Certificate Objects
 
-`--validity-time [-t] <VALIDITY_TIME>` A Date-Time object indicating when the certificate chain needs to be valid. If omitted, the current date and time SHALL be assumed
+`--validity-time [-t] <VALIDITY_TIME>` A Date-Time object indicating when the certificate chain needs to be valid. If
+omitted, the current date and time SHALL be assumed
 
 
 
@@ -951,6 +1126,7 @@ Validate a certificate
 Manage elliptic curve keys. Encrypt and decrypt data using ECIES
 
 ### Usage
+
 `ckms ec <subcommand>`
 
 ### Subcommands
@@ -968,6 +1144,7 @@ Manage elliptic curve keys. Encrypt and decrypt data using ECIES
 Create, destroy, import, and export elliptic curve key pairs
 
 ### Usage
+
 `ckms ec keys <subcommand>`
 
 ### Subcommands
@@ -993,14 +1170,20 @@ Create, destroy, import, and export elliptic curve key pairs
 Create an elliptic curve key pair
 
 ### Usage
+
 `ckms ec keys create [options] [PRIVATE_KEY_ID]
 `
+
 ### Arguments
+
 `--curve [-c] <CURVE>` The elliptic curve
 
-Possible values:  `"nist-p192", "nist-p224", "nist-p256", "nist-p384", "nist-p521", "x25519", "ed25519", "x448", "ed448"` [default: `"nist-p256"`]
+Possible values:
+`"nist-p192", "nist-p224", "nist-p256", "nist-p384", "nist-p521", "x25519", "ed25519", "x448", "ed448"` [default:
+`"nist-p256"`]
 
-`--tag [-t] <TAG>` The tag to associate with the master key pair. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` The tag to associate with the master key pair. To specify multiple tags, use the option multiple
+times
 
 ` <PRIVATE_KEY_ID>` The unique id of the private key; a random uuid is generated if not specified
 
@@ -1017,28 +1200,34 @@ Possible values:  `"true", "false"` [default: `"false"`]
 Export a key from the KMS
 
 ### Usage
+
 `ckms ec keys export [options] <KEY_FILE>
 `
+
 ### Arguments
+
 ` <KEY_FILE>` The file to export the key to
 
 `--key-id [-k] <KEY_ID>` The key unique identifier stored in the KMS. If not specified, tags should be specified
 
-`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option
+multiple times
 
 `--key-format [-f] <KEY_FORMAT>` The format of the key
 
- - `json-ttlv` [default]. It should be the format to use to later re-import the key
- - `sec1-pem` and `sec1-der`only apply to NIST EC private keys (Not Curve25519 or X448)
- - `pkcs1-pem` and `pkcs1-der` only apply to RSA private and public keys
- - `pkcs8-pem` and `pkcs8-der` only apply to RSA and EC private keys
- - `spki-pem` and `spki-der` only apply to RSA and EC public keys
- - `raw` returns the raw bytes of
-      - symmetric keys
-      - Covercrypt keys
-      - wrapped keys
+- `json-ttlv` [default]. It should be the format to use to later re-import the key
+- `sec1-pem` and `sec1-der`only apply to NIST EC private keys (Not Curve25519 or X448)
+- `pkcs1-pem` and `pkcs1-der` only apply to RSA private and public keys
+- `pkcs8-pem` and `pkcs8-der` only apply to RSA and EC private keys
+- `spki-pem` and `spki-der` only apply to RSA and EC public keys
+- `raw` returns the raw bytes of
+    - symmetric keys
+    - Covercrypt keys
+    - wrapped keys
 
-Possible values:  `"json-ttlv", "sec1-pem", "sec1-der", "pkcs1-pem", "pkcs1-der", "pkcs8-pem", "pkcs8-der", "spki-pem", "spki-der", "base64", "raw"` [default: `"json-ttlv"`]
+Possible values:
+`"json-ttlv", "sec1-pem", "sec1-der", "pkcs1-pem", "pkcs1-der", "pkcs8-pem", "pkcs8-der", "spki-pem", "spki-der", "base64", "raw"` [default:
+`"json-ttlv"`]
 
 `--unwrap [-u] <UNWRAP>` Unwrap the key if it is wrapped before export
 
@@ -1060,7 +1249,8 @@ By default, the algorithm used is
 
 Possible values:  `"nist-key-wrap", "aes-gcm", "rsa-pkcs-v15", "rsa-oaep", "rsa-aes-key-wrap"`
 
-`--authenticated-additional-data [-d] <AUTHENTICATED_ADDITIONAL_DATA>` Authenticated encryption additional data Only available for AES GCM wrapping
+`--authenticated-additional-data [-d] <AUTHENTICATED_ADDITIONAL_DATA>` Authenticated encryption additional data Only
+available for AES GCM wrapping
 
 
 
@@ -1071,17 +1261,21 @@ Possible values:  `"nist-key-wrap", "aes-gcm", "rsa-pkcs-v15", "rsa-oaep", "rsa-
 Import a private or public key in the KMS.
 
 ### Usage
+
 `ckms ec keys import [options] <KEY_FILE>
  [KEY_ID]
 `
+
 ### Arguments
+
 ` <KEY_FILE>` The KMIP JSON TTLV key file
 
 ` <KEY_ID>` The unique id of the key; a random uuid is generated if not specified
 
 `--key-format [-f] <KEY_FORMAT>` The format of the key
 
-Possible values:  `"json-ttlv", "pem", "sec1", "pkcs1-priv", "pkcs1-pub", "pkcs8", "spki", "aes", "chacha20"` [default: `"json-ttlv"`]
+Possible values:  `"json-ttlv", "pem", "sec1", "pkcs1-priv", "pkcs1-pub", "pkcs8", "spki", "aes", "chacha20"` [default:
+`"json-ttlv"`]
 
 `--public-key-id [-p] <PUBLIC_KEY_ID>` For a private key: the corresponding KMS public key id if any
 
@@ -1101,9 +1295,11 @@ Possible values:  `"true", "false"` [default: `"false"`]
 
 `--key-usage <KEY_USAGE>` For what operations should the key be used
 
-Possible values:  `"sign", "verify", "encrypt", "decrypt", "wrap-key", "unwrap-key", "mac-generate", "mac-verify", "derive-key", "key-agreement", "certificate-sign", "crl-sign", "authenticate", "unrestricted"`
+Possible values:
+`"sign", "verify", "encrypt", "decrypt", "wrap-key", "unwrap-key", "mac-generate", "mac-verify", "derive-key", "key-agreement", "certificate-sign", "crl-sign", "authenticate", "unrestricted"`
 
-`--authenticated-additional-data [-d] <AUTHENTICATED_ADDITIONAL_DATA>` Optional authenticated encryption additional data to use for AES256GCM authenticated encryption unwrapping
+`--authenticated-additional-data [-d] <AUTHENTICATED_ADDITIONAL_DATA>` Optional authenticated encryption additional data
+to use for AES256GCM authenticated encryption unwrapping
 
 
 
@@ -1114,15 +1310,20 @@ Possible values:  `"sign", "verify", "encrypt", "decrypt", "wrap-key", "unwrap-k
 Locally wrap a key in KMIP JSON TTLV format.
 
 ### Usage
+
 `ckms ec keys wrap [options] <KEY_FILE_IN>
  [KEY_FILE_OUT]
 `
+
 ### Arguments
+
 ` <KEY_FILE_IN>` The KMIP JSON TTLV input key file to wrap
 
 ` <KEY_FILE_OUT>` The KMIP JSON output file. When not specified, the input file is overwritten
 
-`--wrap-password [-p] <WRAP_PASSWORD>` A password to wrap the imported key. This password will be derived into a AES-256 symmetric key. For security reasons, a fresh salt is internally handled and generated by `ckms` and this final AES symmetric key will be displayed only once
+`--wrap-password [-p] <WRAP_PASSWORD>` A password to wrap the imported key. This password will be derived into a AES-256
+symmetric key. For security reasons, a fresh salt is internally handled and generated by `ckms` and this final AES
+symmetric key will be displayed only once
 
 `--wrap-key-b64 [-k] <WRAP_KEY_B64>` A symmetric key as a base 64 string to wrap the imported key
 
@@ -1139,17 +1340,21 @@ Locally wrap a key in KMIP JSON TTLV format.
 Locally unwrap a key in KMIP JSON TTLV format.
 
 ### Usage
+
 `ckms ec keys unwrap [options] <KEY_FILE_IN>
  [KEY_FILE_OUT]
 `
+
 ### Arguments
+
 ` <KEY_FILE_IN>` The KMIP JSON TTLV input key file to unwrap
 
 ` <KEY_FILE_OUT>` The KMIP JSON output file. When not specified the input file is overwritten
 
 `--unwrap-key-b64 [-k] <UNWRAP_KEY_B64>` A symmetric key as a base 64 string to unwrap the imported key
 
-`--unwrap-key-id [-i] <UNWRAP_KEY_ID>` The id of a unwrapping key in the KMS that will be exported and used to unwrap the key
+`--unwrap-key-id [-i] <UNWRAP_KEY_ID>` The id of a unwrapping key in the KMS that will be exported and used to unwrap
+the key
 
 `--unwrap-key-file [-f] <UNWRAP_KEY_FILE>` A unwrapping key in a KMIP JSON TTLV file used to unwrap the key
 
@@ -1162,14 +1367,18 @@ Locally unwrap a key in KMIP JSON TTLV format.
 Revoke a public or private key
 
 ### Usage
+
 `ckms ec keys revoke [options] <REVOCATION_REASON>
 `
+
 ### Arguments
+
 ` <REVOCATION_REASON>` The reason for the revocation as a string
 
 `--key-id [-k] <KEY_ID>` The key unique identifier of the key to revoke. If not specified, tags should be specified
 
-`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option
+multiple times
 
 
 
@@ -1180,11 +1389,15 @@ Revoke a public or private key
 Destroy a public or private key
 
 ### Usage
+
 `ckms ec keys destroy [options]`
+
 ### Arguments
+
 `--key-id [-k] <KEY_ID>` The key unique identifier of the key to destroy If not specified, tags should be specified
 
-`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option
+multiple times
 
 
 
@@ -1196,18 +1409,23 @@ Destroy a public or private key
 Encrypt a file with the given public key using ECIES
 
 ### Usage
+
 `ckms ec encrypt [options] <FILE>
 `
+
 ### Arguments
+
 ` <FILE>` The file to encrypt
 
 `--key-id [-k] <KEY_ID>` The public key unique identifier. If not specified, tags should be specified
 
-`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option
+multiple times
 
 `--output-file [-o] <OUTPUT_FILE>` The encrypted output file path
 
-`--authentication-data [-a] <AUTHENTICATION_DATA>` Optional authentication data. This data needs to be provided back for decryption
+`--authentication-data [-a] <AUTHENTICATION_DATA>` Optional authentication data. This data needs to be provided back for
+decryption
 
 
 
@@ -1218,14 +1436,18 @@ Encrypt a file with the given public key using ECIES
 Decrypts a file with the given private key using ECIES
 
 ### Usage
+
 `ckms ec decrypt [options] <FILE>
 `
+
 ### Arguments
+
 ` <FILE>` The file to decrypt
 
 `--key-id [-k] <KEY_ID>` The private key unique identifier If not specified, tags should be specified
 
-`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option
+multiple times
 
 `--output-file [-o] <OUTPUT_FILE>` The encrypted output file path
 
@@ -1241,6 +1463,7 @@ Decrypts a file with the given private key using ECIES
 Get/Set/Delete the KMIP object attributes
 
 ### Usage
+
 `ckms attributes <subcommand>`
 
 ### Subcommands
@@ -1258,23 +1481,29 @@ Get/Set/Delete the KMIP object attributes
 Get the KMIP object attributes and tags.
 
 ### Usage
+
 `ckms attributes get [options]`
+
 ### Arguments
+
 `--id [-i] <ID>` The unique identifier of the cryptographic object. If not specified, tags should be specified
 
-`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option
+multiple times
 
 `--attribute [-a] <ATTRIBUTE>` The attributes or `KMIP-tags` to retrieve.
 To specify multiple attributes, use the option multiple times.
 If not specified, all possible attributes are returned.
 
-Possible values:  `"ActivationDate", "ApplicationData", "ApplicationNamespace", "ApplicationSpecific_Information", "ArchiveDate", "AsynchronousCorrelation_Value", "AsynchronousIndicator", "Attribute", "AttributeName", "AttributeValue", "Authentication", "BatchCount", "BatchErrorContinuationOption", "BatchItem", "BatchOrderOption", "BlockCipherMode", "CancellationResult", "Certificate", "CertificateRequest", "CertificateRequestType", "CertificateType", "CertificateValue", "CompromiseDate", "CompromiseOccurrenceDate", "ContactInformation", "Credential", "CredentialType", "CredentialValue", "CriticalityIndicator", "CRTCoefficient", "CryptographicAlgorithm", "CryptographicDomainParameters", "CryptographicLength", "CryptographicParameters", "CryptographicUsageMask", "D", "DeactivationDate", "DerivationData", "DerivationMethod", "DerivationParameters", "DestroyDate", "Digest", "DigestValue", "EncryptionKeyInformation", "G", "HashingAlgorithm", "InitialDate", "InitializationVector", "IterationCount", "IVCounterNonce", "J", "Key", "KeyBlock", "KeyCompressionType", "KeyFormatType", "KeyMaterial", "KeyPartIdentifier", "KeyValue", "KeyWrappingData", "KeyWrappingSpecification", "LastChangeDate", "LeaseTime", "Link", "LinkType", "LinkedObjectIdentifier", "MACSignature", "MACSignatureKey_Information", "MaximumItems", "MaximumResponseSize", "MessageExtension", "Modulus", "Name", "NameType", "NameValue", "ObjectGroup", "ObjectType", "Offset", "OpaqueDataType", "OpaqueDataValue", "OpaqueObject", "Operation", "P", "PaddingMethod", "PrimeExponentP", "PrimeExponentQ", "PrimeFieldSize", "PrivateExponent", "PrivateKey", "PrivateKeyUniqueIdentifier", "ProcessStartDate", "ProtectStopDate", "ProtocolVersion", "ProtocolVersionMajor", "ProtocolVersionMinor", "PublicExponent", "PublicKey", "PublicKeyUniqueIdentifier", "PutFunction", "Q", "QString", "Qlength", "QueryFunction", "RecommendedCurve", "ReplacedUniqueIdentifier", "RequestHeader", "RequestMessage", "RequestPayload", "ResponseHeader", "ResponseMessage", "ResponsePayload", "ResultMessage", "ResultReason", "ResultStatus", "RevocationMessage", "RevocationReason", "RevocationReasonCode", "KeyRoleType", "Salt", "SecretData", "SecretDataType", "ServerInformation", "SplitKey", "SplitKeyMethod", "SplitKeyParts", "SplitKeyThreshold", "State", "StorageStatusMask", "SymmetricKey", "TimeStamp", "UniqueBatchItemID", "UniqueIdentifier", "UsageLimits", "UsageLimitsCount", "UsageLimitsTotal", "UsageLimitsUnit", "Username", "ValidityDate", "ValidityIndicator", "VendorExtension", "VendorIdentification", "WrappingMethod", "X", "Y", "Password", "DeviceIdentifier", "EncodingOption", "ExtensionInformation", "ExtensionName", "ExtensionTag", "ExtensionType", "Fresh", "MachineIdentifier", "MediaIdentifier", "NetworkIdentifier", "ObjectGroupMember", "CertificateLength", "DigitalSignatureAlgorithm", "CertificateSerialNumber", "DeviceSerialNumber", "IssuerAlternativeName", "IssuerDistinguishedName", "SubjectAlternativeName", "SubjectDistinguishedName", "X509CertificateIdentifier", "X509CertificateIssuer", "X509CertificateSubject", "KeyValueLocation", "KeyValueLocationValue", "KeyValueLocationType", "KeyValuePresent", "OriginalCreationDate", "PGPKey", "PGPKeyVersion", "AlternativeName", "AlternativeNameValue", "AlternativeNameType", "Data", "SignatureData", "DataLength", "RandomIV", "MACData", "AttestationType", "Nonce", "NonceID", "NonceValue", "AttestationMeasurement", "AttestationAssertion", "IVLength", "TagLength", "FixedFieldLength", "CounterLength", "InitialCounterValue", "InvocationFieldLength", "AttestationCapableIndicator", "OffsetItems", "LocatedItems", "CorrelationValue", "InitIndicator", "FinalIndicator", "RNGParameters", "RNGAlgorithm", "DRBGAlgorithm", "FIPS186Variation", "PredictionResistance", "RandomNumberGenerator", "ValidationInformation", "ValidationAuthorityType", "ValidationAuthorityCountry", "ValidationAuthorityURI", "ValidationVersionMajor", "ValidationVersionMinor", "ValidationType", "ValidationLevel", "ValidationCertificateIdentifier", "ValidationCertificateURI", "ValidationVendorURI", "ValidationProfile", "ProfileInformation", "ProfileName", "ServerURI", "ServerPort", "StreamingCapability", "AsynchronousCapability", "AttestationCapability", "UnwrapMode", "DestroyAction", "ShreddingAlgorithm", "RNGMode", "ClientRegistrationMethod", "CapabilityInformation", "KeyWrapType", "BatchUndoCapability", "BatchContinueCapability", "PKCS12FriendlyName", "Description", "Comment", "AuthenticatedEncryptionAdditionalData", "AuthenticatedEncryptionTag", "SaltLength", "MaskGenerator", "MaskGeneratorHashingAlgorithm", "PSource", "TrailerField", "ClientCorrelationValue", "ServerCorrelationValue", "DigestedData", "CertificateSubjectCN", "CertificateSubjectO", "CertificateSubjectOU", "CertificateSubjectEmail", "CertificateSubjectC", "CertificateSubjectST", "CertificateSubjectL", "CertificateSubjectUID", "CertificateSubjectSerialNumber", "CertificateSubjectTitle", "CertificateSubjectDC", "CertificateSubjectDNQualifier", "CertificateIssuerCN", "CertificateIssuerO", "CertificateIssuerOU", "CertificateIssuerEmail", "CertificateIssuerC", "CertificateIssuerST", "CertificateIssuerL", "CertificateIssuerUID", "CertificateIssuerSerialNumber", "CertificateIssuerTitle", "CertificateIssuerDC", "CertificateIssuerDNQualifier", "Sensitive", "AlwaysSensitive", "Extractable", "NeverExtractable", "ReplaceExisting", "Attributes", "CommonAttributes", "PrivateKeyAttributes", "PublicKeyAttributes", "ExtensionEnumeration", "ExtensionAttribute", "ExtensionParentStructureTag", "ExtensionDescription", "ServerName", "ServerSerialNumber", "ServerVersion", "ServerLoad", "ProductName", "BuildLevel", "BuildDate", "ClusterInfo", "AlternateFailoverEndpoints", "ShortUniqueIdentifier", "Reserved", "Tag", "CertificateRequestUniqueIdentifier", "NISTKeyType", "AttributeReference", "CurrentAttribute", "NewAttribute", "CertificateRequestValue", "LogMessage", "ProfileVersion", "ProfileVersionMajor", "ProfileVersionMinor", "ProtectionLevel", "ProtectionPeriod", "QuantumSafe", "QuantumSafeCapability", "Ticket", "TicketType", "TicketValue", "RequestCount", "Rights", "Objects", "Operations", "Right", "EndpointRole", "DefaultsInformation", "ObjectDefaults", "Ephemeral", "ServerHashedPassword", "OneTimePassword", "HashedPassword", "AdjustmentType", "PKCS11Interface", "PKCS11Function", "PKCS11InputParameters", "PKCS11OutputParameters", "PKCS11ReturnCode", "ProtectionStorageMask", "ProtectionStorageMasks", "InteropFunction", "InteropIdentifier", "AdjustmentValue", "CommonProtectionStorageMasks", "PrivateProtectionStorageMasks", "PublicProtectionStorageMasks"`
+Possible values:
+`"ActivationDate", "ApplicationData", "ApplicationNamespace", "ApplicationSpecific_Information", "ArchiveDate", "AsynchronousCorrelation_Value", "AsynchronousIndicator", "Attribute", "AttributeName", "AttributeValue", "Authentication", "BatchCount", "BatchErrorContinuationOption", "BatchItem", "BatchOrderOption", "BlockCipherMode", "CancellationResult", "Certificate", "CertificateRequest", "CertificateRequestType", "CertificateType", "CertificateValue", "CompromiseDate", "CompromiseOccurrenceDate", "ContactInformation", "Credential", "CredentialType", "CredentialValue", "CriticalityIndicator", "CRTCoefficient", "CryptographicAlgorithm", "CryptographicDomainParameters", "CryptographicLength", "CryptographicParameters", "CryptographicUsageMask", "D", "DeactivationDate", "DerivationData", "DerivationMethod", "DerivationParameters", "DestroyDate", "Digest", "DigestValue", "EncryptionKeyInformation", "G", "HashingAlgorithm", "InitialDate", "InitializationVector", "IterationCount", "IVCounterNonce", "J", "Key", "KeyBlock", "KeyCompressionType", "KeyFormatType", "KeyMaterial", "KeyPartIdentifier", "KeyValue", "KeyWrappingData", "KeyWrappingSpecification", "LastChangeDate", "LeaseTime", "Link", "LinkType", "LinkedObjectIdentifier", "MACSignature", "MACSignatureKey_Information", "MaximumItems", "MaximumResponseSize", "MessageExtension", "Modulus", "Name", "NameType", "NameValue", "ObjectGroup", "ObjectType", "Offset", "OpaqueDataType", "OpaqueDataValue", "OpaqueObject", "Operation", "P", "PaddingMethod", "PrimeExponentP", "PrimeExponentQ", "PrimeFieldSize", "PrivateExponent", "PrivateKey", "PrivateKeyUniqueIdentifier", "ProcessStartDate", "ProtectStopDate", "ProtocolVersion", "ProtocolVersionMajor", "ProtocolVersionMinor", "PublicExponent", "PublicKey", "PublicKeyUniqueIdentifier", "PutFunction", "Q", "QString", "Qlength", "QueryFunction", "RecommendedCurve", "ReplacedUniqueIdentifier", "RequestHeader", "RequestMessage", "RequestPayload", "ResponseHeader", "ResponseMessage", "ResponsePayload", "ResultMessage", "ResultReason", "ResultStatus", "RevocationMessage", "RevocationReason", "RevocationReasonCode", "KeyRoleType", "Salt", "SecretData", "SecretDataType", "ServerInformation", "SplitKey", "SplitKeyMethod", "SplitKeyParts", "SplitKeyThreshold", "State", "StorageStatusMask", "SymmetricKey", "TimeStamp", "UniqueBatchItemID", "UniqueIdentifier", "UsageLimits", "UsageLimitsCount", "UsageLimitsTotal", "UsageLimitsUnit", "Username", "ValidityDate", "ValidityIndicator", "VendorExtension", "VendorIdentification", "WrappingMethod", "X", "Y", "Password", "DeviceIdentifier", "EncodingOption", "ExtensionInformation", "ExtensionName", "ExtensionTag", "ExtensionType", "Fresh", "MachineIdentifier", "MediaIdentifier", "NetworkIdentifier", "ObjectGroupMember", "CertificateLength", "DigitalSignatureAlgorithm", "CertificateSerialNumber", "DeviceSerialNumber", "IssuerAlternativeName", "IssuerDistinguishedName", "SubjectAlternativeName", "SubjectDistinguishedName", "X509CertificateIdentifier", "X509CertificateIssuer", "X509CertificateSubject", "KeyValueLocation", "KeyValueLocationValue", "KeyValueLocationType", "KeyValuePresent", "OriginalCreationDate", "PGPKey", "PGPKeyVersion", "AlternativeName", "AlternativeNameValue", "AlternativeNameType", "Data", "SignatureData", "DataLength", "RandomIV", "MACData", "AttestationType", "Nonce", "NonceID", "NonceValue", "AttestationMeasurement", "AttestationAssertion", "IVLength", "TagLength", "FixedFieldLength", "CounterLength", "InitialCounterValue", "InvocationFieldLength", "AttestationCapableIndicator", "OffsetItems", "LocatedItems", "CorrelationValue", "InitIndicator", "FinalIndicator", "RNGParameters", "RNGAlgorithm", "DRBGAlgorithm", "FIPS186Variation", "PredictionResistance", "RandomNumberGenerator", "ValidationInformation", "ValidationAuthorityType", "ValidationAuthorityCountry", "ValidationAuthorityURI", "ValidationVersionMajor", "ValidationVersionMinor", "ValidationType", "ValidationLevel", "ValidationCertificateIdentifier", "ValidationCertificateURI", "ValidationVendorURI", "ValidationProfile", "ProfileInformation", "ProfileName", "ServerURI", "ServerPort", "StreamingCapability", "AsynchronousCapability", "AttestationCapability", "UnwrapMode", "DestroyAction", "ShreddingAlgorithm", "RNGMode", "ClientRegistrationMethod", "CapabilityInformation", "KeyWrapType", "BatchUndoCapability", "BatchContinueCapability", "PKCS12FriendlyName", "Description", "Comment", "AuthenticatedEncryptionAdditionalData", "AuthenticatedEncryptionTag", "SaltLength", "MaskGenerator", "MaskGeneratorHashingAlgorithm", "PSource", "TrailerField", "ClientCorrelationValue", "ServerCorrelationValue", "DigestedData", "CertificateSubjectCN", "CertificateSubjectO", "CertificateSubjectOU", "CertificateSubjectEmail", "CertificateSubjectC", "CertificateSubjectST", "CertificateSubjectL", "CertificateSubjectUID", "CertificateSubjectSerialNumber", "CertificateSubjectTitle", "CertificateSubjectDC", "CertificateSubjectDNQualifier", "CertificateIssuerCN", "CertificateIssuerO", "CertificateIssuerOU", "CertificateIssuerEmail", "CertificateIssuerC", "CertificateIssuerST", "CertificateIssuerL", "CertificateIssuerUID", "CertificateIssuerSerialNumber", "CertificateIssuerTitle", "CertificateIssuerDC", "CertificateIssuerDNQualifier", "Sensitive", "AlwaysSensitive", "Extractable", "NeverExtractable", "ReplaceExisting", "Attributes", "CommonAttributes", "PrivateKeyAttributes", "PublicKeyAttributes", "ExtensionEnumeration", "ExtensionAttribute", "ExtensionParentStructureTag", "ExtensionDescription", "ServerName", "ServerSerialNumber", "ServerVersion", "ServerLoad", "ProductName", "BuildLevel", "BuildDate", "ClusterInfo", "AlternateFailoverEndpoints", "ShortUniqueIdentifier", "Reserved", "Tag", "CertificateRequestUniqueIdentifier", "NISTKeyType", "AttributeReference", "CurrentAttribute", "NewAttribute", "CertificateRequestValue", "LogMessage", "ProfileVersion", "ProfileVersionMajor", "ProfileVersionMinor", "ProtectionLevel", "ProtectionPeriod", "QuantumSafe", "QuantumSafeCapability", "Ticket", "TicketType", "TicketValue", "RequestCount", "Rights", "Objects", "Operations", "Right", "EndpointRole", "DefaultsInformation", "ObjectDefaults", "Ephemeral", "ServerHashedPassword", "OneTimePassword", "HashedPassword", "AdjustmentType", "PKCS11Interface", "PKCS11Function", "PKCS11InputParameters", "PKCS11OutputParameters", "PKCS11ReturnCode", "ProtectionStorageMask", "ProtectionStorageMasks", "InteropFunction", "InteropIdentifier", "AdjustmentValue", "CommonProtectionStorageMasks", "PrivateProtectionStorageMasks", "PublicProtectionStorageMasks"`
 
 `--link-type [-l] <LINK_TYPE>` Filter on retrieved links. Only if KMIP tag `LinkType` is used in `attribute` parameter.
 To specify multiple attributes, use the option multiple times.
 If not specified, all possible link types are returned.
 
-Possible values:  `"CertificateLink", "PublicKeyLink", "PrivateKeyLink", "DerivationBaseObjectLink", "DerivedKeyLink", "ReplacementObjectLink", "ReplacedObjectLink", "ParentLink", "ChildLink", "PreviousLink", "NextLink", "PKCS12CertificateLink", "PKCS12PasswordLink", "WrappingKeyLink"`
+Possible values:
+`"CertificateLink", "PublicKeyLink", "PrivateKeyLink", "DerivationBaseObjectLink", "DerivedKeyLink", "ReplacementObjectLink", "ReplacedObjectLink", "ParentLink", "ChildLink", "PreviousLink", "NextLink", "PKCS12CertificateLink", "PKCS12PasswordLink", "WrappingKeyLink"`
 
 `--output-file [-o] <OUTPUT_FILE>` An optional file where to export the attributes.
 The attributes will be in JSON TTLV format.
@@ -1288,23 +1517,29 @@ The attributes will be in JSON TTLV format.
 Set the KMIP object attributes.
 
 ### Usage
+
 `ckms attributes set [options]`
+
 ### Arguments
+
 `--id [-i] <ID>` The unique identifier of the cryptographic object. If not specified, tags should be specified
 
-`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option
+multiple times
 
 `--activation-date [-d] <ACTIVATION_DATE>` Set the activation date of the key. Epoch time (or Unix time) in milliseconds
 
 `--cryptographic-algorithm [-a] <CRYPTOGRAPHIC_ALGORITHM>` The cryptographic algorithm used by the key
 
-Possible values:  `"DES", "THREE_DES", "AES", "RSA", "DSA", "ECDSA", "HMACSHA1", "HMACSHA224", "HMACSHA256", "HMACSHA384", "HMACSHA512", "HMACMD5", "DH", "ECDH", "ECMQV", "Blowfish", "Camellia", "CAST5", "IDEA", "MARS", "RC2", "RC4", "RC5", "SKIPJACK", "Twofish", "EC", "OneTimePad", "ChaCha20", "Poly1305", "ChaCha20Poly1305", "SHA3224", "SHA3256", "SHA3384", "SHA3512", "HMACSHA3224", "HMACSHA3256", "HMACSHA3384", "HMACSHA3512", "SHAKE128", "SHAKE256", "ARIA", "SEED", "SM2", "SM3", "SM4", "GOSTR34102012", "GOSTR34112012", "GOSTR34132015", "GOST2814789", "XMSS", "SPHINCS_256", "Page166Of230McEliece", "McEliece6960119", "McEliece8192128", "Ed25519", "Ed448", "CoverCrypt", "CoverCryptBulk"`
+Possible values:
+`"DES", "THREE_DES", "AES", "RSA", "DSA", "ECDSA", "HMACSHA1", "HMACSHA224", "HMACSHA256", "HMACSHA384", "HMACSHA512", "HMACMD5", "DH", "ECDH", "ECMQV", "Blowfish", "Camellia", "CAST5", "IDEA", "MARS", "RC2", "RC4", "RC5", "SKIPJACK", "Twofish", "EC", "OneTimePad", "ChaCha20", "Poly1305", "ChaCha20Poly1305", "SHA3224", "SHA3256", "SHA3384", "SHA3512", "HMACSHA3224", "HMACSHA3256", "HMACSHA3384", "HMACSHA3512", "SHAKE128", "SHAKE256", "ARIA", "SEED", "SM2", "SM3", "SM4", "GOSTR34102012", "GOSTR34112012", "GOSTR34132015", "GOST2814789", "XMSS", "SPHINCS_256", "Page166Of230McEliece", "McEliece6960119", "McEliece8192128", "Ed25519", "Ed448", "CoverCrypt", "CoverCryptBulk"`
 
 `--cryptographic-length <CRYPTOGRAPHIC_LENGTH>` The length of the cryptographic key
 
 `--key-usage [-u] <KEY_USAGE>` The key usage. Add multiple times to specify multiple key usages
 
-Possible values:  `"sign", "verify", "encrypt", "decrypt", "wrap-key", "unwrap-key", "mac-generate", "mac-verify", "derive-key", "key-agreement", "certificate-sign", "crl-sign", "authenticate", "unrestricted"`
+Possible values:
+`"sign", "verify", "encrypt", "decrypt", "wrap-key", "unwrap-key", "mac-generate", "mac-verify", "derive-key", "key-agreement", "certificate-sign", "crl-sign", "authenticate", "unrestricted"`
 
 `--public-key-id <PUBLIC_KEY_ID>` The link to the corresponding public key id if any
 
@@ -1335,23 +1570,29 @@ Possible values:  `"sign", "verify", "encrypt", "decrypt", "wrap-key", "unwrap-k
 Delete the KMIP object attributes.
 
 ### Usage
+
 `ckms attributes delete [options]`
+
 ### Arguments
+
 `--id [-i] <ID>` The unique identifier of the cryptographic object. If not specified, tags should be specified
 
-`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option
+multiple times
 
 `--activation-date [-d] <ACTIVATION_DATE>` Set the activation date of the key. Epoch time (or Unix time) in milliseconds
 
 `--cryptographic-algorithm [-a] <CRYPTOGRAPHIC_ALGORITHM>` The cryptographic algorithm used by the key
 
-Possible values:  `"DES", "THREE_DES", "AES", "RSA", "DSA", "ECDSA", "HMACSHA1", "HMACSHA224", "HMACSHA256", "HMACSHA384", "HMACSHA512", "HMACMD5", "DH", "ECDH", "ECMQV", "Blowfish", "Camellia", "CAST5", "IDEA", "MARS", "RC2", "RC4", "RC5", "SKIPJACK", "Twofish", "EC", "OneTimePad", "ChaCha20", "Poly1305", "ChaCha20Poly1305", "SHA3224", "SHA3256", "SHA3384", "SHA3512", "HMACSHA3224", "HMACSHA3256", "HMACSHA3384", "HMACSHA3512", "SHAKE128", "SHAKE256", "ARIA", "SEED", "SM2", "SM3", "SM4", "GOSTR34102012", "GOSTR34112012", "GOSTR34132015", "GOST2814789", "XMSS", "SPHINCS_256", "Page166Of230McEliece", "McEliece6960119", "McEliece8192128", "Ed25519", "Ed448", "CoverCrypt", "CoverCryptBulk"`
+Possible values:
+`"DES", "THREE_DES", "AES", "RSA", "DSA", "ECDSA", "HMACSHA1", "HMACSHA224", "HMACSHA256", "HMACSHA384", "HMACSHA512", "HMACMD5", "DH", "ECDH", "ECMQV", "Blowfish", "Camellia", "CAST5", "IDEA", "MARS", "RC2", "RC4", "RC5", "SKIPJACK", "Twofish", "EC", "OneTimePad", "ChaCha20", "Poly1305", "ChaCha20Poly1305", "SHA3224", "SHA3256", "SHA3384", "SHA3512", "HMACSHA3224", "HMACSHA3256", "HMACSHA3384", "HMACSHA3512", "SHAKE128", "SHAKE256", "ARIA", "SEED", "SM2", "SM3", "SM4", "GOSTR34102012", "GOSTR34112012", "GOSTR34132015", "GOST2814789", "XMSS", "SPHINCS_256", "Page166Of230McEliece", "McEliece6960119", "McEliece8192128", "Ed25519", "Ed448", "CoverCrypt", "CoverCryptBulk"`
 
 `--cryptographic-length <CRYPTOGRAPHIC_LENGTH>` The length of the cryptographic key
 
 `--key-usage [-u] <KEY_USAGE>` The key usage. Add multiple times to specify multiple key usages
 
-Possible values:  `"sign", "verify", "encrypt", "decrypt", "wrap-key", "unwrap-key", "mac-generate", "mac-verify", "derive-key", "key-agreement", "certificate-sign", "crl-sign", "authenticate", "unrestricted"`
+Possible values:
+`"sign", "verify", "encrypt", "decrypt", "wrap-key", "unwrap-key", "mac-generate", "mac-verify", "derive-key", "key-agreement", "certificate-sign", "crl-sign", "authenticate", "unrestricted"`
 
 `--public-key-id <PUBLIC_KEY_ID>` The link to the corresponding public key id if any
 
@@ -1376,7 +1617,8 @@ Possible values:  `"sign", "verify", "encrypt", "decrypt", "wrap-key", "unwrap-k
 `--attribute <ATTRIBUTE>` The attributes or tags to retrieve.
 To specify multiple attributes, use the option multiple times.
 
-Possible values:  `"ActivationDate", "ApplicationData", "ApplicationNamespace", "ApplicationSpecific_Information", "ArchiveDate", "AsynchronousCorrelation_Value", "AsynchronousIndicator", "Attribute", "AttributeName", "AttributeValue", "Authentication", "BatchCount", "BatchErrorContinuationOption", "BatchItem", "BatchOrderOption", "BlockCipherMode", "CancellationResult", "Certificate", "CertificateRequest", "CertificateRequestType", "CertificateType", "CertificateValue", "CompromiseDate", "CompromiseOccurrenceDate", "ContactInformation", "Credential", "CredentialType", "CredentialValue", "CriticalityIndicator", "CRTCoefficient", "CryptographicAlgorithm", "CryptographicDomainParameters", "CryptographicLength", "CryptographicParameters", "CryptographicUsageMask", "D", "DeactivationDate", "DerivationData", "DerivationMethod", "DerivationParameters", "DestroyDate", "Digest", "DigestValue", "EncryptionKeyInformation", "G", "HashingAlgorithm", "InitialDate", "InitializationVector", "IterationCount", "IVCounterNonce", "J", "Key", "KeyBlock", "KeyCompressionType", "KeyFormatType", "KeyMaterial", "KeyPartIdentifier", "KeyValue", "KeyWrappingData", "KeyWrappingSpecification", "LastChangeDate", "LeaseTime", "Link", "LinkType", "LinkedObjectIdentifier", "MACSignature", "MACSignatureKey_Information", "MaximumItems", "MaximumResponseSize", "MessageExtension", "Modulus", "Name", "NameType", "NameValue", "ObjectGroup", "ObjectType", "Offset", "OpaqueDataType", "OpaqueDataValue", "OpaqueObject", "Operation", "P", "PaddingMethod", "PrimeExponentP", "PrimeExponentQ", "PrimeFieldSize", "PrivateExponent", "PrivateKey", "PrivateKeyUniqueIdentifier", "ProcessStartDate", "ProtectStopDate", "ProtocolVersion", "ProtocolVersionMajor", "ProtocolVersionMinor", "PublicExponent", "PublicKey", "PublicKeyUniqueIdentifier", "PutFunction", "Q", "QString", "Qlength", "QueryFunction", "RecommendedCurve", "ReplacedUniqueIdentifier", "RequestHeader", "RequestMessage", "RequestPayload", "ResponseHeader", "ResponseMessage", "ResponsePayload", "ResultMessage", "ResultReason", "ResultStatus", "RevocationMessage", "RevocationReason", "RevocationReasonCode", "KeyRoleType", "Salt", "SecretData", "SecretDataType", "ServerInformation", "SplitKey", "SplitKeyMethod", "SplitKeyParts", "SplitKeyThreshold", "State", "StorageStatusMask", "SymmetricKey", "TimeStamp", "UniqueBatchItemID", "UniqueIdentifier", "UsageLimits", "UsageLimitsCount", "UsageLimitsTotal", "UsageLimitsUnit", "Username", "ValidityDate", "ValidityIndicator", "VendorExtension", "VendorIdentification", "WrappingMethod", "X", "Y", "Password", "DeviceIdentifier", "EncodingOption", "ExtensionInformation", "ExtensionName", "ExtensionTag", "ExtensionType", "Fresh", "MachineIdentifier", "MediaIdentifier", "NetworkIdentifier", "ObjectGroupMember", "CertificateLength", "DigitalSignatureAlgorithm", "CertificateSerialNumber", "DeviceSerialNumber", "IssuerAlternativeName", "IssuerDistinguishedName", "SubjectAlternativeName", "SubjectDistinguishedName", "X509CertificateIdentifier", "X509CertificateIssuer", "X509CertificateSubject", "KeyValueLocation", "KeyValueLocationValue", "KeyValueLocationType", "KeyValuePresent", "OriginalCreationDate", "PGPKey", "PGPKeyVersion", "AlternativeName", "AlternativeNameValue", "AlternativeNameType", "Data", "SignatureData", "DataLength", "RandomIV", "MACData", "AttestationType", "Nonce", "NonceID", "NonceValue", "AttestationMeasurement", "AttestationAssertion", "IVLength", "TagLength", "FixedFieldLength", "CounterLength", "InitialCounterValue", "InvocationFieldLength", "AttestationCapableIndicator", "OffsetItems", "LocatedItems", "CorrelationValue", "InitIndicator", "FinalIndicator", "RNGParameters", "RNGAlgorithm", "DRBGAlgorithm", "FIPS186Variation", "PredictionResistance", "RandomNumberGenerator", "ValidationInformation", "ValidationAuthorityType", "ValidationAuthorityCountry", "ValidationAuthorityURI", "ValidationVersionMajor", "ValidationVersionMinor", "ValidationType", "ValidationLevel", "ValidationCertificateIdentifier", "ValidationCertificateURI", "ValidationVendorURI", "ValidationProfile", "ProfileInformation", "ProfileName", "ServerURI", "ServerPort", "StreamingCapability", "AsynchronousCapability", "AttestationCapability", "UnwrapMode", "DestroyAction", "ShreddingAlgorithm", "RNGMode", "ClientRegistrationMethod", "CapabilityInformation", "KeyWrapType", "BatchUndoCapability", "BatchContinueCapability", "PKCS12FriendlyName", "Description", "Comment", "AuthenticatedEncryptionAdditionalData", "AuthenticatedEncryptionTag", "SaltLength", "MaskGenerator", "MaskGeneratorHashingAlgorithm", "PSource", "TrailerField", "ClientCorrelationValue", "ServerCorrelationValue", "DigestedData", "CertificateSubjectCN", "CertificateSubjectO", "CertificateSubjectOU", "CertificateSubjectEmail", "CertificateSubjectC", "CertificateSubjectST", "CertificateSubjectL", "CertificateSubjectUID", "CertificateSubjectSerialNumber", "CertificateSubjectTitle", "CertificateSubjectDC", "CertificateSubjectDNQualifier", "CertificateIssuerCN", "CertificateIssuerO", "CertificateIssuerOU", "CertificateIssuerEmail", "CertificateIssuerC", "CertificateIssuerST", "CertificateIssuerL", "CertificateIssuerUID", "CertificateIssuerSerialNumber", "CertificateIssuerTitle", "CertificateIssuerDC", "CertificateIssuerDNQualifier", "Sensitive", "AlwaysSensitive", "Extractable", "NeverExtractable", "ReplaceExisting", "Attributes", "CommonAttributes", "PrivateKeyAttributes", "PublicKeyAttributes", "ExtensionEnumeration", "ExtensionAttribute", "ExtensionParentStructureTag", "ExtensionDescription", "ServerName", "ServerSerialNumber", "ServerVersion", "ServerLoad", "ProductName", "BuildLevel", "BuildDate", "ClusterInfo", "AlternateFailoverEndpoints", "ShortUniqueIdentifier", "Reserved", "Tag", "CertificateRequestUniqueIdentifier", "NISTKeyType", "AttributeReference", "CurrentAttribute", "NewAttribute", "CertificateRequestValue", "LogMessage", "ProfileVersion", "ProfileVersionMajor", "ProfileVersionMinor", "ProtectionLevel", "ProtectionPeriod", "QuantumSafe", "QuantumSafeCapability", "Ticket", "TicketType", "TicketValue", "RequestCount", "Rights", "Objects", "Operations", "Right", "EndpointRole", "DefaultsInformation", "ObjectDefaults", "Ephemeral", "ServerHashedPassword", "OneTimePassword", "HashedPassword", "AdjustmentType", "PKCS11Interface", "PKCS11Function", "PKCS11InputParameters", "PKCS11OutputParameters", "PKCS11ReturnCode", "ProtectionStorageMask", "ProtectionStorageMasks", "InteropFunction", "InteropIdentifier", "AdjustmentValue", "CommonProtectionStorageMasks", "PrivateProtectionStorageMasks", "PublicProtectionStorageMasks"`
+Possible values:
+`"ActivationDate", "ApplicationData", "ApplicationNamespace", "ApplicationSpecific_Information", "ArchiveDate", "AsynchronousCorrelation_Value", "AsynchronousIndicator", "Attribute", "AttributeName", "AttributeValue", "Authentication", "BatchCount", "BatchErrorContinuationOption", "BatchItem", "BatchOrderOption", "BlockCipherMode", "CancellationResult", "Certificate", "CertificateRequest", "CertificateRequestType", "CertificateType", "CertificateValue", "CompromiseDate", "CompromiseOccurrenceDate", "ContactInformation", "Credential", "CredentialType", "CredentialValue", "CriticalityIndicator", "CRTCoefficient", "CryptographicAlgorithm", "CryptographicDomainParameters", "CryptographicLength", "CryptographicParameters", "CryptographicUsageMask", "D", "DeactivationDate", "DerivationData", "DerivationMethod", "DerivationParameters", "DestroyDate", "Digest", "DigestValue", "EncryptionKeyInformation", "G", "HashingAlgorithm", "InitialDate", "InitializationVector", "IterationCount", "IVCounterNonce", "J", "Key", "KeyBlock", "KeyCompressionType", "KeyFormatType", "KeyMaterial", "KeyPartIdentifier", "KeyValue", "KeyWrappingData", "KeyWrappingSpecification", "LastChangeDate", "LeaseTime", "Link", "LinkType", "LinkedObjectIdentifier", "MACSignature", "MACSignatureKey_Information", "MaximumItems", "MaximumResponseSize", "MessageExtension", "Modulus", "Name", "NameType", "NameValue", "ObjectGroup", "ObjectType", "Offset", "OpaqueDataType", "OpaqueDataValue", "OpaqueObject", "Operation", "P", "PaddingMethod", "PrimeExponentP", "PrimeExponentQ", "PrimeFieldSize", "PrivateExponent", "PrivateKey", "PrivateKeyUniqueIdentifier", "ProcessStartDate", "ProtectStopDate", "ProtocolVersion", "ProtocolVersionMajor", "ProtocolVersionMinor", "PublicExponent", "PublicKey", "PublicKeyUniqueIdentifier", "PutFunction", "Q", "QString", "Qlength", "QueryFunction", "RecommendedCurve", "ReplacedUniqueIdentifier", "RequestHeader", "RequestMessage", "RequestPayload", "ResponseHeader", "ResponseMessage", "ResponsePayload", "ResultMessage", "ResultReason", "ResultStatus", "RevocationMessage", "RevocationReason", "RevocationReasonCode", "KeyRoleType", "Salt", "SecretData", "SecretDataType", "ServerInformation", "SplitKey", "SplitKeyMethod", "SplitKeyParts", "SplitKeyThreshold", "State", "StorageStatusMask", "SymmetricKey", "TimeStamp", "UniqueBatchItemID", "UniqueIdentifier", "UsageLimits", "UsageLimitsCount", "UsageLimitsTotal", "UsageLimitsUnit", "Username", "ValidityDate", "ValidityIndicator", "VendorExtension", "VendorIdentification", "WrappingMethod", "X", "Y", "Password", "DeviceIdentifier", "EncodingOption", "ExtensionInformation", "ExtensionName", "ExtensionTag", "ExtensionType", "Fresh", "MachineIdentifier", "MediaIdentifier", "NetworkIdentifier", "ObjectGroupMember", "CertificateLength", "DigitalSignatureAlgorithm", "CertificateSerialNumber", "DeviceSerialNumber", "IssuerAlternativeName", "IssuerDistinguishedName", "SubjectAlternativeName", "SubjectDistinguishedName", "X509CertificateIdentifier", "X509CertificateIssuer", "X509CertificateSubject", "KeyValueLocation", "KeyValueLocationValue", "KeyValueLocationType", "KeyValuePresent", "OriginalCreationDate", "PGPKey", "PGPKeyVersion", "AlternativeName", "AlternativeNameValue", "AlternativeNameType", "Data", "SignatureData", "DataLength", "RandomIV", "MACData", "AttestationType", "Nonce", "NonceID", "NonceValue", "AttestationMeasurement", "AttestationAssertion", "IVLength", "TagLength", "FixedFieldLength", "CounterLength", "InitialCounterValue", "InvocationFieldLength", "AttestationCapableIndicator", "OffsetItems", "LocatedItems", "CorrelationValue", "InitIndicator", "FinalIndicator", "RNGParameters", "RNGAlgorithm", "DRBGAlgorithm", "FIPS186Variation", "PredictionResistance", "RandomNumberGenerator", "ValidationInformation", "ValidationAuthorityType", "ValidationAuthorityCountry", "ValidationAuthorityURI", "ValidationVersionMajor", "ValidationVersionMinor", "ValidationType", "ValidationLevel", "ValidationCertificateIdentifier", "ValidationCertificateURI", "ValidationVendorURI", "ValidationProfile", "ProfileInformation", "ProfileName", "ServerURI", "ServerPort", "StreamingCapability", "AsynchronousCapability", "AttestationCapability", "UnwrapMode", "DestroyAction", "ShreddingAlgorithm", "RNGMode", "ClientRegistrationMethod", "CapabilityInformation", "KeyWrapType", "BatchUndoCapability", "BatchContinueCapability", "PKCS12FriendlyName", "Description", "Comment", "AuthenticatedEncryptionAdditionalData", "AuthenticatedEncryptionTag", "SaltLength", "MaskGenerator", "MaskGeneratorHashingAlgorithm", "PSource", "TrailerField", "ClientCorrelationValue", "ServerCorrelationValue", "DigestedData", "CertificateSubjectCN", "CertificateSubjectO", "CertificateSubjectOU", "CertificateSubjectEmail", "CertificateSubjectC", "CertificateSubjectST", "CertificateSubjectL", "CertificateSubjectUID", "CertificateSubjectSerialNumber", "CertificateSubjectTitle", "CertificateSubjectDC", "CertificateSubjectDNQualifier", "CertificateIssuerCN", "CertificateIssuerO", "CertificateIssuerOU", "CertificateIssuerEmail", "CertificateIssuerC", "CertificateIssuerST", "CertificateIssuerL", "CertificateIssuerUID", "CertificateIssuerSerialNumber", "CertificateIssuerTitle", "CertificateIssuerDC", "CertificateIssuerDNQualifier", "Sensitive", "AlwaysSensitive", "Extractable", "NeverExtractable", "ReplaceExisting", "Attributes", "CommonAttributes", "PrivateKeyAttributes", "PublicKeyAttributes", "ExtensionEnumeration", "ExtensionAttribute", "ExtensionParentStructureTag", "ExtensionDescription", "ServerName", "ServerSerialNumber", "ServerVersion", "ServerLoad", "ProductName", "BuildLevel", "BuildDate", "ClusterInfo", "AlternateFailoverEndpoints", "ShortUniqueIdentifier", "Reserved", "Tag", "CertificateRequestUniqueIdentifier", "NISTKeyType", "AttributeReference", "CurrentAttribute", "NewAttribute", "CertificateRequestValue", "LogMessage", "ProfileVersion", "ProfileVersionMajor", "ProfileVersionMinor", "ProtectionLevel", "ProtectionPeriod", "QuantumSafe", "QuantumSafeCapability", "Ticket", "TicketType", "TicketValue", "RequestCount", "Rights", "Objects", "Operations", "Right", "EndpointRole", "DefaultsInformation", "ObjectDefaults", "Ephemeral", "ServerHashedPassword", "OneTimePassword", "HashedPassword", "AdjustmentType", "PKCS11Interface", "PKCS11Function", "PKCS11InputParameters", "PKCS11OutputParameters", "PKCS11ReturnCode", "ProtectionStorageMask", "ProtectionStorageMasks", "InteropFunction", "InteropIdentifier", "AdjustmentValue", "CommonProtectionStorageMasks", "PrivateProtectionStorageMasks", "PublicProtectionStorageMasks"`
 
 
 
@@ -1388,8 +1630,11 @@ Possible values:  `"ActivationDate", "ApplicationData", "ApplicationNamespace", 
 Locate cryptographic objects inside the KMS
 
 ### Usage
+
 `ckms locate [options]`
+
 ### Arguments
+
 `--tag [-t] <TAG>` User tags or system tags to locate the object.
 To specify multiple tags, use the option multiple times.
 
@@ -1416,6 +1661,7 @@ To specify multiple tags, use the option multiple times.
 Initialize a new user encrypted database and return the secret (`SQLCipher` only).
 
 ### Usage
+
 `ckms new-database`
 
 
@@ -1426,6 +1672,7 @@ Initialize a new user encrypted database and return the secret (`SQLCipher` only
 Manage RSA keys. Encrypt and decrypt data using RSA keys
 
 ### Usage
+
 `ckms rsa <subcommand>`
 
 ### Subcommands
@@ -1434,15 +1681,15 @@ Manage RSA keys. Encrypt and decrypt data using RSA keys
 
 **`encrypt`** [[8.2]](#82-ckms-rsa-encrypt)  Encrypt a file with the given public key using either
 
- - `CKM_RSA_PKCS` a.k.a PKCS #1 RSA V1.5 as specified in PKCS#11 v2.40
- - `CKM_RSA_PKCS_OAEP` a.k.a PKCS #1 RSA OAEP as specified in PKCS#11 v2.40
- - `CKM_RSA_AES_KEY_WRAP` as specified in PKCS#11 v2.40
+- `CKM_RSA_PKCS` a.k.a PKCS #1 RSA V1.5 as specified in PKCS#11 v2.40
+- `CKM_RSA_PKCS_OAEP` a.k.a PKCS #1 RSA OAEP as specified in PKCS#11 v2.40
+- `CKM_RSA_AES_KEY_WRAP` as specified in PKCS#11 v2.40
 
 **`decrypt`** [[8.3]](#83-ckms-rsa-decrypt)  Decrypt a file with the given public key using either
 
- - `CKM_RSA_PKCS` a.k.a PKCS #1 RSA V1.5 as specified in PKCS#11 v2.40
- - `CKM_RSA_PKCS_OAEP` a.k.a PKCS #1 RSA OAEP as specified in PKCS#11 v2.40
- - `CKM_RSA_AES_KEY_WRAP` as specified in PKCS#11 v2.40
+- `CKM_RSA_PKCS` a.k.a PKCS #1 RSA V1.5 as specified in PKCS#11 v2.40
+- `CKM_RSA_PKCS_OAEP` a.k.a PKCS #1 RSA OAEP as specified in PKCS#11 v2.40
+- `CKM_RSA_AES_KEY_WRAP` as specified in PKCS#11 v2.40
 
 ---
 
@@ -1451,6 +1698,7 @@ Manage RSA keys. Encrypt and decrypt data using RSA keys
 Create, destroy, import, and export RSA key pairs
 
 ### Usage
+
 `ckms rsa keys <subcommand>`
 
 ### Subcommands
@@ -1476,12 +1724,16 @@ Create, destroy, import, and export RSA key pairs
 Create a new RSA key pair
 
 ### Usage
+
 `ckms rsa keys create [options] [PRIVATE_KEY_ID]
 `
+
 ### Arguments
+
 `--size_in_bits [-s] <SIZE_IN_BITS>` The expected size in bits
 
-`--tag [-t] <TAG>` The tag to associate with the master key pair. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` The tag to associate with the master key pair. To specify multiple tags, use the option multiple
+times
 
 ` <PRIVATE_KEY_ID>` The unique id of the private key; a random uuid is generated if not specified
 
@@ -1498,28 +1750,34 @@ Possible values:  `"true", "false"` [default: `"false"`]
 Export a key from the KMS
 
 ### Usage
+
 `ckms rsa keys export [options] <KEY_FILE>
 `
+
 ### Arguments
+
 ` <KEY_FILE>` The file to export the key to
 
 `--key-id [-k] <KEY_ID>` The key unique identifier stored in the KMS. If not specified, tags should be specified
 
-`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option
+multiple times
 
 `--key-format [-f] <KEY_FORMAT>` The format of the key
 
- - `json-ttlv` [default]. It should be the format to use to later re-import the key
- - `sec1-pem` and `sec1-der`only apply to NIST EC private keys (Not Curve25519 or X448)
- - `pkcs1-pem` and `pkcs1-der` only apply to RSA private and public keys
- - `pkcs8-pem` and `pkcs8-der` only apply to RSA and EC private keys
- - `spki-pem` and `spki-der` only apply to RSA and EC public keys
- - `raw` returns the raw bytes of
-      - symmetric keys
-      - Covercrypt keys
-      - wrapped keys
+- `json-ttlv` [default]. It should be the format to use to later re-import the key
+- `sec1-pem` and `sec1-der`only apply to NIST EC private keys (Not Curve25519 or X448)
+- `pkcs1-pem` and `pkcs1-der` only apply to RSA private and public keys
+- `pkcs8-pem` and `pkcs8-der` only apply to RSA and EC private keys
+- `spki-pem` and `spki-der` only apply to RSA and EC public keys
+- `raw` returns the raw bytes of
+    - symmetric keys
+    - Covercrypt keys
+    - wrapped keys
 
-Possible values:  `"json-ttlv", "sec1-pem", "sec1-der", "pkcs1-pem", "pkcs1-der", "pkcs8-pem", "pkcs8-der", "spki-pem", "spki-der", "base64", "raw"` [default: `"json-ttlv"`]
+Possible values:
+`"json-ttlv", "sec1-pem", "sec1-der", "pkcs1-pem", "pkcs1-der", "pkcs8-pem", "pkcs8-der", "spki-pem", "spki-der", "base64", "raw"` [default:
+`"json-ttlv"`]
 
 `--unwrap [-u] <UNWRAP>` Unwrap the key if it is wrapped before export
 
@@ -1541,7 +1799,8 @@ By default, the algorithm used is
 
 Possible values:  `"nist-key-wrap", "aes-gcm", "rsa-pkcs-v15", "rsa-oaep", "rsa-aes-key-wrap"`
 
-`--authenticated-additional-data [-d] <AUTHENTICATED_ADDITIONAL_DATA>` Authenticated encryption additional data Only available for AES GCM wrapping
+`--authenticated-additional-data [-d] <AUTHENTICATED_ADDITIONAL_DATA>` Authenticated encryption additional data Only
+available for AES GCM wrapping
 
 
 
@@ -1552,17 +1811,21 @@ Possible values:  `"nist-key-wrap", "aes-gcm", "rsa-pkcs-v15", "rsa-oaep", "rsa-
 Import a private or public key in the KMS.
 
 ### Usage
+
 `ckms rsa keys import [options] <KEY_FILE>
  [KEY_ID]
 `
+
 ### Arguments
+
 ` <KEY_FILE>` The KMIP JSON TTLV key file
 
 ` <KEY_ID>` The unique id of the key; a random uuid is generated if not specified
 
 `--key-format [-f] <KEY_FORMAT>` The format of the key
 
-Possible values:  `"json-ttlv", "pem", "sec1", "pkcs1-priv", "pkcs1-pub", "pkcs8", "spki", "aes", "chacha20"` [default: `"json-ttlv"`]
+Possible values:  `"json-ttlv", "pem", "sec1", "pkcs1-priv", "pkcs1-pub", "pkcs8", "spki", "aes", "chacha20"` [default:
+`"json-ttlv"`]
 
 `--public-key-id [-p] <PUBLIC_KEY_ID>` For a private key: the corresponding KMS public key id if any
 
@@ -1582,9 +1845,11 @@ Possible values:  `"true", "false"` [default: `"false"`]
 
 `--key-usage <KEY_USAGE>` For what operations should the key be used
 
-Possible values:  `"sign", "verify", "encrypt", "decrypt", "wrap-key", "unwrap-key", "mac-generate", "mac-verify", "derive-key", "key-agreement", "certificate-sign", "crl-sign", "authenticate", "unrestricted"`
+Possible values:
+`"sign", "verify", "encrypt", "decrypt", "wrap-key", "unwrap-key", "mac-generate", "mac-verify", "derive-key", "key-agreement", "certificate-sign", "crl-sign", "authenticate", "unrestricted"`
 
-`--authenticated-additional-data [-d] <AUTHENTICATED_ADDITIONAL_DATA>` Optional authenticated encryption additional data to use for AES256GCM authenticated encryption unwrapping
+`--authenticated-additional-data [-d] <AUTHENTICATED_ADDITIONAL_DATA>` Optional authenticated encryption additional data
+to use for AES256GCM authenticated encryption unwrapping
 
 
 
@@ -1595,15 +1860,20 @@ Possible values:  `"sign", "verify", "encrypt", "decrypt", "wrap-key", "unwrap-k
 Locally wrap a key in KMIP JSON TTLV format.
 
 ### Usage
+
 `ckms rsa keys wrap [options] <KEY_FILE_IN>
  [KEY_FILE_OUT]
 `
+
 ### Arguments
+
 ` <KEY_FILE_IN>` The KMIP JSON TTLV input key file to wrap
 
 ` <KEY_FILE_OUT>` The KMIP JSON output file. When not specified, the input file is overwritten
 
-`--wrap-password [-p] <WRAP_PASSWORD>` A password to wrap the imported key. This password will be derived into a AES-256 symmetric key. For security reasons, a fresh salt is internally handled and generated by `ckms` and this final AES symmetric key will be displayed only once
+`--wrap-password [-p] <WRAP_PASSWORD>` A password to wrap the imported key. This password will be derived into a AES-256
+symmetric key. For security reasons, a fresh salt is internally handled and generated by `ckms` and this final AES
+symmetric key will be displayed only once
 
 `--wrap-key-b64 [-k] <WRAP_KEY_B64>` A symmetric key as a base 64 string to wrap the imported key
 
@@ -1620,17 +1890,21 @@ Locally wrap a key in KMIP JSON TTLV format.
 Locally unwrap a key in KMIP JSON TTLV format.
 
 ### Usage
+
 `ckms rsa keys unwrap [options] <KEY_FILE_IN>
  [KEY_FILE_OUT]
 `
+
 ### Arguments
+
 ` <KEY_FILE_IN>` The KMIP JSON TTLV input key file to unwrap
 
 ` <KEY_FILE_OUT>` The KMIP JSON output file. When not specified the input file is overwritten
 
 `--unwrap-key-b64 [-k] <UNWRAP_KEY_B64>` A symmetric key as a base 64 string to unwrap the imported key
 
-`--unwrap-key-id [-i] <UNWRAP_KEY_ID>` The id of a unwrapping key in the KMS that will be exported and used to unwrap the key
+`--unwrap-key-id [-i] <UNWRAP_KEY_ID>` The id of a unwrapping key in the KMS that will be exported and used to unwrap
+the key
 
 `--unwrap-key-file [-f] <UNWRAP_KEY_FILE>` A unwrapping key in a KMIP JSON TTLV file used to unwrap the key
 
@@ -1643,14 +1917,18 @@ Locally unwrap a key in KMIP JSON TTLV format.
 Revoke a public or private key
 
 ### Usage
+
 `ckms rsa keys revoke [options] <REVOCATION_REASON>
 `
+
 ### Arguments
+
 ` <REVOCATION_REASON>` The reason for the revocation as a string
 
 `--key-id [-k] <KEY_ID>` The key unique identifier of the key to revoke. If not specified, tags should be specified
 
-`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option
+multiple times
 
 
 
@@ -1661,11 +1939,15 @@ Revoke a public or private key
 Destroy a public or private key
 
 ### Usage
+
 `ckms rsa keys destroy [options]`
+
 ### Arguments
+
 `--key-id [-k] <KEY_ID>` The key unique identifier of the key to destroy If not specified, tags should be specified
 
-`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option
+multiple times
 
 
 
@@ -1676,19 +1958,23 @@ Destroy a public or private key
 
 Encrypt a file with the given public key using either
 
- - `CKM_RSA_PKCS` a.k.a PKCS #1 RSA V1.5 as specified in PKCS#11 v2.40
- - `CKM_RSA_PKCS_OAEP` a.k.a PKCS #1 RSA OAEP as specified in PKCS#11 v2.40
- - `CKM_RSA_AES_KEY_WRAP` as specified in PKCS#11 v2.40
+- `CKM_RSA_PKCS` a.k.a PKCS #1 RSA V1.5 as specified in PKCS#11 v2.40
+- `CKM_RSA_PKCS_OAEP` a.k.a PKCS #1 RSA OAEP as specified in PKCS#11 v2.40
+- `CKM_RSA_AES_KEY_WRAP` as specified in PKCS#11 v2.40
 
 ### Usage
+
 `ckms rsa encrypt [options] <FILE>
 `
+
 ### Arguments
+
 ` <FILE>` The file to encrypt
 
 `--key-id [-k] <KEY_ID>` The public key unique identifier. If not specified, tags should be specified
 
-`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option
+multiple times
 
 `--encryption-algorithm [-e] <ENCRYPTION_ALGORITHM>` The encryption algorithm
 
@@ -1696,7 +1982,8 @@ Possible values:  `"ckm-rsa-pkcs", "ckm-rsa-pkcs-oaep", "ckm-rsa-aes-key-wrap"` 
 
 `--hashing-algorithm [-s] <HASH_FN>` The hashing algorithm
 
-Possible values:  `"sha1", "sha224", "sha256", "sha384", "sha512", "sha3-224", "sha3-256", "sha3-384", "sha3-512"` [default: `"sha256"`]
+Possible values:
+`"sha1", "sha224", "sha256", "sha384", "sha512", "sha3-224", "sha3-256", "sha3-384", "sha3-512"` [default: `"sha256"`]
 
 `--output-file [-o] <OUTPUT_FILE>` The encrypted output file path
 
@@ -1708,19 +1995,23 @@ Possible values:  `"sha1", "sha224", "sha256", "sha384", "sha512", "sha3-224", "
 
 Decrypt a file with the given public key using either
 
- - `CKM_RSA_PKCS` a.k.a PKCS #1 RSA V1.5 as specified in PKCS#11 v2.40
- - `CKM_RSA_PKCS_OAEP` a.k.a PKCS #1 RSA OAEP as specified in PKCS#11 v2.40
- - `CKM_RSA_AES_KEY_WRAP` as specified in PKCS#11 v2.40
+- `CKM_RSA_PKCS` a.k.a PKCS #1 RSA V1.5 as specified in PKCS#11 v2.40
+- `CKM_RSA_PKCS_OAEP` a.k.a PKCS #1 RSA OAEP as specified in PKCS#11 v2.40
+- `CKM_RSA_AES_KEY_WRAP` as specified in PKCS#11 v2.40
 
 ### Usage
+
 `ckms rsa decrypt [options] <FILE>
 `
+
 ### Arguments
+
 ` <FILE>` The file to decrypt
 
 `--key-id [-k] <KEY_ID>` The private key unique identifier If not specified, tags should be specified
 
-`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option
+multiple times
 
 `--encryption-algorithm [-e] <ENCRYPTION_ALGORITHM>` The encryption algorithm
 
@@ -1728,7 +2019,8 @@ Possible values:  `"ckm-rsa-pkcs", "ckm-rsa-pkcs-oaep", "ckm-rsa-aes-key-wrap"` 
 
 `--hashing-algorithm [-s] <HASH_FN>` The hashing algorithm (for OAEP and AES key wrap)
 
-Possible values:  `"sha1", "sha224", "sha256", "sha384", "sha512", "sha3-224", "sha3-256", "sha3-384", "sha3-512"` [default: `"sha256"`]
+Possible values:
+`"sha1", "sha224", "sha256", "sha384", "sha512", "sha3-224", "sha3-256", "sha3-384", "sha3-512"` [default: `"sha256"`]
 
 `--output-file [-o] <OUTPUT_FILE>` The encrypted output file path
 
@@ -1742,6 +2034,7 @@ Possible values:  `"sha1", "sha224", "sha256", "sha384", "sha512", "sha3-224", "
 Print the version of the server
 
 ### Usage
+
 `ckms server-version`
 
 
@@ -1752,6 +2045,7 @@ Print the version of the server
 Manage symmetric keys. Encrypt and decrypt data
 
 ### Usage
+
 `ckms sym <subcommand>`
 
 ### Subcommands
@@ -1769,6 +2063,7 @@ Manage symmetric keys. Encrypt and decrypt data
 Create, destroy, import, and export symmetric keys
 
 ### Usage
+
 `ckms sym keys <subcommand>`
 
 ### Subcommands
@@ -1796,9 +2091,12 @@ Create, destroy, import, and export symmetric keys
 Create a new symmetric key
 
 ### Usage
+
 `ckms sym keys create [options] [KEY_ID]
 `
+
 ### Arguments
+
 `--number-of-bits [-l] <NUMBER_OF_BITS>` The length of the generated random key or salt in bits
 
 `--bytes-b64 [-k] <WRAP_KEY_B64>` The symmetric key bytes or salt as a base 64 string
@@ -1818,11 +2116,9 @@ Possible values:  `"true", "false"` [default: `"false"`]
 `--wrapping-key-id [-w] <WRAPPING_KEY_ID>` The key to wrap this new key with.
 If the wrapping key is:
 
--  a symmetric key, AES-GCM will be used
--  a RSA key, RSA-OAEP will be used
--  a EC key, ECIES will be used (salsa20poly1305 for X25519)
-
-
+- a symmetric key, AES-GCM will be used
+- a RSA key, RSA-OAEP will be used
+- a EC key, ECIES will be used (salsa20poly1305 for X25519)
 
 ---
 
@@ -1831,8 +2127,11 @@ If the wrapping key is:
 Refresh an existing symmetric key
 
 ### Usage
+
 `ckms sym keys re-key [options]`
+
 ### Arguments
+
 `--key-id [-k] <KEY_ID>` The tag to associate with the key. To specify multiple tags, use the option multiple times
 
 
@@ -1844,28 +2143,34 @@ Refresh an existing symmetric key
 Export a key from the KMS
 
 ### Usage
+
 `ckms sym keys export [options] <KEY_FILE>
 `
+
 ### Arguments
+
 ` <KEY_FILE>` The file to export the key to
 
 `--key-id [-k] <KEY_ID>` The key unique identifier stored in the KMS. If not specified, tags should be specified
 
-`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option
+multiple times
 
 `--key-format [-f] <KEY_FORMAT>` The format of the key
 
- - `json-ttlv` [default]. It should be the format to use to later re-import the key
- - `sec1-pem` and `sec1-der`only apply to NIST EC private keys (Not Curve25519 or X448)
- - `pkcs1-pem` and `pkcs1-der` only apply to RSA private and public keys
- - `pkcs8-pem` and `pkcs8-der` only apply to RSA and EC private keys
- - `spki-pem` and `spki-der` only apply to RSA and EC public keys
- - `raw` returns the raw bytes of
-      - symmetric keys
-      - Covercrypt keys
-      - wrapped keys
+- `json-ttlv` [default]. It should be the format to use to later re-import the key
+- `sec1-pem` and `sec1-der`only apply to NIST EC private keys (Not Curve25519 or X448)
+- `pkcs1-pem` and `pkcs1-der` only apply to RSA private and public keys
+- `pkcs8-pem` and `pkcs8-der` only apply to RSA and EC private keys
+- `spki-pem` and `spki-der` only apply to RSA and EC public keys
+- `raw` returns the raw bytes of
+    - symmetric keys
+    - Covercrypt keys
+    - wrapped keys
 
-Possible values:  `"json-ttlv", "sec1-pem", "sec1-der", "pkcs1-pem", "pkcs1-der", "pkcs8-pem", "pkcs8-der", "spki-pem", "spki-der", "base64", "raw"` [default: `"json-ttlv"`]
+Possible values:
+`"json-ttlv", "sec1-pem", "sec1-der", "pkcs1-pem", "pkcs1-der", "pkcs8-pem", "pkcs8-der", "spki-pem", "spki-der", "base64", "raw"` [default:
+`"json-ttlv"`]
 
 `--unwrap [-u] <UNWRAP>` Unwrap the key if it is wrapped before export
 
@@ -1887,7 +2192,8 @@ By default, the algorithm used is
 
 Possible values:  `"nist-key-wrap", "aes-gcm", "rsa-pkcs-v15", "rsa-oaep", "rsa-aes-key-wrap"`
 
-`--authenticated-additional-data [-d] <AUTHENTICATED_ADDITIONAL_DATA>` Authenticated encryption additional data Only available for AES GCM wrapping
+`--authenticated-additional-data [-d] <AUTHENTICATED_ADDITIONAL_DATA>` Authenticated encryption additional data Only
+available for AES GCM wrapping
 
 
 
@@ -1898,17 +2204,21 @@ Possible values:  `"nist-key-wrap", "aes-gcm", "rsa-pkcs-v15", "rsa-oaep", "rsa-
 Import a private or public key in the KMS.
 
 ### Usage
+
 `ckms sym keys import [options] <KEY_FILE>
  [KEY_ID]
 `
+
 ### Arguments
+
 ` <KEY_FILE>` The KMIP JSON TTLV key file
 
 ` <KEY_ID>` The unique id of the key; a random uuid is generated if not specified
 
 `--key-format [-f] <KEY_FORMAT>` The format of the key
 
-Possible values:  `"json-ttlv", "pem", "sec1", "pkcs1-priv", "pkcs1-pub", "pkcs8", "spki", "aes", "chacha20"` [default: `"json-ttlv"`]
+Possible values:  `"json-ttlv", "pem", "sec1", "pkcs1-priv", "pkcs1-pub", "pkcs8", "spki", "aes", "chacha20"` [default:
+`"json-ttlv"`]
 
 `--public-key-id [-p] <PUBLIC_KEY_ID>` For a private key: the corresponding KMS public key id if any
 
@@ -1928,9 +2238,11 @@ Possible values:  `"true", "false"` [default: `"false"`]
 
 `--key-usage <KEY_USAGE>` For what operations should the key be used
 
-Possible values:  `"sign", "verify", "encrypt", "decrypt", "wrap-key", "unwrap-key", "mac-generate", "mac-verify", "derive-key", "key-agreement", "certificate-sign", "crl-sign", "authenticate", "unrestricted"`
+Possible values:
+`"sign", "verify", "encrypt", "decrypt", "wrap-key", "unwrap-key", "mac-generate", "mac-verify", "derive-key", "key-agreement", "certificate-sign", "crl-sign", "authenticate", "unrestricted"`
 
-`--authenticated-additional-data [-d] <AUTHENTICATED_ADDITIONAL_DATA>` Optional authenticated encryption additional data to use for AES256GCM authenticated encryption unwrapping
+`--authenticated-additional-data [-d] <AUTHENTICATED_ADDITIONAL_DATA>` Optional authenticated encryption additional data
+to use for AES256GCM authenticated encryption unwrapping
 
 
 
@@ -1941,15 +2253,20 @@ Possible values:  `"sign", "verify", "encrypt", "decrypt", "wrap-key", "unwrap-k
 Locally wrap a key in KMIP JSON TTLV format.
 
 ### Usage
+
 `ckms sym keys wrap [options] <KEY_FILE_IN>
  [KEY_FILE_OUT]
 `
+
 ### Arguments
+
 ` <KEY_FILE_IN>` The KMIP JSON TTLV input key file to wrap
 
 ` <KEY_FILE_OUT>` The KMIP JSON output file. When not specified, the input file is overwritten
 
-`--wrap-password [-p] <WRAP_PASSWORD>` A password to wrap the imported key. This password will be derived into a AES-256 symmetric key. For security reasons, a fresh salt is internally handled and generated by `ckms` and this final AES symmetric key will be displayed only once
+`--wrap-password [-p] <WRAP_PASSWORD>` A password to wrap the imported key. This password will be derived into a AES-256
+symmetric key. For security reasons, a fresh salt is internally handled and generated by `ckms` and this final AES
+symmetric key will be displayed only once
 
 `--wrap-key-b64 [-k] <WRAP_KEY_B64>` A symmetric key as a base 64 string to wrap the imported key
 
@@ -1966,17 +2283,21 @@ Locally wrap a key in KMIP JSON TTLV format.
 Locally unwrap a key in KMIP JSON TTLV format.
 
 ### Usage
+
 `ckms sym keys unwrap [options] <KEY_FILE_IN>
  [KEY_FILE_OUT]
 `
+
 ### Arguments
+
 ` <KEY_FILE_IN>` The KMIP JSON TTLV input key file to unwrap
 
 ` <KEY_FILE_OUT>` The KMIP JSON output file. When not specified the input file is overwritten
 
 `--unwrap-key-b64 [-k] <UNWRAP_KEY_B64>` A symmetric key as a base 64 string to unwrap the imported key
 
-`--unwrap-key-id [-i] <UNWRAP_KEY_ID>` The id of a unwrapping key in the KMS that will be exported and used to unwrap the key
+`--unwrap-key-id [-i] <UNWRAP_KEY_ID>` The id of a unwrapping key in the KMS that will be exported and used to unwrap
+the key
 
 `--unwrap-key-file [-f] <UNWRAP_KEY_FILE>` A unwrapping key in a KMIP JSON TTLV file used to unwrap the key
 
@@ -1989,14 +2310,18 @@ Locally unwrap a key in KMIP JSON TTLV format.
 Revoke a symmetric key
 
 ### Usage
+
 `ckms sym keys revoke [options] <REVOCATION_REASON>
 `
+
 ### Arguments
+
 ` <REVOCATION_REASON>` The reason for the revocation as a string
 
 `--key-id [-k] <KEY_ID>` The key unique identifier of the key to revoke. If not specified, tags should be specified
 
-`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option
+multiple times
 
 
 
@@ -2007,11 +2332,15 @@ Revoke a symmetric key
 Destroy a symmetric key
 
 ### Usage
+
 `ckms sym keys destroy [options]`
+
 ### Arguments
+
 `--key-id [-k] <KEY_ID>` The key unique identifier. If not specified, tags should be specified
 
-`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option
+multiple times
 
 
 
@@ -2023,28 +2352,36 @@ Destroy a symmetric key
 Encrypt a file using a symmetric cipher
 
 ### Usage
+
 `ckms sym encrypt [options] <FILE>
 `
+
 ### Arguments
+
 ` <FILE>` The file to encrypt
 
 `--key-id [-k] <KEY_ID>` The symmetric key unique identifier. If not specified, tags should be specified
 
-`--data-encryption-algorithm [-d] <DATA_ENCRYPTION_ALGORITHM>` The data encryption algorithm. If not specified, aes-gcm is used
+`--data-encryption-algorithm [-d] <DATA_ENCRYPTION_ALGORITHM>` The data encryption algorithm. If not specified, aes-gcm
+is used
 
 Possible values:  `"chacha20-poly1305", "aes-gcm", "aes-xts", "aes-gcm-siv"` [default: `"aes-gcm"`]
 
-`--key-encryption-algorithm [-e] <KEY_ENCRYPTION_ALGORITHM>` The optional key encryption algorithm used to encrypt the data encryption key.
+`--key-encryption-algorithm [-e] <KEY_ENCRYPTION_ALGORITHM>` The optional key encryption algorithm used to encrypt the
+data encryption key.
 
 Possible values:  `"chacha20-poly1305", "aes-gcm", "aes-xts", "aes-gcm-siv", "rfc5649"`
 
-`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option
+multiple times
 
 `--output-file [-o] <OUTPUT_FILE>` The encrypted output file path
 
-`--nonce [-n] <NONCE>` Optional nonce/IV (or tweak for XTS) as a hex string. If not provided, a random value is generated
+`--nonce [-n] <NONCE>` Optional nonce/IV (or tweak for XTS) as a hex string. If not provided, a random value is
+generated
 
-`--authentication-data [-a] <AUTHENTICATION_DATA>` Optional additional authentication data as a hex string. This data needs to be provided back for decryption. This data is ignored with XTS
+`--authentication-data [-a] <AUTHENTICATION_DATA>` Optional additional authentication data as a hex string. This data
+needs to be provided back for decryption. This data is ignored with XTS
 
 
 
@@ -2055,26 +2392,33 @@ Possible values:  `"chacha20-poly1305", "aes-gcm", "aes-xts", "aes-gcm-siv", "rf
 Decrypt a file using a symmetric key.
 
 ### Usage
+
 `ckms sym decrypt [options] <FILE>
 `
+
 ### Arguments
+
 ` <FILE>` The file to decrypt
 
 `--key-id [-k] <KEY_ID>` The private key unique identifier If not specified, tags should be specified
 
-`--data-encryption-algorithm [-d] <DATA_ENCRYPTION_ALGORITHM>` The data encryption algorithm. If not specified, aes-gcm is used
+`--data-encryption-algorithm [-d] <DATA_ENCRYPTION_ALGORITHM>` The data encryption algorithm. If not specified, aes-gcm
+is used
 
 Possible values:  `"chacha20-poly1305", "aes-gcm", "aes-xts", "aes-gcm-siv"` [default: `"aes-gcm"`]
 
-`--key-encryption-algorithm [-e] <KEY_ENCRYPTION_ALGORITHM>` The optional key encryption algorithm used to decrypt the data encryption key.
+`--key-encryption-algorithm [-e] <KEY_ENCRYPTION_ALGORITHM>` The optional key encryption algorithm used to decrypt the
+data encryption key.
 
 Possible values:  `"chacha20-poly1305", "aes-gcm", "aes-xts", "aes-gcm-siv", "rfc5649"`
 
-`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option multiple times
+`--tag [-t] <TAG>` Tag to use to retrieve the key when no key id is specified. To specify multiple tags, use the option
+multiple times
 
 `--output-file [-o] <OUTPUT_FILE>` The encrypted output file path
 
-`--authentication-data [-a] <AUTHENTICATION_DATA>` Optional authentication data that was supplied during encryption as a hex string
+`--authentication-data [-a] <AUTHENTICATION_DATA>` Optional authentication data that was supplied during encryption as a
+hex string
 
 
 
@@ -2086,6 +2430,7 @@ Possible values:  `"chacha20-poly1305", "aes-gcm", "aes-xts", "aes-gcm-siv", "rf
 Login to the Identity Provider of the KMS server using the `OAuth2` authorization code flow.
 
 ### Usage
+
 `ckms login`
 
 
@@ -2096,6 +2441,7 @@ Login to the Identity Provider of the KMS server using the `OAuth2` authorizatio
 Logout from the Identity Provider.
 
 ### Usage
+
 `ckms logout`
 
 
@@ -2103,73 +2449,115 @@ Logout from the Identity Provider.
 
 ## 13 ckms markdown
 
-Action to auto-generate doc in Markdown format Run `cargo run --bin ckms -- markdown documentation/docs/cli/main_commands.md`
+Action to auto-generate doc in Markdown format Run
+`cargo run --bin ckms -- markdown documentation/docs/cli/main_commands.md`
 
 ### Usage
+
 `ckms markdown [options] <MARKDOWN_FILE>
 `
+
 ### Arguments
+
 ` <MARKDOWN_FILE>` The file to export the markdown to
 
 
 
 ---
 
-## 14 ckms google
+## 14 ckms bench
+
+Run a set of bunch to check the server performance
+
+### Usage
+
+`ckms bench [options]`
+
+### Arguments
+
+`--number-of-threads [-t] <NUM_THREADS>` The number of parallel threads to use
+
+`--batch-size [-b] <BATCH_SIZE>` The size of an encryption/decryption batch A size of 1 does not use the `BulkData` API
+
+`--num-batches [-n] <NUM_BATCHES>` The number of batches to run
+
+`--wrapped-key [-w] <WRAPPED_KEY>` Use a wrapped key (by a 4096 RSA key) to encrypt the symmetric key
+
+Possible values:  `"true", "false"` [default: `"false"`]
+
+`--verbose [-v] <VERBOSE>` Display batch results details
+
+Possible values:  `"true", "false"` [default: `"false"`]
+
+
+
+---
+
+## 15 ckms google
 
 Manage google elements. Handle key pairs and identities from Gmail API
 
 ### Usage
+
 `ckms google <subcommand>`
 
 ### Subcommands
 
-**`key-pairs`** [[14.1]](#141-ckms-google-key-pairs)  Insert, get, list, enable, disabled and obliterate key pairs to Gmail API
+**`key-pairs`** [[15.1]](#151-ckms-google-key-pairs)  Insert, get, list, enable, disabled and obliterate key pairs to
+Gmail API
 
-**`identities`** [[14.2]](#142-ckms-google-identities)  Insert, get, list, patch and delete identities from Gmail API
+**`identities`** [[15.2]](#152-ckms-google-identities)  Insert, get, list, patch and delete identities from Gmail API
 
 ---
 
-## 14.1 ckms google key-pairs
+## 15.1 ckms google key-pairs
 
 Insert, get, list, enable, disabled and obliterate key pairs to Gmail API
 
 ### Usage
+
 `ckms google key-pairs <subcommand>`
 
 ### Subcommands
 
-**`get`** [[14.1.1]](#1411-ckms-google-key-pairs-get)  Retrieves an existing client-side encryption key pair.
+**`get`** [[15.1.1]](#1511-ckms-google-key-pairs-get)  Retrieves an existing client-side encryption key pair.
 
-**`list`** [[14.1.2]](#1412-ckms-google-key-pairs-list)  Lists client-side encryption key pairs for a user.
+**`list`** [[15.1.2]](#1512-ckms-google-key-pairs-list)  Lists client-side encryption key pairs for a user.
 
-**`enable`** [[14.1.3]](#1413-ckms-google-key-pairs-enable)  Turns on a client-side encryption key pair that was turned off. The key pair becomes active
+**`enable`** [[15.1.3]](#1513-ckms-google-key-pairs-enable)  Turns on a client-side encryption key pair that was turned
+off. The key pair becomes active
 again for any associated client-side encryption identities.
 
-**`disable`** [[14.1.4]](#1414-ckms-google-key-pairs-disable)  Turns off a client-side encryption key pair. The authenticated user can no longer use the key
+**`disable`** [[15.1.4]](#1514-ckms-google-key-pairs-disable)  Turns off a client-side encryption key pair. The
+authenticated user can no longer use the key
 pair to decrypt incoming CSE message texts or sign outgoing CSE mail. To regain access, use the
 key pairs.enable to turn on the key pair. After 30 days, you can permanently delete the key pair
 by using the key pairs.obliterate method.
 
-**`obliterate`** [[14.1.5]](#1415-ckms-google-key-pairs-obliterate)  Deletes a client-side encryption key pair permanently and immediately. You can only permanently
+**`obliterate`** [[15.1.5]](#1515-ckms-google-key-pairs-obliterate)  Deletes a client-side encryption key pair
+permanently and immediately. You can only permanently
 delete key pairs that have been turned off for more than 30 days. To turn off a key pair, use
 the key pairs disable method. Gmail can't restore or decrypt any messages that were encrypted by
 an obliterated key. Authenticated users and Google Workspace administrators lose access to
 reading the encrypted messages.
 
-**`create`** [[14.1.6]](#1416-ckms-google-key-pairs-create)  Creates and uploads a client-side encryption S/MIME public key certificate chain and private key
+**`create`** [[15.1.6]](#1516-ckms-google-key-pairs-create)  Creates and uploads a client-side encryption S/MIME public
+key certificate chain and private key
 metadata for a user.
 
 ---
 
-## 14.1.1 ckms google key-pairs get
+## 15.1.1 ckms google key-pairs get
 
 Retrieves an existing client-side encryption key pair.
 
 ### Usage
+
 `ckms google key-pairs get [options] <KEY_PAIRS_ID>
 `
+
 ### Arguments
+
 ` <KEY_PAIRS_ID>` The identifier of the key pair to retrieve
 
 `--user-id [-u] <USER_ID>` The requester's primary email address
@@ -2178,29 +2566,35 @@ Retrieves an existing client-side encryption key pair.
 
 ---
 
-## 14.1.2 ckms google key-pairs list
+## 15.1.2 ckms google key-pairs list
 
 Lists client-side encryption key pairs for a user.
 
 ### Usage
+
 `ckms google key-pairs list [options] <USER_ID>
 `
+
 ### Arguments
+
 ` <USER_ID>` The requester's primary email address
 
 
 
 ---
 
-## 14.1.3 ckms google key-pairs enable
+## 15.1.3 ckms google key-pairs enable
 
 Turns on a client-side encryption key pair that was turned off. The key pair becomes active
 again for any associated client-side encryption identities.
 
 ### Usage
+
 `ckms google key-pairs enable [options] <KEY_PAIRS_ID>
 `
+
 ### Arguments
+
 ` <KEY_PAIRS_ID>` The identifier of the key pair to enable
 
 `--user-id [-u] <USER_ID>` The requester's primary email address
@@ -2209,7 +2603,7 @@ again for any associated client-side encryption identities.
 
 ---
 
-## 14.1.4 ckms google key-pairs disable
+## 15.1.4 ckms google key-pairs disable
 
 Turns off a client-side encryption key pair. The authenticated user can no longer use the key
 pair to decrypt incoming CSE message texts or sign outgoing CSE mail. To regain access, use the
@@ -2217,9 +2611,12 @@ key pairs.enable to turn on the key pair. After 30 days, you can permanently del
 by using the key pairs.obliterate method.
 
 ### Usage
+
 `ckms google key-pairs disable [options] <KEY_PAIRS_ID>
 `
+
 ### Arguments
+
 ` <KEY_PAIRS_ID>` The identifier of the key pair to disable
 
 `--user-id [-u] <USER_ID>` The requester's primary email address
@@ -2228,7 +2625,7 @@ by using the key pairs.obliterate method.
 
 ---
 
-## 14.1.5 ckms google key-pairs obliterate
+## 15.1.5 ckms google key-pairs obliterate
 
 Deletes a client-side encryption key pair permanently and immediately. You can only permanently
 delete key pairs that have been turned off for more than 30 days. To turn off a key pair, use
@@ -2237,9 +2634,12 @@ an obliterated key. Authenticated users and Google Workspace administrators lose
 reading the encrypted messages.
 
 ### Usage
+
 `ckms google key-pairs obliterate [options] <KEY_PAIRS_ID>
 `
+
 ### Arguments
+
 ` <KEY_PAIRS_ID>` The identifier of the key pair to obliterate
 
 `--user-id [-u] <USER_ID>` The requester's primary email address
@@ -2248,15 +2648,18 @@ reading the encrypted messages.
 
 ---
 
-## 14.1.6 ckms google key-pairs create
+## 15.1.6 ckms google key-pairs create
 
 Creates and uploads a client-side encryption S/MIME public key certificate chain and private key
 metadata for a user.
 
 ### Usage
+
 `ckms google key-pairs create [options] <USER_ID>
 `
+
 ### Arguments
+
 ` <USER_ID>` The requester's primary email address
 
 `--cse-key-id [-w] <CSE_KEY_ID>` CSE key ID to wrap exported user private key
@@ -2266,7 +2669,8 @@ metadata for a user.
 `--subject-name [-s] <SUBJECT_NAME>` When certifying a public key, or generating a keypair,
 the subject name to use.
 
-`--rsa-private-key-id [-k] <RSA_PRIVATE_KEY_ID>` The existing private key id of an existing RSA keypair to use (optional - if no ID is provided, a RSA keypair will be created)
+`--rsa-private-key-id [-k] <RSA_PRIVATE_KEY_ID>` The existing private key id of an existing RSA keypair to use (
+optional - if no ID is provided, a RSA keypair will be created)
 
 `--sensitive <SENSITIVE>` Sensitive: if set, the key will not be exportable
 
@@ -2281,109 +2685,129 @@ Possible values:  `"true", "false"` [default: `"false"`]
 
 ---
 
-## 14.2 ckms google identities
+## 15.2 ckms google identities
 
 Insert, get, list, patch and delete identities from Gmail API
 
 ### Usage
+
 `ckms google identities <subcommand>`
 
 ### Subcommands
 
-**`get`** [[14.2.1]](#1421-ckms-google-identities-get)  Retrieves a client-side encryption identity configuration.
+**`get`** [[15.2.1]](#1521-ckms-google-identities-get)  Retrieves a client-side encryption identity configuration.
 
-**`list`** [[14.2.2]](#1422-ckms-google-identities-list)  Lists the client-side encrypted identities for an authenticated user.
+**`list`** [[15.2.2]](#1522-ckms-google-identities-list)  Lists the client-side encrypted identities for an
+authenticated user.
 
-**`insert`** [[14.2.3]](#1423-ckms-google-identities-insert)  Creates and configures a client-side encryption identity that's authorized to send mail from the
+**`insert`** [[15.2.3]](#1523-ckms-google-identities-insert)  Creates and configures a client-side encryption identity
+that's authorized to send mail from the
 user account. Google publishes the S/MIME certificate to a shared domain-wide directory so that
 people within a Google Workspace organization can encrypt and send mail to the identity.
 
-**`delete`** [[14.2.4]](#1424-ckms-google-identities-delete)  Deletes a client-side encryption identity. The authenticated user can no longer use the identity
+**`delete`** [[15.2.4]](#1524-ckms-google-identities-delete)  Deletes a client-side encryption identity. The
+authenticated user can no longer use the identity
 to send encrypted messages. You cannot restore the identity after you delete it. Instead, use
 the identities.create method to create another identity with the same configuration.
 
-**`patch`** [[14.2.5]](#1425-ckms-google-identities-patch)  Associates a different key pair with an existing client-side encryption identity. The updated
+**`patch`** [[15.2.5]](#1525-ckms-google-identities-patch)  Associates a different key pair with an existing client-side
+encryption identity. The updated
 key pair must validate against Google's S/MIME certificate profiles.
 
 ---
 
-## 14.2.1 ckms google identities get
+## 15.2.1 ckms google identities get
 
 Retrieves a client-side encryption identity configuration.
 
 ### Usage
+
 `ckms google identities get [options] <USER_ID>
 `
+
 ### Arguments
-` <USER_ID>` The primary email address associated with the client-side encryption identity configuration that's retrieved
+
+` <USER_ID>` The primary email address associated with the client-side encryption identity configuration that's
+retrieved
 
 
 
 ---
 
-## 14.2.2 ckms google identities list
+## 15.2.2 ckms google identities list
 
 Lists the client-side encrypted identities for an authenticated user.
 
 ### Usage
+
 `ckms google identities list [options] <USER_ID>
 `
+
 ### Arguments
+
 ` <USER_ID>` The requester's primary email address
 
 
 
 ---
 
-## 14.2.3 ckms google identities insert
+## 15.2.3 ckms google identities insert
 
 Creates and configures a client-side encryption identity that's authorized to send mail from the
 user account. Google publishes the S/MIME certificate to a shared domain-wide directory so that
 people within a Google Workspace organization can encrypt and send mail to the identity.
 
 ### Usage
+
 `ckms google identities insert [options] <KEY_PAIRS_ID>
 `
-### Arguments
-` <KEY_PAIRS_ID>` The keypair id, associated with a given cert/key. You can get the by listing the keypairs associated with the user-id
 
-`--user-id [-u] <USER_ID>` The primary email address associated with the client-side encryption identity configuration that's retrieved
+### Arguments
+
+` <KEY_PAIRS_ID>` The keypair id, associated with a given cert/key. You can get the by listing the keypairs associated
+with the user-id
+
+`--user-id [-u] <USER_ID>` The primary email address associated with the client-side encryption identity configuration
+that's retrieved
 
 
 
 ---
 
-## 14.2.4 ckms google identities delete
+## 15.2.4 ckms google identities delete
 
 Deletes a client-side encryption identity. The authenticated user can no longer use the identity
 to send encrypted messages. You cannot restore the identity after you delete it. Instead, use
 the identities.create method to create another identity with the same configuration.
 
 ### Usage
+
 `ckms google identities delete [options] <USER_ID>
 `
+
 ### Arguments
-` <USER_ID>` The primary email address associated with the client-side encryption identity configuration that's retrieved
+
+` <USER_ID>` The primary email address associated with the client-side encryption identity configuration that's
+retrieved
 
 
 
 ---
 
-## 14.2.5 ckms google identities patch
+## 15.2.5 ckms google identities patch
 
 Associates a different key pair with an existing client-side encryption identity. The updated
 key pair must validate against Google's S/MIME certificate profiles.
 
 ### Usage
+
 `ckms google identities patch [options] <KEY_PAIRS_ID>
 `
+
 ### Arguments
-` <KEY_PAIRS_ID>` The key pair id, associated with a given cert/key. You can get the by listing the key pairs associated with the user-id
 
-`--user-id [-u] <USER_ID>` The primary email address associated with the client-side encryption identity configuration that's retrieved
+` <KEY_PAIRS_ID>` The key pair id, associated with a given cert/key. You can get the by listing the key pairs associated
+with the user-id
 
-
-
-
-
-
+`--user-id [-u] <USER_ID>` The primary email address associated with the client-side encryption identity configuration
+that's retrieved


### PR DESCRIPTION
Add a `bench` command to the CLI to run a set of benches that check the server performance.

This command will create one or more keys, encrypt and decrypt a set of data
then revoke the keys.