### PR TITLE
Review of the Covercrypt integration

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -41,6 +41,11 @@ jobs:
         run: cargo +${{ inputs.toolchain }} fmt --all -- --check --color always
 
       - name: Static analysis
+        run: cargo clippy --workspace --all-targets -- -D warnings
+        env:
+          OPENSSL_DIR: ${{ env.OPENSSL_DIR }}
+
+      - name: Static analysis all features
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
         env:
           OPENSSL_DIR: ${{ env.OPENSSL_DIR }}

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -38,7 +38,7 @@ jobs:
 
       # Ensure all code has been formatted with rustfmt
       - name: Check formatting
-        run: cargo fmt --all -- --check --color always
+        run: cargo +${{ inputs.toolchain }} fmt --all -- --check --color always
 
       - name: Static analysis
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -116,7 +116,7 @@ repos:
   - repo: https://github.com/Cosmian/git-hooks.git
     rev: v1.0.32
     hooks:
-      - id: cargo-format
+      # - id: cargo-format
       # - id: dprint-toml-fix
       # - id: cargo-upgrade
       # - id: cargo-update
@@ -130,7 +130,7 @@ repos:
       - id: clippy-autofix-all-targets
       - id: clippy-all-targets-all-features
       - id: clippy-all-targets
-      - id: cargo-format # in last du to clippy fixes
+      # - id: cargo-format # in last du to clippy fixes
       - id: docker-compose-down
 
   - repo: https://github.com/EmbarkStudios/cargo-deny

--- a/crate/cli/src/actions/cover_crypt/encrypt.rs
+++ b/crate/cli/src/actions/cover_crypt/encrypt.rs
@@ -79,7 +79,6 @@ impl EncryptAction {
             Some(self.encryption_policy.to_string()),
             data,
             None,
-            None,
             self.authentication_data
                 .as_deref()
                 .map(|s| s.as_bytes().to_vec()),

--- a/crate/cli/src/actions/cover_crypt/keys/create_key_pair.rs
+++ b/crate/cli/src/actions/cover_crypt/keys/create_key_pair.rs
@@ -80,7 +80,10 @@ impl CreateMasterKeyPairAction {
 
         let mut stdout = console::Stdout::new("The master keypair has been properly generated.");
         stdout.set_tags(Some(&self.tags));
-        stdout.set_key_pair_unique_identifier(&res.private_key_unique_identifier, &res.public_key_unique_identifier);
+        stdout.set_key_pair_unique_identifier(
+            &res.private_key_unique_identifier,
+            &res.public_key_unique_identifier,
+        );
         stdout.write()
     }
 }

--- a/crate/cli/src/actions/cover_crypt/keys/create_key_pair.rs
+++ b/crate/cli/src/actions/cover_crypt/keys/create_key_pair.rs
@@ -69,23 +69,18 @@ impl CreateMasterKeyPairAction {
 
         debug!("client: access_structure: {access_structure:?}");
 
-        let req = build_create_covercrypt_master_keypair_request(
-            &access_structure,
-            &self.tags,
-            self.sensitive,
-        )?;
-
         let res = kms_rest_client
-            .create_key_pair(req)
+            .create_key_pair(build_create_covercrypt_master_keypair_request(
+                &access_structure,
+                &self.tags,
+                self.sensitive,
+            )?)
             .await
             .with_context(|| "failed creating a Covercrypt Master Key Pair")?;
 
-        let msk_uid = &res.private_key_unique_identifier;
-        let mpk_uid = &res.public_key_unique_identifier;
-
         let mut stdout = console::Stdout::new("The master keypair has been properly generated.");
         stdout.set_tags(Some(&self.tags));
-        stdout.set_key_pair_unique_identifier(msk_uid, mpk_uid);
+        stdout.set_key_pair_unique_identifier(&res.private_key_unique_identifier, &res.public_key_unique_identifier);
         stdout.write()
     }
 }

--- a/crate/cli/src/actions/cover_crypt/keys/create_key_pair.rs
+++ b/crate/cli/src/actions/cover_crypt/keys/create_key_pair.rs
@@ -13,7 +13,8 @@ use crate::{
     error::result::{CliResult, CliResultHelper},
 };
 
-/// Create a new master key pair for a given policy and return the key IDs.
+/// Create a new master keypair for a given access structure and return the key
+/// IDs.
 ///
 ///
 ///  - The master public key is used to encrypt the files and can be safely shared.
@@ -50,7 +51,7 @@ pub struct CreateMasterKeyPairAction {
     /// The JSON access structure specifications file to use to generate the keys.
     /// See the inline doc of the `create-master-key-pair` command for details.
     #[clap(long, short = 's')]
-    access_structure_specification: PathBuf,
+    specification: PathBuf,
 
     /// The tag to associate with the master key pair.
     /// To specify multiple tags, use the option multiple times.
@@ -64,33 +65,27 @@ pub struct CreateMasterKeyPairAction {
 
 impl CreateMasterKeyPairAction {
     pub async fn run(&self, kms_rest_client: &KmsClient) -> CliResult<()> {
-        // Parse the json access structure file
-        let access_structure =
-            access_structure_from_json_file(&self.access_structure_specification)?;
+        let access_structure = access_structure_from_json_file(&self.specification)?;
+
         debug!("client: access_structure: {access_structure:?}");
-        let create_key_pair = build_create_covercrypt_master_keypair_request(
+
+        let req = build_create_covercrypt_master_keypair_request(
             &access_structure,
             &self.tags,
             self.sensitive,
         )?;
 
-        // Query the KMS with your kmip data and get the key pair ids
-        let create_key_pair_response = kms_rest_client
-            .create_key_pair(create_key_pair)
+        let res = kms_rest_client
+            .create_key_pair(req)
             .await
             .with_context(|| "failed creating a Covercrypt Master Key Pair")?;
 
-        let private_key_unique_identifier = &create_key_pair_response.private_key_unique_identifier;
-        let public_key_unique_identifier = &create_key_pair_response.public_key_unique_identifier;
+        let msk_uid = &res.private_key_unique_identifier;
+        let mpk_uid = &res.public_key_unique_identifier;
 
-        let mut stdout = console::Stdout::new("The master key pair has been properly generated.");
+        let mut stdout = console::Stdout::new("The master keypair has been properly generated.");
         stdout.set_tags(Some(&self.tags));
-        stdout.set_key_pair_unique_identifier(
-            private_key_unique_identifier,
-            public_key_unique_identifier,
-        );
-        stdout.write()?;
-
-        Ok(())
+        stdout.set_key_pair_unique_identifier(msk_uid, mpk_uid);
+        stdout.write()
     }
 }

--- a/crate/cli/src/actions/cover_crypt/keys/rekey.rs
+++ b/crate/cli/src/actions/cover_crypt/keys/rekey.rs
@@ -46,13 +46,11 @@ impl RekeyAction {
             cli_bail!("Either --key-id or one or more --tag must be specified")
         };
 
-        let req = build_rekey_keypair_request(
-            &id,
-            &RekeyEditAction::RekeyAccessPolicy(self.access_policy.clone()),
-        )?;
-
         let res = kms_rest_client
-            .rekey_keypair(req)
+            .rekey_keypair(build_rekey_keypair_request(
+                &id,
+                &RekeyEditAction::RekeyAccessPolicy(self.access_policy.clone()),
+            )?)
             .await
             .with_context(|| "failed rekeying the master keys")?;
 

--- a/crate/cli/src/actions/cover_crypt/keys/rekey.rs
+++ b/crate/cli/src/actions/cover_crypt/keys/rekey.rs
@@ -10,7 +10,7 @@ use crate::{
     error::result::{CliResult, CliResultHelper},
 };
 
-/// Rekey the master and user keys for a given access policy.
+/// Rekey the given access policy.
 ///
 /// Active user decryption keys are automatically re-keyed.
 /// Revoked or destroyed user decryption keys are not re-keyed.
@@ -46,34 +46,29 @@ impl RekeyAction {
             cli_bail!("Either --key-id or one or more --tag must be specified")
         };
 
-        // Create the kmip query
-        let query = build_rekey_keypair_request(
+        let req = build_rekey_keypair_request(
             &id,
             &RekeyEditAction::RekeyAccessPolicy(self.access_policy.clone()),
         )?;
 
-        // Query the KMS with your kmip data
-        let response = kms_rest_client
-            .rekey_keypair(query)
+        let res = kms_rest_client
+            .rekey_keypair(req)
             .await
             .with_context(|| "failed rekeying the master keys")?;
 
         let stdout = format!(
-            "The master secret key {} and master public key {} were rekeyed for the access policy \
-             {:?}",
-            &response.private_key_unique_identifier,
-            &response.public_key_unique_identifier,
+            "The MSK {} and MPK {} were rekeyed for the access policy {:?}",
+            &res.private_key_unique_identifier,
+            &res.public_key_unique_identifier,
             &self.access_policy
         );
 
         let mut stdout = console::Stdout::new(&stdout);
         stdout.set_key_pair_unique_identifier(
-            response.private_key_unique_identifier,
-            response.public_key_unique_identifier,
+            res.private_key_unique_identifier,
+            res.public_key_unique_identifier,
         );
-        stdout.write()?;
-
-        Ok(())
+        stdout.write()
     }
 }
 

--- a/crate/cli/src/actions/elliptic_curves/encrypt.rs
+++ b/crate/cli/src/actions/elliptic_curves/encrypt.rs
@@ -59,7 +59,6 @@ impl EncryptAction {
             None,
             data,
             None,
-            None,
             self.authentication_data
                 .as_deref()
                 .map(|s| s.as_bytes().to_vec()),

--- a/crate/cli/src/actions/rsa/encrypt.rs
+++ b/crate/cli/src/actions/rsa/encrypt.rs
@@ -112,7 +112,6 @@ impl EncryptAction {
             data,
             None,
             None,
-            None,
             Some(
                 self.encryption_algorithm
                     .to_cryptographic_parameters(self.hash_fn),

--- a/crate/cli/src/actions/shared/import_key.rs
+++ b/crate/cli/src/actions/shared/import_key.rs
@@ -2,7 +2,6 @@ use std::path::PathBuf;
 
 use clap::{Parser, ValueEnum};
 use cosmian_kms_client::{
-    KmsClient,
     cosmian_kmip::kmip_2_1::{
         kmip_data_structures::{KeyBlock, KeyMaterial, KeyValue},
         kmip_objects::{Object, ObjectType},
@@ -11,13 +10,14 @@ use cosmian_kms_client::{
         },
     },
     import_object, objects_from_pem, read_bytes_from_file, read_object_from_json_ttlv_bytes,
+    KmsClient,
 };
 use zeroize::Zeroizing;
 
-use super::utils::{KeyUsage, build_usage_mask_from_key_usage};
+use super::utils::{build_usage_mask_from_key_usage, KeyUsage};
 use crate::{
     actions::console,
-    error::{CliError, result::CliResult},
+    error::{result::CliResult, CliError},
 };
 
 #[derive(ValueEnum, Debug, Clone)]

--- a/crate/cli/src/actions/symmetric/encrypt.rs
+++ b/crate/cli/src/actions/symmetric/encrypt.rs
@@ -209,7 +209,6 @@ impl EncryptAction {
             data_encryption_key_id,
             None,
             plaintext,
-            None,
             nonce,
             authenticated_data,
             Some(cryptographic_parameters),

--- a/crate/cli/src/tests/cover_crypt/access_structure.rs
+++ b/crate/cli/src/tests/cover_crypt/access_structure.rs
@@ -185,7 +185,7 @@ async fn test_edit_access_structure() -> CliResult<()> {
     // generate a new master key pair
     let (master_secret_key_id, master_public_key_id) = create_cc_master_key_pair(
         &ctx.owner_client_conf_path,
-        "--access-structure-specification",
+        "--specification",
         "../../test_data/access_structure_specifications.json",
         &[],
         false,

--- a/crate/cli/src/tests/cover_crypt/encrypt_decrypt.rs
+++ b/crate/cli/src/tests/cover_crypt/encrypt_decrypt.rs
@@ -99,7 +99,7 @@ async fn test_encrypt_decrypt_using_object_ids() -> CliResult<()> {
 
     let (master_secret_key_id, master_public_key_id) = create_cc_master_key_pair(
         &ctx.owner_client_conf_path,
-        "--access-structure-specification",
+        "--specification",
         "../../test_data/access_structure_specifications.json",
         &[],
         false,
@@ -189,7 +189,7 @@ async fn test_encrypt_decrypt_bulk_using_object_ids() -> CliResult<()> {
 
     let (master_secret_key_id, master_public_key_id) = create_cc_master_key_pair(
         &ctx.owner_client_conf_path,
-        "--access-structure-specification",
+        "--specification",
         "../../test_data/access_structure_specifications.json",
         &[],
         false,
@@ -309,7 +309,7 @@ async fn test_encrypt_decrypt_using_tags() -> CliResult<()> {
 
     let (master_secret_key_id, _master_public_key_id) = create_cc_master_key_pair(
         &ctx.owner_client_conf_path,
-        "--access-structure-specification",
+        "--specification",
         "../../test_data/access_structure_specifications.json",
         &["tag"],
         false,
@@ -432,7 +432,7 @@ async fn test_encrypt_decrypt_bulk_using_tags() -> CliResult<()> {
 
     let (master_secret_key_id, _master_public_key_id) = create_cc_master_key_pair(
         &ctx.owner_client_conf_path,
-        "--access-structure-specification",
+        "--specification",
         "../../test_data/access_structure_specifications.json",
         &["tag_bulk"],
         false,

--- a/crate/cli/src/tests/cover_crypt/master_key_pair.rs
+++ b/crate/cli/src/tests/cover_crypt/master_key_pair.rs
@@ -62,7 +62,7 @@ pub(crate) async fn test_create_master_key_pair() -> CliResult<()> {
     let ctx = start_default_test_kms_server().await;
     create_cc_master_key_pair(
         &ctx.owner_client_conf_path,
-        "--access-structure-specification",
+        "--specification",
         "../../test_data/access_structure_specifications.json",
         &[],
         false,

--- a/crate/cli/src/tests/cover_crypt/rekey.rs
+++ b/crate/cli/src/tests/cover_crypt/rekey.rs
@@ -84,7 +84,7 @@ async fn test_rekey_error() -> CliResult<()> {
     // generate a new master key pair
     let (master_secret_key_id, _master_public_key_id) = create_cc_master_key_pair(
         &ctx.owner_client_conf_path,
-        "--access-structure-specification",
+        "--specification",
         "../../test_data/access_structure_specifications.json",
         &[],
         false,
@@ -216,7 +216,7 @@ async fn test_enc_dec_rekey() -> CliResult<()> {
     // generate a new master key pair
     let (master_secret_key_id, master_public_key_id) = create_cc_master_key_pair(
         &ctx.owner_client_conf_path,
-        "--access-structure-specification",
+        "--specification",
         "../../test_data/access_structure.json",
         &[],
         false,
@@ -284,7 +284,7 @@ async fn test_rekey_prune() -> CliResult<()> {
     // generate a new master key pair
     let (master_secret_key_id, master_public_key_id) = create_cc_master_key_pair(
         &ctx.owner_client_conf_path,
-        "--access-structure-specification",
+        "--specification",
         "../../test_data/access_structure_specifications.json",
         &[],
         false,

--- a/crate/cli/src/tests/cover_crypt/user_decryption_keys.rs
+++ b/crate/cli/src/tests/cover_crypt/user_decryption_keys.rs
@@ -60,7 +60,7 @@ pub(crate) async fn test_user_decryption_key() -> CliResult<()> {
     // generate a new master key pair
     let (master_secret_key_id, _) = create_cc_master_key_pair(
         &ctx.owner_client_conf_path,
-        "--access-structure-specification",
+        "--specification",
         "../../test_data/access_structure_specifications.json",
         &[],
         false,
@@ -86,7 +86,7 @@ pub(crate) async fn test_user_decryption_key_error() -> CliResult<()> {
     // generate a new master key pair
     let (master_secret_key_id, _) = create_cc_master_key_pair(
         &ctx.owner_client_conf_path,
-        "--access-structure-specification",
+        "--specification",
         "../../test_data/access_structure_specifications.json",
         &[],
         false,

--- a/crate/cli/src/tests/shared/destroy.rs
+++ b/crate/cli/src/tests/shared/destroy.rs
@@ -274,7 +274,7 @@ async fn test_destroy_cover_crypt() -> CliResult<()> {
         // generate a new master key pair
         let (master_private_key_id, master_public_key_id) = create_cc_master_key_pair(
             &ctx.owner_client_conf_path,
-            "--access-structure-specification",
+            "--specification",
             "../../test_data/access_structure_specifications.json",
             &[],
             false,
@@ -332,7 +332,7 @@ async fn test_destroy_cover_crypt() -> CliResult<()> {
         // generate a new master key pair
         let (master_private_key_id, master_public_key_id) = create_cc_master_key_pair(
             &ctx.owner_client_conf_path,
-            "--access-structure-specification",
+            "--specification",
             "../../test_data/access_structure_specifications.json",
             &[],
             false,
@@ -390,7 +390,7 @@ async fn test_destroy_cover_crypt() -> CliResult<()> {
         // generate a new master key pair
         let (master_private_key_id, master_public_key_id) = create_cc_master_key_pair(
             &ctx.owner_client_conf_path,
-            "--access-structure-specification",
+            "--specification",
             "../../test_data/access_structure_specifications.json",
             &[],
             false,

--- a/crate/cli/src/tests/shared/export.rs
+++ b/crate/cli/src/tests/shared/export.rs
@@ -380,7 +380,7 @@ pub(crate) async fn test_export_covercrypt() -> CliResult<()> {
     // generate a new master key pair
     let (master_private_key_id, master_public_key_id) = create_cc_master_key_pair(
         &ctx.owner_client_conf_path,
-        "--access-structure-specification",
+        "--specification",
         "../../test_data/access_structure_specifications.json",
         &[],
         false,
@@ -439,7 +439,7 @@ pub(crate) async fn test_export_error_cover_crypt() -> CliResult<()> {
     // generate a new master key pair
     let (master_private_key_id, _master_public_key_id) = create_cc_master_key_pair(
         &ctx.owner_client_conf_path,
-        "--access-structure-specification",
+        "--specification",
         "../../test_data/access_structure_specifications.json",
         &[],
         false,
@@ -716,7 +716,7 @@ pub(crate) async fn test_sensitive_covercrypt_key() -> CliResult<()> {
     // generate a new master key pair
     let (master_private_key_id, master_public_key_id) = create_cc_master_key_pair(
         &ctx.owner_client_conf_path,
-        "--access-structure-specification",
+        "--specification",
         "../../test_data/access_structure_specifications.json",
         &[],
         true,

--- a/crate/cli/src/tests/shared/import.rs
+++ b/crate/cli/src/tests/shared/import.rs
@@ -153,7 +153,7 @@ pub(crate) async fn test_generate_export_import() -> CliResult<()> {
     // Covercrypt import/export test
     let (private_key_id, _public_key_id) = create_cc_master_key_pair(
         &ctx.owner_client_conf_path,
-        "--access-structure-specification",
+        "--specification",
         "../../test_data/access_structure_specifications.json",
         &[],
         false,

--- a/crate/cli/src/tests/shared/import_export_wrapping.rs
+++ b/crate/cli/src/tests/shared/import_export_wrapping.rs
@@ -60,7 +60,7 @@ pub(crate) async fn test_import_export_wrap_rfc_5649() -> CliResult<()> {
     // test CC
     let (private_key_id, _public_key_id) = create_cc_master_key_pair(
         &ctx.owner_client_conf_path,
-        "--access-structure-specification",
+        "--specification",
         "../../test_data/access_structure_specifications.json",
         &[],
         false,
@@ -147,7 +147,7 @@ pub(crate) async fn test_import_export_wrap_ecies() -> CliResult<()> {
     // test CC
     let (private_key_id, _public_key_id) = create_cc_master_key_pair(
         &ctx.owner_client_conf_path,
-        "--access-structure-specification",
+        "--specification",
         "../../test_data/access_structure_specifications.json",
         &[],
         false,

--- a/crate/cli/src/tests/shared/locate.rs
+++ b/crate/cli/src/tests/shared/locate.rs
@@ -75,7 +75,7 @@ pub(crate) async fn test_locate_cover_crypt() -> CliResult<()> {
     // generate a new master key pair
     let (master_private_key_id, master_public_key_id) = create_cc_master_key_pair(
         &ctx.owner_client_conf_path,
-        "--access-structure-specification",
+        "--specification",
         "../../test_data/access_structure_specifications.json",
         &["test_cc"],
         false,
@@ -388,7 +388,7 @@ pub(crate) async fn test_locate_grant() -> CliResult<()> {
     // generate a new master key pair
     let (master_private_key_id, master_public_key_id) = create_cc_master_key_pair(
         &ctx.owner_client_conf_path,
-        "--access-structure-specification",
+        "--specification",
         "../../test_data/access_structure_specifications.json",
         &["test_grant"],
         false,

--- a/crate/cli/src/tests/shared/revoke.rs
+++ b/crate/cli/src/tests/shared/revoke.rs
@@ -156,7 +156,7 @@ async fn test_revoke_cover_crypt() -> CliResult<()> {
         // generate a new master key pair
         let (master_private_key_id, master_public_key_id) = create_cc_master_key_pair(
             &ctx.owner_client_conf_path,
-            "--access-structure-specification",
+            "--specification",
             "../../test_data/access_structure_specifications.json",
             &[],
             false,
@@ -196,7 +196,7 @@ async fn test_revoke_cover_crypt() -> CliResult<()> {
         // generate a new master key pair
         let (master_private_key_id, master_public_key_id) = create_cc_master_key_pair(
             &ctx.owner_client_conf_path,
-            "--access-structure-specification",
+            "--specification",
             "../../test_data/access_structure_specifications.json",
             &[],
             false,
@@ -236,7 +236,7 @@ async fn test_revoke_cover_crypt() -> CliResult<()> {
         // generate a new master key pair
         let (master_private_key_id, master_public_key_id) = create_cc_master_key_pair(
             &ctx.owner_client_conf_path,
-            "--access-structure-specification",
+            "--specification",
             "../../test_data/access_structure_specifications.json",
             &[],
             false,

--- a/crate/cli/src/tests/shared/wrap_unwrap.rs
+++ b/crate/cli/src/tests/shared/wrap_unwrap.rs
@@ -138,7 +138,7 @@ pub(crate) async fn test_password_wrap_import() -> CliResult<()> {
     // CC
     let (private_key_id, _public_key_id) = create_cc_master_key_pair(
         &ctx.owner_client_conf_path,
-        "--access-structure-specification",
+        "--specification",
         "../../test_data/access_structure_specifications.json",
         &[],
         false,

--- a/crate/client/src/import_utils.rs
+++ b/crate/client/src/import_utils.rs
@@ -13,7 +13,7 @@ use crate::{
 ///
 /// If the `import_attributes` are not specified,
 /// the attributes of the object are used, if any.
-pub async fn import_object<'a, T: IntoIterator<Item = impl AsRef<str>>>(
+pub async fn import_object<T: IntoIterator<Item = impl AsRef<str>>>(
     kms_rest_client: &KmsClient,
     object_id: Option<String>,
     object: Object,

--- a/crate/crypto/src/crypto/cover_crypt/access_structure.rs
+++ b/crate/crypto/src/crypto/cover_crypt/access_structure.rs
@@ -29,6 +29,9 @@ pub fn access_structure_from_str(access_structure_str: &str) -> CryptoResult<Acc
             access_structure.add_anarchy(dimension.clone())?;
         }
 
+        // Reversing the iterator is necessary because hierarchical attributes
+        // are declared in increasing order but inserted in decreasing order
+        // when `None` is passed as `after`.
         for name in attributes.iter().rev() {
             let attribute = QualifiedAttribute {
                 dimension: dimension.trim_end_matches("::<").to_owned(),

--- a/crate/crypto/src/crypto/cover_crypt/attributes.rs
+++ b/crate/crypto/src/crypto/cover_crypt/attributes.rs
@@ -88,7 +88,7 @@ pub fn qualified_attributes_from_attributes(
                 "the attributes do not contain Covercrypt (vendor) Attributes".to_owned(),
             )
         })?;
-    let attribute_strings = serde_json::from_slice::<Vec<String>>(&bytes).map_err(|e| {
+    let attribute_strings = serde_json::from_slice::<Vec<String>>(bytes).map_err(|e| {
         CryptoError::Kmip(format!(
             "failed reading the Covercrypt attribute strings from the attributes bytes: {e}"
         ))

--- a/crate/crypto/src/crypto/cover_crypt/decryption.rs
+++ b/crate/crypto/src/crypto/cover_crypt/decryption.rs
@@ -1,7 +1,7 @@
-use cosmian_cover_crypt::{Error, UserSecretKey, XEnc, api::Covercrypt, traits::KemAc};
+use cosmian_cover_crypt::{api::Covercrypt, traits::KemAc, Error, UserSecretKey, XEnc};
 use cosmian_crypto_core::{
-    Aes256Gcm, Dem, FixedSizeCBytes, Instantiable, Nonce, SymmetricKey,
     bytes_ser_de::{Deserializer, Serializable, Serializer},
+    Aes256Gcm, Dem, FixedSizeCBytes, Instantiable, Nonce, SymmetricKey,
 };
 use cosmian_kmip::kmip_2_1::{
     kmip_objects::Object,
@@ -14,7 +14,7 @@ use zeroize::Zeroizing;
 use super::user_key::unwrap_user_decryption_key_object;
 use crate::{
     crypto::DecryptionSystem,
-    error::{CryptoError, result::CryptoResult},
+    error::{result::CryptoResult, CryptoError},
 };
 
 /// Decrypt a single block of data encrypted using an hybrid encryption mode

--- a/crate/crypto/src/crypto/cover_crypt/encryption.rs
+++ b/crate/crypto/src/crypto/cover_crypt/encryption.rs
@@ -1,16 +1,16 @@
-use cosmian_cover_crypt::{AccessPolicy, MasterPublicKey, api::Covercrypt, traits::KemAc};
+use cosmian_cover_crypt::{api::Covercrypt, traits::KemAc, AccessPolicy, MasterPublicKey};
 use cosmian_crypto_core::{
-    Aes256Gcm, Dem, Instantiable, Nonce, RandomFixedSizeCBytes, SymmetricKey,
     bytes_ser_de::{Deserializer, Serializable, Serializer},
     reexport::zeroize::Zeroizing,
+    Aes256Gcm, Dem, Instantiable, Nonce, RandomFixedSizeCBytes, SymmetricKey,
 };
 use cosmian_kmip::{
-    DataToEncrypt,
     kmip_2_1::{
         kmip_objects::Object,
         kmip_operations::{Encrypt, EncryptResponse},
         kmip_types::{CryptographicAlgorithm, CryptographicParameters, UniqueIdentifier},
     },
+    DataToEncrypt,
 };
 use tracing::{debug, trace};
 

--- a/crate/crypto/src/crypto/cover_crypt/encryption.rs
+++ b/crate/crypto/src/crypto/cover_crypt/encryption.rs
@@ -1,7 +1,6 @@
-use cosmian_cover_crypt::{api::Covercrypt, AccessPolicy, EncryptedHeader, MasterPublicKey};
+use cosmian_cover_crypt::{api::Covercrypt, traits::KemAc, AccessPolicy, MasterPublicKey};
 use cosmian_crypto_core::{
     bytes_ser_de::{Deserializer, Serializable, Serializer},
-    kdf256,
     reexport::zeroize::Zeroizing,
     Aes256Gcm, Dem, Instantiable, Nonce, RandomFixedSizeCBytes, SymmetricKey,
 };
@@ -17,7 +16,6 @@ use tracing::{debug, trace};
 
 use crate::{crypto::EncryptionSystem, error::CryptoError};
 
-const SYM_KEY_LENGTH: usize = 32;
 /// Encrypt a single block of data using a KEM-DEM cryptosystem
 /// Cannot be used as a stream cipher
 pub struct CoverCryptEncryption {
@@ -45,8 +43,8 @@ impl CoverCryptEncryption {
 
     /// Encrypt multiple LEB128-serialized payloads
     ///
-    /// The input plaintext data is serialized using LEB128 (bulk mode).
-    /// Each chunk of data is encrypted and serialized back to LEB128.
+    /// The input plaintext data is serialized using LEB128 (bulk mode).  Each
+    /// chunk of data is encrypted and serialized back to LEB128.
     ///
     /// Bulk encryption / decryption scheme
     ///
@@ -69,15 +67,20 @@ impl CoverCryptEncryption {
     ///
     fn bulk_encrypt(
         &self,
-        encrypted_header: &[u8],
-        plaintext: &[u8],
+        mpk: &MasterPublicKey,
+        ptx: &[u8],
         ad: Option<&[u8]>,
-        symmetric_key: &SymmetricKey<SYM_KEY_LENGTH>,
+        ap: AccessPolicy,
     ) -> Result<Vec<u8>, CryptoError> {
-        let mut de = Deserializer::new(plaintext);
+        let mut de = Deserializer::new(ptx);
         let mut ser = Serializer::new();
 
-        // number of chunks of plaintext data to encrypt
+        let (seed, enc) = self.cover_crypt.encaps(&mpk, &ap)?;
+        let key = SymmetricKey::derive(&seed, b"Covercrypt AEAD key")?;
+        let enc = enc.serialize()?;
+
+        trace!("CoverCryptEncryption: encrypt: encryption_policy: {ap:?}",);
+
         let nb_chunks = {
             let len = de.read_leb128_u64()?;
             ser.write_leb128_u64(len)?;
@@ -88,37 +91,46 @@ impl CoverCryptEncryption {
             })?
         };
 
-        // encrypt each chunk and serialize it
-        // a copy of the encrypted header is also serialized, prepending the chunk
+        // Encrypt each chunk and serialize it along with a copy of the
+        // Covecrypt encapsulation.
         for _ in 0..nb_chunks {
-            let chunk_data = de.read_vec_as_ref()?;
-            let mut encrypted_block = self.encrypt(chunk_data, ad, symmetric_key)?;
-            let mut chunk = encrypted_header.to_vec();
-            chunk.append(&mut encrypted_block);
-            ser.write_vec(&chunk)?;
+            let ptx = de.read_vec_as_ref()?;
+            let ctx = self.aead_encrypt(&key, ptx, ad)?;
+            let res = [&**enc, &ctx].concat();
+            ser.write_vec(&res)?;
         }
 
         Ok(ser.finalize().to_vec())
     }
 
-    fn encrypt(
+    fn single_encrypt(
         &self,
-        plaintext: &[u8],
+        mpk: &MasterPublicKey,
+        ptx: &[u8],
         ad: Option<&[u8]>,
-        symmetric_key: &SymmetricKey<{ SYM_KEY_LENGTH }>,
+        ap: AccessPolicy,
     ) -> Result<Vec<u8>, CryptoError> {
-        // Encrypt the data
-        let aes256gcm = Aes256Gcm::new(symmetric_key);
+        let (seed, enc) = self.cover_crypt.encaps(&mpk, &ap)?;
+        let key = SymmetricKey::derive(&seed, b"Covercrypt AEAD key")?;
+        let enc = enc.serialize()?;
+        trace!("CoverCryptEncryption: encrypt: encryption_policy: {ap:?}",);
+        let ctx = self.aead_encrypt(&key, ptx, ad)?;
+        Ok([&**enc, &ctx].concat())
+    }
+
+    fn aead_encrypt(
+        &self,
+        key: &SymmetricKey<{ Aes256Gcm::KEY_LENGTH }>,
+        ptx: &[u8],
+        ad: Option<&[u8]>,
+    ) -> Result<Vec<u8>, CryptoError> {
         let nonce = Nonce::new(&mut *self.cover_crypt.rng());
-        let mut ciphertext = aes256gcm.encrypt(&nonce, plaintext, ad)?;
-        let mut res =
-            Vec::with_capacity(plaintext.len() + Aes256Gcm::MAC_LENGTH + Aes256Gcm::NONCE_LENGTH);
-        res.extend(nonce.0);
-        res.append(&mut ciphertext);
+        let ctx = Aes256Gcm::new(key).encrypt(&nonce, ptx, ad)?;
+        let res = [&nonce.0, &*ctx].concat();
         debug!(
             "Encrypted data with auth data {:?} of len (Plain/Enc): {}/{}",
             ad,
-            plaintext.len(),
+            ptx.len(),
             res.len(),
         );
         Ok(res)
@@ -130,69 +142,39 @@ impl EncryptionSystem for CoverCryptEncryption {
         let ad = request.authenticated_encryption_additional_data.as_deref();
 
         trace!("CoverCryptEncryption: encrypt: authenticated_encryption_additional_data: {ad:?}",);
-        let data_to_encrypt = DataToEncrypt::try_from_bytes(
+
+        let encrypted_data =
             request
                 .data
                 .as_deref()
-                .ok_or_else(|| CryptoError::Kmip("Missing data to encrypt".to_owned()))?,
-        )?;
+                .map(|data| -> Result<_, _> {
+                    let ptx = DataToEncrypt::try_from_bytes(data)?;
+                    let mpk = MasterPublicKey::deserialize(self.public_key_bytes.as_slice())
+                        .map_err(|e| {
+                            CryptoError::Kmip(format!(
+                                "Covercrypt encrypt: failed recovering the master public key: {e}"
+                            ))
+                        })?;
 
-        let public_key =
-            MasterPublicKey::deserialize(self.public_key_bytes.as_slice()).map_err(|e| {
-                CryptoError::Kmip(format!(
-                    "cover crypt encrypt: failed recovering the public key: {e}"
-                ))
-            })?;
+                    let ap = AccessPolicy::parse(ptx.encryption_policy.as_deref().ok_or_else(
+                        || CryptoError::Kmip("encryption policy missing".to_owned()),
+                    )?)?;
 
-        let encryption_policy = data_to_encrypt
-            .encryption_policy
-            .as_deref()
-            .ok_or_else(|| CryptoError::Kmip("encryption policy missing".to_owned()))?;
-        trace!("CoverCryptEncryption: encrypt: encryption_policy_string: {encryption_policy}",);
-        // Generate a symmetric key and encrypt the header
-        let (secret, encrypted_header) = EncryptedHeader::generate(
-            &self.cover_crypt,
-            &public_key,
-            &AccessPolicy::parse(encryption_policy)?,
-            data_to_encrypt.header_metadata.as_deref(),
-            ad,
-        )
-        .map_err(|e| CryptoError::Kmip(e.to_string()))?;
-
-        let mut encrypted_header = encrypted_header
-            .serialize()
-            .map_err(|e| CryptoError::Kmip(e.to_string()))?;
-
-        let mut symmetric_key = SymmetricKey::default();
-        kdf256!(&mut *symmetric_key, &*secret);
-
-        let encrypted_data = if let Some(CryptographicParameters {
-            cryptographic_algorithm: Some(CryptographicAlgorithm::CoverCryptBulk),
-            ..
-        }) = request.cryptographic_parameters
-        {
-            self.bulk_encrypt(
-                &encrypted_header,
-                &data_to_encrypt.plaintext,
-                ad,
-                &symmetric_key,
-            )?
-        } else {
-            let mut encrypted_data =
-                self.encrypt(&data_to_encrypt.plaintext, ad, &symmetric_key)?;
-            debug!(
-                "Encrypted bytes len: {}, Encrypted header len: {}, Encrypted data len: {}",
-                encrypted_header.len() + encrypted_data.len(),
-                encrypted_header.len(),
-                encrypted_data.len(),
-            );
-            encrypted_header.append(&mut encrypted_data);
-            encrypted_header.to_vec()
-        };
+                    if let Some(CryptographicParameters {
+                        cryptographic_algorithm: Some(CryptographicAlgorithm::CoverCryptBulk),
+                        ..
+                    }) = request.cryptographic_parameters
+                    {
+                        self.bulk_encrypt(&mpk, &ptx.plaintext, ad, ap)
+                    } else {
+                        self.single_encrypt(&mpk, &ptx.plaintext, ad, ap)
+                    }
+                })
+                .transpose()?;
 
         Ok(EncryptResponse {
             unique_identifier: UniqueIdentifier::TextString(self.public_key_uid.clone()),
-            data: Some(encrypted_data),
+            data: encrypted_data,
             iv_counter_nonce: None,
             correlation_value: None,
             authenticated_encryption_tag: ad.map(<[u8]>::to_vec),

--- a/crate/crypto/src/crypto/cover_crypt/master_keys.rs
+++ b/crate/crypto/src/crypto/cover_crypt/master_keys.rs
@@ -1,4 +1,4 @@
-use cosmian_cover_crypt::{MasterPublicKey, MasterSecretKey, api::Covercrypt};
+use cosmian_cover_crypt::{api::Covercrypt, MasterPublicKey, MasterSecretKey};
 use cosmian_crypto_core::bytes_ser_de::Serializable;
 use cosmian_kmip::kmip_2_1::{
     extra::VENDOR_ID_COSMIAN,
@@ -14,10 +14,10 @@ use zeroize::Zeroizing;
 
 use crate::{
     crypto::{
-        KeyPair,
         cover_crypt::attributes::{
-            VENDOR_ATTR_COVER_CRYPT_ACCESS_STRUCTURE, access_structure_from_attributes,
+            access_structure_from_attributes, VENDOR_ATTR_COVER_CRYPT_ACCESS_STRUCTURE,
         },
+        KeyPair,
     },
     error::CryptoError,
 };

--- a/crate/crypto/src/crypto/cover_crypt/master_keys.rs
+++ b/crate/crypto/src/crypto/cover_crypt/master_keys.rs
@@ -52,7 +52,7 @@ pub fn create_master_keypair(
 
     let msk_owm = create_msk_object(
         msk.serialize()?,
-        msk_attributes.unwrap_or(common_attributes.clone()),
+        msk_attributes.unwrap_or_else(|| common_attributes.clone()),
         public_key_uid,
         sensitive,
     )?;
@@ -169,7 +169,7 @@ pub fn kmip_objects_from_cc_master_keypair(
             Ok(())
         }
         _ => Err(CryptoError::Kmip(
-            "wrong key material type for MSK".to_string(),
+            "wrong key material type for MSK".to_owned(),
         )),
     }?;
 
@@ -183,7 +183,7 @@ pub fn kmip_objects_from_cc_master_keypair(
             Ok(())
         }
         _ => Err(CryptoError::Kmip(
-            "wrong key material type for MPK".to_string(),
+            "wrong key material type for MPK".to_owned(),
         )),
     }?;
 

--- a/crate/crypto/src/crypto/cover_crypt/master_keys.rs
+++ b/crate/crypto/src/crypto/cover_crypt/master_keys.rs
@@ -1,4 +1,4 @@
-use cosmian_cover_crypt::{api::Covercrypt, AccessStructure, MasterPublicKey, MasterSecretKey};
+use cosmian_cover_crypt::{MasterPublicKey, MasterSecretKey, api::Covercrypt};
 use cosmian_crypto_core::bytes_ser_de::Serializable;
 use cosmian_kmip::kmip_2_1::{
     kmip_data_structures::{KeyBlock, KeyMaterial, KeyValue},
@@ -8,96 +8,82 @@ use cosmian_kmip::kmip_2_1::{
         LinkedObjectIdentifier,
     },
 };
-use tracing::{debug, trace};
+use tracing::debug;
 use zeroize::Zeroizing;
 
 use crate::{
-    crypto::{
-        cover_crypt::attributes::{
-            access_structure_from_attributes, upsert_access_structure_in_attributes,
-        },
-        KeyPair,
-    },
+    crypto::{KeyPair, cover_crypt::attributes::access_structure_from_attributes},
     error::CryptoError,
 };
 
 /// Group a key UID with its KMIP Object
 pub type KmipKeyUidObject = (String, Object);
 
-/// Generate a `KeyPair` `(PrivateKey, MasterPublicKey)` from the attributes
-/// of a `CreateKeyPair` operation
+/// Generate a new Covercrypt master keypair the attributes of a `CreateKeyPair`
+/// operation.
 pub fn create_master_keypair(
     cover_crypt: &Covercrypt,
-    private_key_uid: &str,
+    private_key_uid: String,
     public_key_uid: &str,
-    common_attributes: &Option<Attributes>,
-    private_key_attributes: &Option<Attributes>,
-    public_key_attributes: &Option<Attributes>,
+    common_attributes: Attributes,
+    msk_attributes: Option<Attributes>,
+    mpk_attributes: Option<Attributes>,
     sensitive: bool,
 ) -> Result<KeyPair, CryptoError> {
-    let access_structure =
-        access_structure_from_attributes(&common_attributes.clone().unwrap_or_default())?;
+    let access_structure = access_structure_from_attributes(&common_attributes)?;
+
     debug!("server: access_structure: {access_structure:?}");
 
-    // Now generate a master key using the Covercrypt Engine
-    let (mut msk, _mpk) = cover_crypt
+    let (mut msk, _) = cover_crypt
         .setup()
         .map_err(|e| CryptoError::Kmip(e.to_string()))?;
-
     msk.access_structure = access_structure;
-
     let mpk = cover_crypt.update_msk(&mut msk)?;
 
-    // First generate fresh attributes with that policy
-    let private_key_attributes = private_key_attributes
-        .as_ref()
-        .or(common_attributes.as_ref());
+    // Removes the access structure from the common attributes.
 
-    let private_key = create_master_secret_key_object(
-        &msk.serialize()?,
-        private_key_attributes,
+    // TODO: this creates a bug: the MSK cannot be found anymore :/
+    //
+    // common_attributes.remove_vendor_attribute(VENDOR_ID_COSMIAN,
+    // VENDOR_ATTR_COVER_CRYPT_ACCESS_STRUCTURE);
+
+    let msk_owm = create_msk_object(
+        msk.serialize()?,
+        msk_attributes.unwrap_or(common_attributes.clone()),
         public_key_uid,
-        &msk.access_structure,
         sensitive,
     )?;
 
-    // Public Key generation
-    // First generate fresh attributes with that policy
-    let public_key_attributes = public_key_attributes
-        .as_ref()
-        .or(common_attributes.as_ref());
-    let public_key =
-        create_master_public_key_object(&mpk.serialize()?, public_key_attributes, private_key_uid)?;
-    Ok(KeyPair((private_key, public_key)))
+    let mpk_owm = create_mpk_object(
+        mpk.serialize()?,
+        mpk_attributes.unwrap_or(common_attributes),
+        private_key_uid,
+    )?;
+
+    Ok(KeyPair((msk_owm, mpk_owm)))
 }
 
-pub fn create_master_secret_key_object(
-    key: &[u8],
-    attributes: Option<&Attributes>,
-    master_public_key_uid: &str,
-    access_structure: &AccessStructure,
+pub fn create_msk_object(
+    msk_bytes: Zeroizing<Vec<u8>>,
+    mut attributes: Attributes,
+    mpk_uid: &str,
     sensitive: bool,
 ) -> Result<Object, CryptoError> {
     debug!(
-        "create_master_secret_key_object: key len: {}, attributes: {attributes:?}",
-        key.len()
+        "create_msk_object: key len: {}, attributes: {attributes:?}",
+        msk_bytes.len()
     );
-    let mut attributes = attributes.cloned().unwrap_or_default();
+
     attributes.object_type = Some(ObjectType::PrivateKey);
     attributes.key_format_type = Some(KeyFormatType::CoverCryptSecretKey);
-    // Covercrypt keys are set to have unrestricted usage.
     attributes.set_cryptographic_usage_mask_bits(CryptographicUsageMask::Unrestricted);
-    // add the policy to the attributes
-    upsert_access_structure_in_attributes(&mut attributes, access_structure)?;
-    // link the private key to the public key
     attributes.link = Some(vec![Link {
         link_type: LinkType::PublicKeyLink,
-        linked_object_identifier: LinkedObjectIdentifier::TextString(
-            master_public_key_uid.to_owned(),
-        ),
+        linked_object_identifier: LinkedObjectIdentifier::TextString(mpk_uid.to_owned()),
     }]);
     attributes.sensitive = sensitive;
-    let cryptographic_length = Some(i32::try_from(key.len())? * 8);
+
+    let cryptographic_length = Some(i32::try_from(msk_bytes.len())? * 8);
 
     Ok(Object::PrivateKey {
         key_block: KeyBlock {
@@ -105,7 +91,7 @@ pub fn create_master_secret_key_object(
             key_format_type: KeyFormatType::CoverCryptSecretKey,
             key_compression_type: None,
             key_value: KeyValue {
-                key_material: KeyMaterial::ByteString(Zeroizing::from(key.to_vec())),
+                key_material: KeyMaterial::ByteString(msk_bytes),
                 attributes: Some(attributes),
             },
             cryptographic_length,
@@ -118,12 +104,11 @@ pub fn create_master_secret_key_object(
 /// Policy and optional additional attributes
 ///
 /// see `cover_crypt_unwrap_master_public_key` for the reverse operation
-fn create_master_public_key_object(
-    key: &[u8],
-    attributes: Option<&Attributes>,
-    master_secret_key_uid: &str,
+fn create_mpk_object(
+    key: Zeroizing<Vec<u8>>,
+    mut attributes: Attributes,
+    msk_uid: String,
 ) -> Result<Object, CryptoError> {
-    let mut attributes = attributes.cloned().unwrap_or_default();
     attributes.sensitive = false;
     attributes.object_type = Some(ObjectType::PublicKey);
     attributes.key_format_type = Some(KeyFormatType::CoverCryptPublicKey);
@@ -132,9 +117,7 @@ fn create_master_public_key_object(
     // link the public key to the private key
     attributes.link = Some(vec![Link {
         link_type: LinkType::PrivateKeyLink,
-        linked_object_identifier: LinkedObjectIdentifier::TextString(
-            master_secret_key_uid.to_owned(),
-        ),
+        linked_object_identifier: LinkedObjectIdentifier::TextString(msk_uid),
     }]);
     let cryptographic_length = Some(i32::try_from(key.len())? * 8);
     Ok(Object::PublicKey {
@@ -143,7 +126,7 @@ fn create_master_public_key_object(
             key_format_type: KeyFormatType::CoverCryptPublicKey,
             key_compression_type: None,
             key_value: KeyValue {
-                key_material: KeyMaterial::ByteString(Zeroizing::from(key.to_vec())),
+                key_material: KeyMaterial::ByteString(key),
                 attributes: Some(attributes),
             },
             cryptographic_length,
@@ -152,67 +135,54 @@ fn create_master_public_key_object(
     })
 }
 
-pub fn covercrypt_keys_from_kmip_objects(
-    master_secret_key: &Object,
-    master_public_key: &Object,
+pub fn cc_master_keypair_from_kmip_objects(
+    msk: &Object,
+    mpk: &Object,
 ) -> Result<(MasterSecretKey, MasterPublicKey), CryptoError> {
-    // Recover the Covercrypt PrivateKey Object
-    let msk_key_block = master_secret_key.key_block()?;
-    let msk_key_bytes = msk_key_block.key_bytes()?;
-    trace!(
-        "covercrypt_keys_from_kmip_objects: msk_key_bytes len: {}",
-        msk_key_bytes.len()
-    );
-    let msk = MasterSecretKey::deserialize(&msk_key_bytes).map_err(|e| {
-        CryptoError::Kmip(format!(
-            "Failed deserializing the Covercrypt master secret key: {e}"
-        ))
-    })?;
+    let msk_bytes = msk.key_block()?.key_bytes()?;
+    let msk = MasterSecretKey::deserialize(&msk_bytes)
+        .map_err(|e| CryptoError::Kmip(format!("Failed deserializing the Covercrypt MSK: {e}")))?;
 
-    // Recover the Covercrypt MasterPublicKey Object
-    let mpk_key_block = master_public_key.key_block()?;
-    let mpk_key_bytes = mpk_key_block.key_bytes()?;
-    let mpk = MasterPublicKey::deserialize(&mpk_key_bytes).map_err(|e| {
-        CryptoError::Kmip(format!(
-            "Failed deserializing the Covercrypt Master Public Key: {e}"
-        ))
-    })?;
+    let mpk_bytes = mpk.key_block()?.key_bytes()?;
+    let mpk = MasterPublicKey::deserialize(&mpk_bytes)
+        .map_err(|e| CryptoError::Kmip(format!("Failed deserializing the Covercrypt MPK: {e}")))?;
 
     Ok((msk, mpk))
 }
 
-pub fn kmip_objects_from_covercrypt_keys(
+pub fn kmip_objects_from_cc_master_keypair(
     msk: &MasterSecretKey,
     mpk: &MasterPublicKey,
-    msk_obj: KmipKeyUidObject,
-    mpk_obj: KmipKeyUidObject,
-    sensitive: bool,
-) -> Result<(KmipKeyUidObject, KmipKeyUidObject), CryptoError> {
-    let updated_master_secret_key_bytes = &msk.serialize()?;
-    trace!(
-        "kmip_objects_from_covercrypt_keys: updated_master_secret_key_bytes len: {}",
-        updated_master_secret_key_bytes.len()
-    );
-    let updated_master_secret_key = create_master_secret_key_object(
-        updated_master_secret_key_bytes,
-        Some(msk_obj.1.attributes()?),
-        &mpk_obj.0,
-        &msk.access_structure,
-        sensitive,
-    )?;
-    let updated_master_public_key_bytes = &mpk.serialize().map_err(|e| {
-        CryptoError::Kmip(format!(
-            "Failed serializing the Covercrypt Master Public Key: {e}"
-        ))
-    })?;
-    let updated_master_public_key = create_master_public_key_object(
-        updated_master_public_key_bytes,
-        Some(mpk_obj.1.attributes()?),
-        &msk_obj.0,
-    )?;
+    mut msk_obj: Object,
+    mut mpk_obj: Object,
+) -> Result<(Object, Object), CryptoError> {
+    let msk_bytes = msk
+        .serialize()
+        .map_err(|e| CryptoError::Kmip(format!("Failed serializing the Covercrypt MSK: {e}")))?;
 
-    Ok((
-        (msk_obj.0, updated_master_secret_key),
-        (mpk_obj.0, updated_master_public_key),
-    ))
+    match &mut msk_obj.key_block_mut()?.key_value.key_material {
+        KeyMaterial::ByteString(bytes) => {
+            *bytes = msk_bytes;
+            Ok(())
+        }
+        _ => Err(CryptoError::Kmip(
+            "wrong key material type for MSK".to_string(),
+        )),
+    }?;
+
+    let mpk_bytes = mpk
+        .serialize()
+        .map_err(|e| CryptoError::Kmip(format!("Failed serializing the Covercrypt MPK: {e}")))?;
+
+    match &mut mpk_obj.key_block_mut()?.key_value.key_material {
+        KeyMaterial::ByteString(bytes) => {
+            *bytes = mpk_bytes;
+            Ok(())
+        }
+        _ => Err(CryptoError::Kmip(
+            "wrong key material type for MPK".to_string(),
+        )),
+    }?;
+
+    Ok((msk_obj, mpk_obj))
 }

--- a/crate/crypto/src/crypto/cover_crypt/user_key.rs
+++ b/crate/crypto/src/crypto/cover_crypt/user_key.rs
@@ -1,4 +1,4 @@
-use cosmian_cover_crypt::{api::Covercrypt, AccessPolicy, MasterSecretKey, UserSecretKey};
+use cosmian_cover_crypt::{AccessPolicy, MasterSecretKey, UserSecretKey, api::Covercrypt};
 use cosmian_crypto_core::bytes_ser_de::Serializable;
 use cosmian_kmip::kmip_2_1::{
     kmip_data_structures::{KeyBlock, KeyMaterial, KeyValue},
@@ -115,7 +115,7 @@ impl<'a> UserDecryptionKeysHandler<'a> {
     }
 
     /// Refresh the user decryption key according to the (new) policy of the master key
-    pub fn refresh_user_decryption_key_object(
+    pub fn refresh_usk_object(
         &mut self,
         user_decryption_key: &Object,
         keep_old_rights: bool,

--- a/crate/crypto/src/crypto/cover_crypt/user_key.rs
+++ b/crate/crypto/src/crypto/cover_crypt/user_key.rs
@@ -1,4 +1,4 @@
-use cosmian_cover_crypt::{AccessPolicy, MasterSecretKey, UserSecretKey, api::Covercrypt};
+use cosmian_cover_crypt::{api::Covercrypt, AccessPolicy, MasterSecretKey, UserSecretKey};
 use cosmian_crypto_core::bytes_ser_de::Serializable;
 use cosmian_kmip::kmip_2_1::{
     kmip_data_structures::{KeyBlock, KeyMaterial, KeyValue},

--- a/crate/crypto/src/crypto/symmetric/rfc5649.rs
+++ b/crate/crypto/src/crypto/symmetric/rfc5649.rs
@@ -12,10 +12,10 @@
 //! Google provides a patch : <https://cloud.google.com/kms/docs/configuring-openssl-for-manual-key-wrapping>
 //! and so does AWS: <https://repost.aws/en/knowledge-center/patch-openssl-cloudhsm>
 
-use openssl::symm::{Cipher, Crypter, Mode, encrypt};
+use openssl::symm::{encrypt, Cipher, Crypter, Mode};
 use zeroize::Zeroizing;
 
-use crate::error::{CryptoError, result::CryptoResult};
+use crate::error::{result::CryptoResult, CryptoError};
 
 const DEFAULT_RFC5649_CONST: u32 = 0xA659_59A6_u32;
 const DEFAULT_IV: u64 = 0xA6A6_A6A6_A6A6_A6A6;

--- a/crate/crypto/src/crypto/symmetric/rfc5649.rs
+++ b/crate/crypto/src/crypto/symmetric/rfc5649.rs
@@ -12,10 +12,10 @@
 //! Google provides a patch : <https://cloud.google.com/kms/docs/configuring-openssl-for-manual-key-wrapping>
 //! and so does AWS: <https://repost.aws/en/knowledge-center/patch-openssl-cloudhsm>
 
-use openssl::symm::{encrypt, Cipher, Crypter, Mode};
+use openssl::symm::{Cipher, Crypter, Mode, encrypt};
 use zeroize::Zeroizing;
 
-use crate::error::{result::CryptoResult, CryptoError};
+use crate::error::{CryptoError, result::CryptoResult};
 
 const DEFAULT_RFC5649_CONST: u32 = 0xA659_59A6_u32;
 const DEFAULT_IV: u64 = 0xA6A6_A6A6_A6A6_A6A6;
@@ -26,7 +26,7 @@ const AES_BLOCK_SIZE: usize = 0x10;
 ///
 /// `wrapped_key_size` is the size of the key to wrap.
 fn build_iv(wrapped_key_size: usize) -> CryptoResult<u64> {
-    Ok(u64::from(DEFAULT_RFC5649_CONST) << 32 | u64::try_from(wrapped_key_size)?.to_le())
+    Ok((u64::from(DEFAULT_RFC5649_CONST) << 32) | u64::try_from(wrapped_key_size)?.to_le())
 }
 
 /// Check if the `iv` value obtained after decryption is appropriate according
@@ -88,7 +88,7 @@ pub fn rfc5649_wrap(plain: &[u8], kek: &[u8]) -> Result<Vec<u8>, CryptoError> {
 
         Ok(ciphertext[..AES_BLOCK_SIZE].to_vec())
     } else {
-        _wrap_64(&padded_plain, kek, Some(build_iv(n)?))
+        wrap_64(&padded_plain, kek, Some(build_iv(n)?))
     }
 }
 
@@ -107,7 +107,7 @@ pub fn rfc5649_unwrap(ciphertext: &[u8], kek: &[u8]) -> Result<Zeroizing<Vec<u8>
     }
 
     if n > 16 {
-        let (iv, padded_plain) = _unwrap_64(ciphertext, kek)?;
+        let (iv, padded_plain) = unwrap_64(ciphertext, kek)?;
 
         // Verify integrity check register as described in RFC 5649.
         if !check_iv(iv, &padded_plain)? {
@@ -165,7 +165,7 @@ pub fn rfc5649_unwrap(ciphertext: &[u8], kek: &[u8]) -> Result<Zeroizing<Vec<u8>
 ///
 /// The function name matches the one used in the RFC and has no link to the
 /// unwrap function in Rust.
-fn _wrap_64(plain: &[u8], kek: &[u8], iv: Option<u64>) -> Result<Vec<u8>, CryptoError> {
+fn wrap_64(plain: &[u8], kek: &[u8], iv: Option<u64>) -> Result<Vec<u8>, CryptoError> {
     let n = plain.len();
 
     if n % AES_WRAP_PAD_BLOCK_SIZE != 0 {
@@ -198,7 +198,7 @@ fn _wrap_64(plain: &[u8], kek: &[u8], iv: Option<u64>) -> Result<Vec<u8>, Crypto
     for j in 0..6 {
         for (i, block) in blocks.iter_mut().enumerate().take(n) {
             // B = AES(K, A | R[i])
-            let plaintext_block = (u128::from(icr) << 64 | u128::from(*block)).to_be_bytes();
+            let plaintext_block = ((u128::from(icr) << 64) | u128::from(*block)).to_be_bytes();
 
             /*
              * Encrypt block using AES with ECB mode i.e. raw AES as specified in
@@ -223,7 +223,7 @@ fn _wrap_64(plain: &[u8], kek: &[u8], iv: Option<u64>) -> Result<Vec<u8>, Crypto
     Ok(wrapped_key)
 }
 
-fn _unwrap_64(ciphertext: &[u8], kek: &[u8]) -> Result<(u64, Zeroizing<Vec<u8>>), CryptoError> {
+fn unwrap_64(ciphertext: &[u8], kek: &[u8]) -> Result<(u64, Zeroizing<Vec<u8>>), CryptoError> {
     let n = ciphertext.len();
 
     if n % AES_WRAP_PAD_BLOCK_SIZE != 0 || n < AES_BLOCK_SIZE {
@@ -266,7 +266,7 @@ fn _unwrap_64(ciphertext: &[u8], kek: &[u8]) -> Result<(u64, Zeroizing<Vec<u8>>)
             let t = u64::try_from((n * j) + (n - i))?;
 
             // B = AES-1(K, (A ^ t) | R[i]) where t = n*j+i
-            let big_i = (u128::from(icr ^ t) << 64 | u128::from(*block)).to_be_bytes();
+            let big_i = ((u128::from(icr ^ t) << 64) | u128::from(*block)).to_be_bytes();
             let big_b = big_i.as_slice();
 
             let mut plaintext = Zeroizing::from(vec![0; big_b.len() + AES_BLOCK_SIZE]);

--- a/crate/crypto/src/lib.rs
+++ b/crate/crypto/src/lib.rs
@@ -52,8 +52,6 @@
 )]
 // required to detect generic type in Serializer
 #![feature(min_specialization)]
-// To parse a slice
-#![feature(slice_take)]
 
 pub use error::{result::CryptoResultHelper, CryptoError};
 

--- a/crate/crypto/src/lib.rs
+++ b/crate/crypto/src/lib.rs
@@ -54,7 +54,7 @@
 // required to detect generic type in Serializer
 #![feature(min_specialization)]
 
-pub use error::{CryptoError, result::CryptoResultHelper};
+pub use error::{result::CryptoResultHelper, CryptoError};
 
 pub mod crypto;
 mod error;

--- a/crate/crypto/src/lib.rs
+++ b/crate/crypto/src/lib.rs
@@ -40,6 +40,7 @@
     // clippy::use_debug,
 )]
 #![allow(
+    clippy::too_long_first_doc_paragraph,
     clippy::module_name_repetitions,
     clippy::similar_names,
     clippy::too_many_lines,
@@ -53,7 +54,7 @@
 // required to detect generic type in Serializer
 #![feature(min_specialization)]
 
-pub use error::{result::CryptoResultHelper, CryptoError};
+pub use error::{CryptoError, result::CryptoResultHelper};
 
 pub mod crypto;
 mod error;

--- a/crate/kmip/src/data_to_encrypt.rs
+++ b/crate/kmip/src/data_to_encrypt.rs
@@ -2,25 +2,20 @@ use crate::{error::KmipError, kmip_2_1::kmip_operations::ErrorReason, Deserializ
 
 /// Structure used to encrypt with Covercrypt or ECIES
 ///
-/// To encrypt some data with Covercrypt we need to
-/// pass an access policy. The KMIP format do not provide
-/// us a way to send this access policy with the plaintext
-/// data to encrypt (in a vendor attribute for example).
-/// We need to prepend the encoded access policy to the plaintext
-/// bytes and decode them in the KMS code before encrypting with
-/// Covercrypt. This struct is not useful (and shouldn't be use)
-/// if the user ask to encrypt with something else than Cover Crypt
-/// (for example an AES encrypt.) See also `DecryptedData` struct.
-/// The binary format of this struct is:
-/// 1. LEB128 unsigned length of encryption policy string in UTF8 encoded bytes
-/// 2. encryption policy string in UTF8 encoded bytes
-/// 3. LEB128 unsigned length of additional metadata
-/// 4. additional metadata encrypted in the header by the DEM
-/// 5. plaintext data to encrypt
+/// To encrypt some data with Covercrypt we need to pass an access policy. The
+/// KMIP format do not provide us a way to send this access policy with the
+/// plaintext data to encrypt (in a vendor attribute for example).  We need to
+/// prepend the encoded access policy to the plaintext bytes and decode them in
+/// the KMS code before encrypting with Covercrypt. This struct is not useful
+/// (and shouldn't be use) if the user ask to encrypt with something else than
+/// Cover Crypt (for example an AES encrypt.) See also `DecryptedData` struct.
+/// The binary format of this struct is: 1. LEB128 unsigned length of encryption
+/// policy string in UTF8 encoded bytes 2. encryption policy string in UTF8
+/// encoded bytes 3. LEB128 unsigned length of additional metadata 4. additional
+/// metadata encrypted in the header by the DEM 5. plaintext data to encrypt
 #[derive(Debug, PartialEq, Eq, Default)]
 pub struct DataToEncrypt {
     pub encryption_policy: Option<String>,
-    pub header_metadata: Option<Vec<u8>>,
     pub plaintext: Vec<u8>,
 }
 
@@ -34,20 +29,11 @@ impl DataToEncrypt {
         if let Some(encryption_policy) = &self.encryption_policy {
             mem_size += encryption_policy.len();
         }
-        if let Some(metadata) = &self.header_metadata {
-            mem_size += metadata.len();
-        }
 
         // Write the encryption policy
         let mut se = Serializer::with_capacity(mem_size);
         if let Some(encryption_policy) = &self.encryption_policy {
             se.write_vec(encryption_policy.as_bytes())?;
-        } else {
-            se.write_leb128_u64(0)?;
-        }
-        // Write the metadata
-        if let Some(metadata) = &self.header_metadata {
-            se.write_vec(metadata)?;
         } else {
             se.write_leb128_u64(0)?;
         }
@@ -74,17 +60,11 @@ impl DataToEncrypt {
             })
             .transpose()?;
 
-        // Read the metadata
-        let metadata = de
-            .read_vec()
-            .map(|metadata| (!metadata.is_empty()).then_some(metadata))?;
-
         // Remaining is the plaintext to encrypt
         let plaintext = de.finalize();
 
         Ok(Self {
             encryption_policy,
-            header_metadata: metadata,
             plaintext,
         })
     }
@@ -101,7 +81,6 @@ mod tests {
         {
             let data_to_encrypt = DataToEncrypt {
                 encryption_policy: Some("a && b".to_owned()),
-                header_metadata: Some(String::from("äbcdef").into_bytes()),
                 plaintext: String::from("this is a plain text à è ").into_bytes(),
             };
             let bytes = data_to_encrypt.to_bytes().unwrap();
@@ -112,7 +91,6 @@ mod tests {
         {
             let data_to_encrypt = DataToEncrypt {
                 encryption_policy: Some("a && b".to_owned()),
-                header_metadata: None,
                 plaintext: String::from("this is a plain text à è ").into_bytes(),
             };
             let bytes = data_to_encrypt.to_bytes().unwrap();
@@ -123,7 +101,6 @@ mod tests {
         {
             let data_to_encrypt = DataToEncrypt {
                 encryption_policy: None,
-                header_metadata: Some(String::from("äbcdef").into_bytes()),
                 plaintext: String::from("this is a plain text à è ").into_bytes(),
             };
             let bytes = data_to_encrypt.to_bytes().unwrap();
@@ -134,7 +111,6 @@ mod tests {
         {
             let data_to_encrypt = DataToEncrypt {
                 encryption_policy: None,
-                header_metadata: None,
                 plaintext: String::from("this is a plain text à è ").into_bytes(),
             };
             let bytes = data_to_encrypt.to_bytes().unwrap();

--- a/crate/kmip/src/kmip_2_1/kmip_data_structures.rs
+++ b/crate/kmip/src/kmip_2_1/kmip_data_structures.rs
@@ -5,14 +5,15 @@ use std::{
 
 use num_bigint_dig::BigUint;
 use serde::{
+    Deserialize, Serialize,
     de::{self, MapAccess, Visitor},
     ser::SerializeStruct,
-    Deserialize, Serialize,
 };
 use zeroize::Zeroizing;
 
 use super::kmip_types::{LinkType, LinkedObjectIdentifier};
 use crate::{
+    SafeBigUint,
     error::KmipError,
     kmip_2_1::{
         kmip_operations::ErrorReason,
@@ -22,7 +23,7 @@ use crate::{
             WrappingMethod,
         },
     },
-    pad_be_bytes, SafeBigUint,
+    pad_be_bytes,
 };
 
 /// A Key Block object is a structure used to encapsulate all of the information
@@ -227,6 +228,9 @@ impl Display for KeyValue {
     }
 }
 
+// This is required since its signature must match what serde
+// skip_serializing_if is expecting.
+#[allow(clippy::ref_option)]
 // Attributes is default is a fix for https://github.com/Cosmian/kms/issues/92
 fn attributes_is_default_or_none<T: Default + PartialEq + Serialize>(val: &Option<T>) -> bool {
     val.as_ref().map_or(true, |v| *v == T::default())

--- a/crate/kmip/src/kmip_2_1/kmip_data_structures.rs
+++ b/crate/kmip/src/kmip_2_1/kmip_data_structures.rs
@@ -5,15 +5,14 @@ use std::{
 
 use num_bigint_dig::BigUint;
 use serde::{
-    Deserialize, Serialize,
     de::{self, MapAccess, Visitor},
     ser::SerializeStruct,
+    Deserialize, Serialize,
 };
 use zeroize::Zeroizing;
 
 use super::kmip_types::{LinkType, LinkedObjectIdentifier};
 use crate::{
-    SafeBigUint,
     error::KmipError,
     kmip_2_1::{
         kmip_operations::ErrorReason,
@@ -23,7 +22,7 @@ use crate::{
             WrappingMethod,
         },
     },
-    pad_be_bytes,
+    pad_be_bytes, SafeBigUint,
 };
 
 /// A Key Block object is a structure used to encapsulate all of the information

--- a/crate/kmip/src/kmip_2_1/kmip_objects.rs
+++ b/crate/kmip/src/kmip_2_1/kmip_objects.rs
@@ -241,6 +241,11 @@ impl Object {
     }
 
     /// Returns the `Attributes` of that object if any, an error otherwise
+    pub fn into_attributes(&self) -> Result<&Attributes, KmipError> {
+        self.key_block()?.attributes()
+    }
+
+    /// Returns the `Attributes` of that object if any, an error otherwise
     pub fn attributes(&self) -> Result<&Attributes, KmipError> {
         self.key_block()?.attributes()
     }

--- a/crate/kmip/src/kmip_2_1/kmip_operations.rs
+++ b/crate/kmip/src/kmip_2_1/kmip_operations.rs
@@ -20,7 +20,6 @@ use super::{
         UniqueIdentifier, ValidityIndicator,
     },
 };
-use crate::{error::KmipError, Deserializer, Serializer};
 
 #[allow(non_camel_case_types)]
 #[derive(Serialize, Deserialize, Copy, Clone, Display, Debug, Eq, PartialEq, Default)]
@@ -1436,55 +1435,6 @@ impl Display for Decrypt {
             self.authenticated_encryption_additional_data,
             self.authenticated_encryption_tag
         )
-    }
-}
-
-/// When decrypting data with Cover Crypt we can have some
-/// additional metadata stored inside the header and encrypted
-/// with de DEM. We need to return these data to the user but
-/// the KMIP protocol do not provide a way to do it. So we prepend
-/// the decrypted bytes with the decrypted additional metadata.
-/// This struct is not useful (and shouldn't be use) if the user
-/// ask to encrypt with something else than Cover Crypt (for example an AES encrypt.)
-/// See also `DataToEncrypt` struct.
-/// The binary format of this struct is:
-/// 1. LEB128 unsigned length of the metadata
-/// 2. metadata decrypted bytes
-/// 3. data decrypted
-pub struct DecryptedData {
-    pub metadata: Vec<u8>,
-    pub plaintext: Zeroizing<Vec<u8>>,
-}
-
-impl TryInto<Vec<u8>> for DecryptedData {
-    type Error = KmipError;
-
-    fn try_into(self) -> Result<Vec<u8>, Self::Error> {
-        let mut ser = Serializer::new();
-        ser.write_vec(&self.metadata)?;
-
-        let mut result = ser.finalize().to_vec();
-        result.extend_from_slice(&self.plaintext);
-        Ok(result)
-    }
-}
-
-impl TryFrom<&[u8]> for DecryptedData {
-    type Error = KmipError;
-
-    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
-        let mut de = Deserializer::new(bytes);
-
-        // Read the metadata
-        let metadata = de.read_vec()?;
-
-        // Remaining is the decrypted plaintext
-        let plaintext = Zeroizing::from(de.finalize());
-
-        Ok(Self {
-            metadata,
-            plaintext,
-        })
     }
 }
 

--- a/crate/kmip/src/kmip_2_1/mod.rs
+++ b/crate/kmip/src/kmip_2_1/mod.rs
@@ -78,7 +78,7 @@ impl FromStr for KmipOperation {
             "locate" => Ok(Self::Locate),
             "rekey" => Ok(Self::Rekey),
             "revoke" => Ok(Self::Revoke),
-            _ => Err("Could not parse an operation {op}"),
+            _ => Err("Could not parse an operation"),
         }
     }
 }

--- a/crate/kmip/src/kmip_2_1/requests/encrypt.rs
+++ b/crate/kmip/src/kmip_2_1/requests/encrypt.rs
@@ -8,7 +8,7 @@ use crate::{
     DataToEncrypt, KmipError,
 };
 
-/// Build an Encryption Request to encrypt the provided `plaintext`
+/// Build an Encryption Request to encrypt the provided `plaintext`.
 /// The cryptographic scheme is determined by that of the key identified by `key_unique_identifier`
 /// For Covercrypt,
 ///     - the `encryption_policy` must be provided
@@ -20,28 +20,26 @@ pub fn encrypt_request(
     key_unique_identifier: &str,
     encryption_policy: Option<String>,
     plaintext: Vec<u8>,
-    header_metadata: Option<Vec<u8>>,
     nonce: Option<Vec<u8>>,
     authenticated_encryption_additional_data: Option<Vec<u8>>,
     cryptographic_parameters: Option<CryptographicParameters>,
 ) -> Result<Encrypt, KmipError> {
-    let data_to_encrypt = Zeroizing::from(if encryption_policy.is_some() {
+    let data_to_encrypt = if encryption_policy.is_some() {
         DataToEncrypt {
             encryption_policy,
-            header_metadata,
             plaintext,
         }
         .to_bytes()?
     } else {
         plaintext
-    });
+    };
 
     Ok(Encrypt {
         unique_identifier: Some(UniqueIdentifier::TextString(
             key_unique_identifier.to_owned(),
         )),
         cryptographic_parameters,
-        data: Some(data_to_encrypt),
+        data: Some(Zeroizing::from(data_to_encrypt)),
         iv_counter_nonce: nonce,
         correlation_value: None,
         init_indicator: None,

--- a/crate/kmip/src/kmip_2_1/ttlv/mod.rs
+++ b/crate/kmip/src/kmip_2_1/ttlv/mod.rs
@@ -17,11 +17,11 @@ use core::fmt;
 
 use num_bigint_dig::BigUint;
 use serde::{
-    Deserialize, Serialize,
     de::{self, MapAccess, Visitor},
     ser::{self, SerializeStruct, Serializer},
+    Deserialize, Serialize,
 };
-use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 use crate::error::result::KmipResult;
 

--- a/crate/kmip/src/kmip_2_1/ttlv/mod.rs
+++ b/crate/kmip/src/kmip_2_1/ttlv/mod.rs
@@ -17,11 +17,11 @@ use core::fmt;
 
 use num_bigint_dig::BigUint;
 use serde::{
+    Deserialize, Serialize,
     de::{self, MapAccess, Visitor},
     ser::{self, SerializeStruct, Serializer},
-    Deserialize, Serialize,
 };
-use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 use crate::error::result::KmipResult;
 
@@ -156,7 +156,7 @@ impl Serialize for TTLV {
     where
         S: Serializer,
     {
-        fn _serialize<S, T>(
+        fn serialize<S, T>(
             serializer: S,
             tag: &str,
             typ: &str,
@@ -174,15 +174,15 @@ impl Serialize for TTLV {
         }
 
         match &self.value {
-            TTLValue::Structure(v) => _serialize(serializer, &self.tag, "Structure", v),
-            TTLValue::Integer(v) => _serialize(serializer, &self.tag, "Integer", v),
-            TTLValue::BitMask(v) => _serialize(
+            TTLValue::Structure(v) => serialize(serializer, &self.tag, "Structure", v),
+            TTLValue::Integer(v) => serialize(serializer, &self.tag, "Integer", v),
+            TTLValue::BitMask(v) => serialize(
                 serializer,
                 &self.tag,
                 "Integer",
                 &("0x".to_owned() + &hex::encode_upper(v.to_be_bytes())),
             ),
-            TTLValue::LongInteger(v) => _serialize(
+            TTLValue::LongInteger(v) => serialize(
                 serializer,
                 &self.tag,
                 "LongInteger",
@@ -192,20 +192,20 @@ impl Serialize for TTLV {
                 //TODO Note that Big Integers must be sign extended to
                 //TODO  contain a multiple of 8 bytes, and as per LongInteger, JS numbers only
                 // support a limited range of values.
-                _serialize(
+                serialize(
                     serializer,
                     &self.tag,
                     "BigInteger",
                     &("0x".to_owned() + &hex::encode_upper(v.to_bytes_be())),
                 )
             }
-            TTLValue::Enumeration(v) => _serialize(serializer, &self.tag, "Enumeration", v),
-            TTLValue::Boolean(v) => _serialize(serializer, &self.tag, "Boolean", v),
-            TTLValue::TextString(v) => _serialize(serializer, &self.tag, "TextString", v),
+            TTLValue::Enumeration(v) => serialize(serializer, &self.tag, "Enumeration", v),
+            TTLValue::Boolean(v) => serialize(serializer, &self.tag, "Boolean", v),
+            TTLValue::TextString(v) => serialize(serializer, &self.tag, "TextString", v),
             TTLValue::ByteString(v) => {
-                _serialize(serializer, &self.tag, "ByteString", &hex::encode_upper(v))
+                serialize(serializer, &self.tag, "ByteString", &hex::encode_upper(v))
             }
-            TTLValue::DateTime(v) => _serialize(
+            TTLValue::DateTime(v) => serialize(
                 serializer,
                 &self.tag,
                 "DateTime",
@@ -213,8 +213,8 @@ impl Serialize for TTLV {
                     ser::Error::custom(format!("Cannot format DateTime {v} into RFC3339: {err}"))
                 })?,
             ),
-            TTLValue::Interval(v) => _serialize(serializer, &self.tag, "Interval", v),
-            TTLValue::DateTimeExtended(v) => _serialize(
+            TTLValue::Interval(v) => serialize(serializer, &self.tag, "Interval", v),
+            TTLValue::DateTimeExtended(v) => serialize(
                 serializer,
                 &self.tag,
                 "DateTimeExtended",

--- a/crate/kmip/src/lib.rs
+++ b/crate/kmip/src/lib.rs
@@ -40,6 +40,7 @@
     // clippy::use_debug,
 )]
 #![allow(
+    clippy::too_long_first_doc_paragraph,
     clippy::module_name_repetitions,
     clippy::similar_names,
     clippy::too_many_lines,
@@ -53,10 +54,10 @@
 // required to detect generic type in Serializer
 #![feature(min_specialization)]
 
-pub use error::{result::KmipResultHelper, KmipError};
+pub use error::{KmipError, result::KmipResultHelper};
 
 mod bytes_ser_de;
-pub use bytes_ser_de::{test_serialization, to_leb128_len, Deserializer, Serializer};
+pub use bytes_ser_de::{Deserializer, Serializer, test_serialization, to_leb128_len};
 mod data_to_encrypt;
 pub use data_to_encrypt::DataToEncrypt;
 mod error;

--- a/crate/kmip/src/lib.rs
+++ b/crate/kmip/src/lib.rs
@@ -54,10 +54,10 @@
 // required to detect generic type in Serializer
 #![feature(min_specialization)]
 
-pub use error::{KmipError, result::KmipResultHelper};
+pub use error::{result::KmipResultHelper, KmipError};
 
 mod bytes_ser_de;
-pub use bytes_ser_de::{Deserializer, Serializer, test_serialization, to_leb128_len};
+pub use bytes_ser_de::{test_serialization, to_leb128_len, Deserializer, Serializer};
 mod data_to_encrypt;
 pub use data_to_encrypt::DataToEncrypt;
 mod error;

--- a/crate/kmip/src/lib.rs
+++ b/crate/kmip/src/lib.rs
@@ -52,8 +52,6 @@
 )]
 // required to detect generic type in Serializer
 #![feature(min_specialization)]
-// To parse a slice
-#![feature(slice_take)]
 
 pub use error::{result::KmipResultHelper, KmipError};
 

--- a/crate/server/src/config/command_line/jwt_auth_config.rs
+++ b/crate/server/src/config/command_line/jwt_auth_config.rs
@@ -50,11 +50,13 @@ pub struct JwtAuthConfig {
 impl JwtAuthConfig {
     /// Build a JWKS URI using `jwt_issuer_uri` and an optional `jwks_uri`.
     pub(crate) fn uri(jwt_issuer_uri: &str, jwks_uri: Option<&str>) -> String {
-        jwks_uri.as_ref().map_or(
-            format!(
-                "{}/.well-known/jwks.json",
-                jwt_issuer_uri.trim_end_matches('/')
-            ),
+        jwks_uri.as_ref().map_or_else(
+            || {
+                format!(
+                    "{}/.well-known/jwks.json",
+                    jwt_issuer_uri.trim_end_matches('/')
+                )
+            },
             std::string::ToString::to_string,
         )
     }

--- a/crate/server/src/core/cover_crypt/create_user_decryption_key.rs
+++ b/crate/server/src/core/cover_crypt/create_user_decryption_key.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use cosmian_cover_crypt::{MasterSecretKey, api::Covercrypt};
+use cosmian_cover_crypt::{api::Covercrypt, MasterSecretKey};
 use cosmian_crypto_core::bytes_ser_de::Serializable;
 use cosmian_kmip::kmip_2_1::{
     kmip_objects::{Object, ObjectType},

--- a/crate/server/src/core/cover_crypt/create_user_decryption_key.rs
+++ b/crate/server/src/core/cover_crypt/create_user_decryption_key.rs
@@ -8,8 +8,7 @@ use cosmian_kmip::kmip_2_1::{
     kmip_types::{Attributes, KeyFormatType, StateEnumeration, UniqueIdentifier},
 };
 use cosmian_kms_crypto::crypto::cover_crypt::{
-    attributes::{access_policy_from_attributes, access_structure_from_attributes},
-    master_keys::create_msk_object,
+    attributes::access_policy_from_attributes, master_keys::create_msk_object,
     user_key::UserDecryptionKeysHandler,
 };
 use cosmian_kms_interfaces::{ObjectWithMetadata, SessionParams};
@@ -60,11 +59,6 @@ pub(crate) async fn create_user_decryption_key(
 
         // The master key should be a CoverCrypt secret key
         if attributes.key_format_type != Some(KeyFormatType::CoverCryptSecretKey) {
-            continue;
-        }
-
-        // a master key should have policies in the attributes
-        if access_structure_from_attributes(attributes).is_err() {
             continue;
         }
 

--- a/crate/server/src/core/cover_crypt/create_user_decryption_key.rs
+++ b/crate/server/src/core/cover_crypt/create_user_decryption_key.rs
@@ -1,29 +1,26 @@
 use std::sync::Arc;
 
-use cosmian_cover_crypt::api::Covercrypt;
+use cosmian_cover_crypt::{MasterSecretKey, api::Covercrypt};
 use cosmian_crypto_core::bytes_ser_de::Serializable;
 use cosmian_kmip::kmip_2_1::{
     kmip_objects::{Object, ObjectType},
-    kmip_operations::{Create, CreateKeyPair, Get, Import},
+    kmip_operations::{Create, Import},
     kmip_types::{Attributes, KeyFormatType, StateEnumeration, UniqueIdentifier},
 };
-use cosmian_kms_crypto::crypto::{
-    cover_crypt::{
-        attributes::{access_policy_from_attributes, access_structure_from_attributes},
-        master_keys::create_master_secret_key_object,
-        user_key::UserDecryptionKeysHandler,
-    },
-    KeyPair,
+use cosmian_kms_crypto::crypto::cover_crypt::{
+    attributes::{access_policy_from_attributes, access_structure_from_attributes},
+    master_keys::create_msk_object,
+    user_key::UserDecryptionKeysHandler,
 };
-use cosmian_kms_interfaces::SessionParams;
+use cosmian_kms_interfaces::{ObjectWithMetadata, SessionParams};
 use tracing::{debug, trace};
 
 use super::KMS;
 use crate::{error::KmsError, kms_bail, result::KResult};
-/// Create a User Decryption Key in the KMS
+
+/// Create a User Decryption Key in the KMS.
 ///
-/// The attributes of the `Create` request must contain the
-/// `Access Policy`
+/// The attributes of the `Create` request must contain the `Access Policy`.
 pub(crate) async fn create_user_decryption_key(
     kmip_server: &KMS,
     cover_crypt: Covercrypt,
@@ -32,42 +29,17 @@ pub(crate) async fn create_user_decryption_key(
     params: Option<Arc<dyn SessionParams>>,
     sensitive: bool,
 ) -> KResult<Object> {
-    create_user_decryption_key_(
-        kmip_server,
-        cover_crypt,
-        &create_request.attributes,
-        owner,
-        params,
-        sensitive,
-    )
-    .await
-}
-
-async fn create_user_decryption_key_(
-    kms: &KMS,
-    cover_crypt: Covercrypt,
-    create_attributes: &Attributes,
-    user: &str,
-    params: Option<Arc<dyn SessionParams>>,
-    sensitive: bool,
-) -> KResult<Object> {
-    // Recover the access policy
-    let access_policy = access_policy_from_attributes(create_attributes)?;
-    debug!("create_user_decryption_key_: Access Policy: {access_policy}");
-
-    // Recover private key
-    let msk_uid_or_tags = create_attributes
+    let msk_uid_or_tags = create_request
+        .attributes
         .get_parent_id()
         .ok_or_else(|| {
             KmsError::InvalidRequest(
-                "there should be a reference to the master secret key in the creation attributes"
-                    .to_owned(),
+                "there should be a reference to the MSK in the creation attributes".to_owned(),
             )
         })?
         .to_string();
 
-    // retrieve from tags or use passed identifier
-    for owm in kms
+    for owm in kmip_server
         .database
         .retrieve_objects(&msk_uid_or_tags, params.clone())
         .await?
@@ -96,56 +68,32 @@ async fn create_user_decryption_key_(
             continue;
         }
 
-        let master_secret_key = owm.object();
-        if master_secret_key.key_wrapping_data().is_some() {
-            kms_bail!(KmsError::InconsistentOperation(
-                "The server can't create a decryption key: the master secret key is wrapped"
-                    .to_owned()
-            ));
-        }
+        let access_policy = access_policy_from_attributes(&create_request.attributes)?;
+        debug!("create_user_decryption_key_: Access Policy: {access_policy}");
 
-        let mut usk_handler =
-            UserDecryptionKeysHandler::instantiate(cover_crypt, master_secret_key)?;
-        let usk: Object = usk_handler
-            .create_user_decryption_key_object(&access_policy, Some(create_attributes), owm.id())
-            .map_err(KmsError::from)?;
-
-        // Update the master secret key
-        let updated_master_secret_key_bytes = usk_handler.master_secret_key.serialize()?;
-        trace!(
-            "create_user_decryption_key_: updated_master_secret_key_bytes len: {}",
-            updated_master_secret_key_bytes.len()
-        );
-        let msk_attributes = master_secret_key.attributes()?;
-        let public_key_link =
-            msk_attributes.get_link(cosmian_kmip::kmip_2_1::kmip_types::LinkType::PublicKeyLink);
-        let Some(mpk_link) = public_key_link else {
-            kms_bail!(KmsError::InconsistentOperation(
-                "The server can't create a decryption key: the master secret key has no public \
-                 key link"
-                    .to_owned()
-            ))
-        };
-
-        let new_msk_object = create_master_secret_key_object(
-            &updated_master_secret_key_bytes,
-            Some(msk_attributes),
-            &mpk_link.to_string(),
-            &usk_handler.master_secret_key.access_structure,
+        let (msk_obj, usk_obj) = create_user_decryption_key_(
+            &owm,
+            &cover_crypt,
+            &access_policy,
+            &create_request.attributes,
             sensitive,
-        )?;
+        )
+        .await?;
 
         let import_request = Import {
-            unique_identifier: UniqueIdentifier::TextString(msk_uid_or_tags),
+            unique_identifier: UniqueIdentifier::TextString(owm.id().to_string()),
             object_type: ObjectType::PrivateKey,
             replace_existing: Some(true),
             key_wrap_type: None,
-            attributes: msk_attributes.clone(),
-            object: new_msk_object,
+            attributes: owm.attributes().clone(),
+            object: msk_obj,
         };
-        let _msk_uid = kms.import(import_request, user, params.clone()).await?;
 
-        return Ok(usk);
+        kmip_server
+            .import(import_request, owner, params.clone())
+            .await?;
+
+        return Ok(usk_obj);
     }
 
     Err(KmsError::InvalidRequest(format!(
@@ -153,60 +101,50 @@ async fn create_user_decryption_key_(
     )))
 }
 
-#[allow(unused)]
-//TODO: there is noway to distinguish between the creation of a user decryption key pair and a master key pair
-/// Create a KMIP tuple (`Object::PrivateKey`, `Object::PublicKey`)
-pub(crate) async fn create_user_decryption_key_pair(
-    kmip_server: &KMS,
-    cover_crypt: Covercrypt,
-    create_key_pair_request: &CreateKeyPair,
-    owner: &str,
-    params: Option<Arc<dyn SessionParams>>,
+async fn create_user_decryption_key_(
+    owm: &ObjectWithMetadata,
+    cover_crypt: &Covercrypt,
+    access_policy: &String,
+    create_attributes: &Attributes,
     sensitive: bool,
-) -> KResult<KeyPair> {
-    // create user decryption key
-    let private_key_attributes = create_key_pair_request
-        .private_key_attributes
-        .as_ref()
-        .or(create_key_pair_request.common_attributes.as_ref())
+) -> KResult<(Object, Object)> {
+    if owm.object().key_wrapping_data().is_some() {
+        kms_bail!(KmsError::InconsistentOperation(
+            "The server can't create a decryption key: the master secret key is wrapped".to_owned()
+        ));
+    }
+
+    let mut msk = MasterSecretKey::deserialize(&**owm.object().key_block()?.key_bytes()?)?;
+    let mut usk_handler = UserDecryptionKeysHandler::instantiate(&cover_crypt, &mut msk);
+
+    let usk_obj = usk_handler
+        .create_usk_object(access_policy, Some(create_attributes), owm.id())
+        .map_err(KmsError::from)?;
+
+    let msk_bytes = msk.serialize()?;
+
+    trace!(
+        "create_user_decryption_key_: updated_master_secret_key_bytes len: {}",
+        msk_bytes.len()
+    );
+
+    let msk_attributes = owm.object().attributes()?;
+    let mpk_link = msk_attributes
+        .get_link(cosmian_kmip::kmip_2_1::kmip_types::LinkType::PublicKeyLink)
         .ok_or_else(|| {
-            KmsError::InvalidRequest(
-                "Missing private attributes in CoverCrypt Create Keypair request".to_owned(),
+            KmsError::InconsistentOperation(
+                "The server can't create a decryption key: the master secret key has no public \
+                 key link"
+                    .to_owned(),
             )
         })?;
-    let private_key = create_user_decryption_key_(
-        kmip_server,
-        cover_crypt,
-        private_key_attributes,
-        owner,
-        params.clone(),
+
+    let msk_obj = create_msk_object(
+        msk_bytes,
+        msk_attributes.clone(),
+        &mpk_link.to_string(),
         sensitive,
-    )
-    .await?;
+    )?;
 
-    //Recover Public Key
-    let public_key_attributes = create_key_pair_request
-        .public_key_attributes
-        .as_ref()
-        .or(create_key_pair_request.common_attributes.as_ref())
-        .ok_or_else(|| {
-            KmsError::InvalidRequest(
-                "Missing public attributes in CoverCrypt Create Keypair request".to_owned(),
-            )
-        })?;
-    let master_public_key_uid = public_key_attributes.get_parent_id().ok_or_else(|| {
-        KmsError::InvalidRequest(
-            "the master public key id should be available in the public creation attributes"
-                .to_owned(),
-        )
-    })?;
-    let gr_public_key = kmip_server
-        .get(
-            Get::from(UniqueIdentifier::from(master_public_key_uid)),
-            owner,
-            params,
-        )
-        .await?;
-
-    Ok(KeyPair((private_key, gr_public_key.object)))
+    return Ok((msk_obj, usk_obj));
 }

--- a/crate/server/src/core/cover_crypt/destroy_user_decryption_keys.rs
+++ b/crate/server/src/core/cover_crypt/destroy_user_decryption_keys.rs
@@ -3,15 +3,15 @@ use std::{collections::HashSet, sync::Arc};
 use cosmian_kmip::kmip_2_1::kmip_types::UniqueIdentifier;
 use cosmian_kms_interfaces::SessionParams;
 
-use super::locate_user_decryption_keys;
+use super::locate_usk;
 use crate::{
-    core::{operations::recursively_destroy_object, KMS},
+    core::{KMS, operations::recursively_destroy_object},
     result::KResult,
 };
 
 /// Revoke all the user decryption keys associated with the master secret key
 pub(crate) async fn destroy_user_decryption_keys(
-    master_secret_key_id: &str,
+    msk_id: &str,
     remove: bool,
     kms: &KMS,
     owner: &str,
@@ -20,8 +20,7 @@ pub(crate) async fn destroy_user_decryption_keys(
     ids_to_skip: HashSet<String>,
 ) -> KResult<()> {
     if let Some(ids) =
-        locate_user_decryption_keys(kms, master_secret_key_id, None, None, owner, params.clone())
-            .await?
+        locate_usk(kms, msk_uid, None, None, owner, params.clone()).await?
     {
         for id in ids.into_iter().filter(|id| !ids_to_skip.contains(id)) {
             recursively_destroy_object(

--- a/crate/server/src/core/cover_crypt/destroy_user_decryption_keys.rs
+++ b/crate/server/src/core/cover_crypt/destroy_user_decryption_keys.rs
@@ -11,7 +11,7 @@ use crate::{
 
 /// Revoke all the user decryption keys associated with the master secret key
 pub(crate) async fn destroy_user_decryption_keys(
-    msk_id: &str,
+    msk_uid: &str,
     remove: bool,
     kms: &KMS,
     owner: &str,
@@ -19,9 +19,7 @@ pub(crate) async fn destroy_user_decryption_keys(
     // keys that should be skipped
     ids_to_skip: HashSet<String>,
 ) -> KResult<()> {
-    if let Some(ids) =
-        locate_usk(kms, msk_uid, None, None, owner, params.clone()).await?
-    {
+    if let Some(ids) = locate_usk(kms, msk_uid, None, None, owner, params.clone()).await? {
         for id in ids.into_iter().filter(|id| !ids_to_skip.contains(id)) {
             recursively_destroy_object(
                 &UniqueIdentifier::TextString(id),

--- a/crate/server/src/core/cover_crypt/destroy_user_decryption_keys.rs
+++ b/crate/server/src/core/cover_crypt/destroy_user_decryption_keys.rs
@@ -5,7 +5,7 @@ use cosmian_kms_interfaces::SessionParams;
 
 use super::locate_usk;
 use crate::{
-    core::{KMS, operations::recursively_destroy_object},
+    core::{operations::recursively_destroy_object, KMS},
     result::KResult,
 };
 

--- a/crate/server/src/core/cover_crypt/locate_user_decryption_keys.rs
+++ b/crate/server/src/core/cover_crypt/locate_user_decryption_keys.rs
@@ -13,7 +13,7 @@ use cosmian_kms_crypto::crypto::cover_crypt::attributes::qualified_attributes_as
 use cosmian_kms_interfaces::SessionParams;
 
 use crate::{
-    core::{KMS, operations},
+    core::{operations, KMS},
     result::KResult,
 };
 

--- a/crate/server/src/core/cover_crypt/locate_user_decryption_keys.rs
+++ b/crate/server/src/core/cover_crypt/locate_user_decryption_keys.rs
@@ -9,7 +9,7 @@ use cosmian_kmip::kmip_2_1::{
         StateEnumeration,
     },
 };
-use cosmian_kms_crypto::crypto::cover_crypt::attributes::attributes_as_vendor_attribute;
+use cosmian_kms_crypto::crypto::cover_crypt::attributes::qualified_attributes_as_vendor_attributes;
 use cosmian_kms_interfaces::SessionParams;
 
 use crate::{
@@ -29,7 +29,7 @@ pub(crate) async fn locate_user_decryption_keys(
 ) -> KResult<Option<Vec<String>>> {
     // Convert the access structure attributes to vendor attributes
     let vendor_attributes = match cover_crypt_policy_attributes_to_revoke {
-        Some(att) => Some(vec![attributes_as_vendor_attribute(&att)?]),
+        Some(att) => Some(vec![qualified_attributes_as_vendor_attributes(&att)?]),
         None => None,
     };
     // Search the user decryption keys that need to be refreshed

--- a/crate/server/src/core/cover_crypt/locate_user_decryption_keys.rs
+++ b/crate/server/src/core/cover_crypt/locate_user_decryption_keys.rs
@@ -13,13 +13,13 @@ use cosmian_kms_crypto::crypto::cover_crypt::attributes::qualified_attributes_as
 use cosmian_kms_interfaces::SessionParams;
 
 use crate::{
-    core::{operations, KMS},
+    core::{KMS, operations},
     result::KResult,
 };
 
 /// Locate all the user decryption keys associated with the master secret key
 /// and for the given access structure attributes
-pub(crate) async fn locate_user_decryption_keys(
+pub(crate) async fn locate_usk(
     kmip_server: &KMS,
     master_secret_key_uid: &str,
     cover_crypt_policy_attributes_to_revoke: Option<Vec<QualifiedAttribute>>,

--- a/crate/server/src/core/cover_crypt/mod.rs
+++ b/crate/server/src/core/cover_crypt/mod.rs
@@ -8,6 +8,6 @@ mod revoke_user_decryption_keys;
 
 pub(crate) use create_user_decryption_key::create_user_decryption_key;
 pub(crate) use destroy_user_decryption_keys::destroy_user_decryption_keys;
-pub(crate) use locate_user_decryption_keys::locate_user_decryption_keys;
+pub(crate) use locate_user_decryption_keys::locate_usk;
 pub(crate) use rekey_keys::rekey_keypair_cover_crypt;
 pub(crate) use revoke_user_decryption_keys::revoke_user_decryption_keys;

--- a/crate/server/src/core/cover_crypt/rekey_keys.rs
+++ b/crate/server/src/core/cover_crypt/rekey_keys.rs
@@ -1,16 +1,16 @@
 #![allow(clippy::large_stack_frames)]
-use std::sync::Arc;
+use std::{ops::AsyncFn, sync::Arc};
 
-use cosmian_cover_crypt::{api::Covercrypt, MasterPublicKey, MasterSecretKey};
+use cosmian_cover_crypt::{MasterPublicKey, MasterSecretKey, api::Covercrypt};
 use cosmian_kmip::kmip_2_1::{
     kmip_objects::{Object, ObjectType},
     kmip_operations::{ErrorReason, Get, Import, ReKeyKeyPairResponse},
     kmip_types::{LinkType, StateEnumeration, UniqueIdentifier},
 };
 use cosmian_kms_crypto::crypto::cover_crypt::{
-    attributes::{deserialize_access_policy, RekeyEditAction},
+    attributes::{RekeyEditAction, deserialize_access_policy},
     master_keys::{
-        covercrypt_keys_from_kmip_objects, kmip_objects_from_covercrypt_keys, KmipKeyUidObject,
+        KmipKeyUidObject, cc_master_keypair_from_kmip_objects, kmip_objects_from_cc_master_keypair,
     },
     user_key::UserDecryptionKeysHandler,
 };
@@ -22,7 +22,7 @@ use crate::{
     core::cover_crypt::locate_user_decryption_keys, error::KmsError, kms_bail, result::KResult,
 };
 
-/// KMIP `Re_key` for `CoverCrypt` master keys can be one of these actions:
+/// KMIP `ReKey` for `CoverCrypt` master keys can be one of these actions:
 ///
 /// - `RekeyAccessPolicy`: Generate new keys for the given access policy.
 /// - `PruneAccessPolicy`: Remove old keys associated to an access policy.
@@ -37,145 +37,116 @@ pub(crate) async fn rekey_keypair_cover_crypt(
     owner: &str,
     action: RekeyEditAction,
     params: Option<Arc<dyn SessionParams>>,
-    sensitive: bool,
+    _sensitive: bool,
 ) -> KResult<ReKeyKeyPairResponse> {
     trace!("Internal rekey key pair Covercrypt");
-    let (msk_uid, mpk_uid) = match action {
+    let mpk_uid = match action {
         RekeyEditAction::RekeyAccessPolicy(access_policy) => {
-            let res = Box::pin(update_master_keys(
+            update_master_keys(
                 kmip_server,
                 owner,
                 params.clone(),
-                msk_uid,
-                |msk, mpk| {
+                &msk_uid,
+                async |msk, mpk| {
                     let ap = deserialize_access_policy(&access_policy)?;
-                    trace!("rekey_keypair_cover_crypt: access_policy: {access_policy}");
                     *mpk = cover_crypt.rekey(msk, &ap)?;
+                    update_all_active_usk(
+                        kmip_server,
+                        &cover_crypt,
+                        &msk_uid,
+                        msk,
+                        owner,
+                        params.clone(),
+                    )
+                    .await?;
                     Ok(())
                 },
-                sensitive,
-            ))
-            .await?;
-            let (msk_obj, mpk_obj) = res;
-
-            update_all_active_usk(kmip_server, cover_crypt, &msk_obj, owner, params.clone())
-                .await?;
-
-            (msk_obj.0, mpk_obj.0)
+            )
+            .await?
         }
         RekeyEditAction::PruneAccessPolicy(access_policy) => {
-            let res = Box::pin(update_master_keys(
+            update_master_keys(
                 kmip_server,
                 owner,
                 params.clone(),
-                msk_uid,
-                |msk, _mpk| {
+                &msk_uid,
+                async |msk, _mpk| {
                     let ap = deserialize_access_policy(&access_policy)?;
                     cover_crypt.prune_master_secret_key(msk, &ap)?;
+                    update_all_active_usk(
+                        kmip_server,
+                        &cover_crypt,
+                        &msk_uid,
+                        msk,
+                        owner,
+                        params.clone(),
+                    )
+                    .await?;
                     Ok(())
                 },
-                sensitive,
-            ))
-            .await?;
-            let (msk_obj, mpk_obj) = res;
-
-            update_all_active_usk(kmip_server, cover_crypt, &msk_obj, owner, params.clone())
-                .await?;
-
-            (msk_obj.0, mpk_obj.0)
+            )
+            .await?
         }
         RekeyEditAction::DeleteAttribute(attrs) => {
-            let res = Box::pin(update_master_keys(
+            update_master_keys(
                 kmip_server,
                 owner,
                 params.clone(),
-                msk_uid,
-                |msk, mpk| {
-                    drop(
-                        attrs
-                            .iter()
-                            .try_for_each(|attr| msk.access_structure.del_attribute(attr)),
-                    );
+                &msk_uid,
+                async |msk, mpk| {
+                    attrs
+                        .iter()
+                        .try_for_each(|attr| msk.access_structure.del_attribute(attr))?;
                     *mpk = cover_crypt.update_msk(msk)?;
+                    update_all_active_usk(
+                        kmip_server,
+                        &cover_crypt,
+                        &msk_uid,
+                        msk,
+                        owner,
+                        params.clone(),
+                    )
+                    .await?;
                     Ok(())
                 },
-                sensitive,
-            ))
-            .await?;
-            let (msk_obj, mpk_obj) = res;
-
-            update_all_active_usk(kmip_server, cover_crypt, &msk_obj, owner, params).await?;
-
-            (msk_obj.0, mpk_obj.0)
+            )
+            .await?
         }
         RekeyEditAction::DisableAttribute(attrs) => {
-            let res = Box::pin(update_master_keys(
-                kmip_server,
-                owner,
-                params,
-                msk_uid,
-                |msk, mpk| {
-                    drop(
-                        attrs
-                            .iter()
-                            .try_for_each(|attr| msk.access_structure.disable_attribute(attr)),
-                    );
-                    *mpk = cover_crypt.update_msk(msk)?;
-                    Ok(())
-                },
-                sensitive,
-            ))
-            .await?;
-            let (msk_obj, mpk_obj) = res;
-
-            (msk_obj.0, mpk_obj.0)
+            update_master_keys(kmip_server, owner, params, &msk_uid, async |msk, mpk| {
+                attrs
+                    .iter()
+                    .try_for_each(|attr| msk.access_structure.disable_attribute(attr))?;
+                *mpk = cover_crypt.update_msk(msk)?;
+                Ok(())
+            })
+            .await?
         }
         RekeyEditAction::RenameAttribute(pairs_attr_name) => {
-            let res = Box::pin(update_master_keys(
-                kmip_server,
-                owner,
-                params,
-                msk_uid,
-                |msk, mpk| {
-                    drop(
-                        pairs_attr_name
-                            .iter()
-                            .try_for_each(|(ap_attributes, new_name)| {
-                                msk.access_structure
-                                    .rename_attribute(ap_attributes, new_name.clone())
-                            }),
-                    );
-                    *mpk = cover_crypt.update_msk(msk)?;
-                    Ok(())
-                },
-                sensitive,
-            ))
-            .await?;
-            let (msk_obj, mpk_obj) = res;
-            (msk_obj.0, mpk_obj.0)
+            update_master_keys(kmip_server, owner, params, &msk_uid, async |msk, mpk| {
+                pairs_attr_name
+                    .iter()
+                    .try_for_each(|(ap_attributes, new_name)| {
+                        msk.access_structure
+                            .rename_attribute(ap_attributes, new_name.clone())
+                    })?;
+                *mpk = cover_crypt.update_msk(msk)?;
+                Ok(())
+            })
+            .await?
         }
         RekeyEditAction::AddAttribute(attrs_properties) => {
-            let res = Box::pin(update_master_keys(
-                kmip_server,
-                owner,
-                params,
-                msk_uid,
-                |msk, mpk| {
-                    drop(attrs_properties.iter().try_for_each(
-                        |(attr, encryption_hint, _after)| {
-                            msk.access_structure
-                                .add_attribute(attr.clone(), *encryption_hint, None)
-                        },
-                    ));
-                    *mpk = cover_crypt.update_msk(msk)?;
-                    Ok(())
-                },
-                sensitive,
-            ))
-            .await?;
-            let (msk_obj, mpk_obj) = res;
-
-            (msk_obj.0, mpk_obj.0)
+            update_master_keys(kmip_server, owner, params, &msk_uid, async |msk, mpk| {
+                attrs_properties
+                    .iter()
+                    .try_for_each(|(attr, encryption_hint, _after)| {
+                        msk.access_structure
+                            .add_attribute(attr.clone(), *encryption_hint, None)
+                    })?;
+                *mpk = cover_crypt.update_msk(msk)?;
+                Ok(())
+            })
+            .await?
         }
     };
 
@@ -185,52 +156,56 @@ pub(crate) async fn rekey_keypair_cover_crypt(
     })
 }
 
-/// Updates the key-pair associated to the MSK which ID is given using the given mutator, and
-/// replaces the stored key-pair with the mutated one.
+/// Updates the key-pair associated to the MSK which UID is given using the
+/// given mutator, and replaces the stored key-pair with the mutated
+/// one. Returns the associated MPK UID.
 pub(crate) async fn update_master_keys(
     server: &KMS,
     owner: &str,
     params: Option<Arc<dyn SessionParams>>,
-    msk_uid: String,
-    mutator: impl Fn(&mut MasterSecretKey, &mut MasterPublicKey) -> KResult<()>,
-    sensitive: bool,
-) -> KResult<((String, Object), (String, Object))> {
-    let (msk_obj, mpk_obj) = get_master_keys(server, msk_uid, owner, params.clone()).await?;
-    let (mut msk, mut mpk) = covercrypt_keys_from_kmip_objects(&msk_obj.1, &mpk_obj.1)?;
-    mutator(&mut msk, &mut mpk)?;
-    let (msk_obj, mpk_obj) =
-        kmip_objects_from_covercrypt_keys(&msk, &mpk, msk_obj, mpk_obj, sensitive)?;
-    import_rekeyed_master_keys(server, owner, params, msk_obj.clone(), mpk_obj.clone()).await?;
-    Ok((msk_obj, mpk_obj))
+    msk_uid: &String,
+    mutator: impl AsyncFn(&mut MasterSecretKey, &mut MasterPublicKey) -> KResult<()>,
+) -> KResult<String> {
+    let (msk_obj, (mpk_uid, mpk_obj)) =
+        get_master_keys(server, msk_uid, owner, params.clone()).await?;
+
+    let (mut msk, mut mpk) = cc_master_keypair_from_kmip_objects(&msk_obj, &mpk_obj)?;
+
+    mutator(&mut msk, &mut mpk).await?;
+
+    let (msk_obj, mpk_obj) = kmip_objects_from_cc_master_keypair(&msk, &mpk, msk_obj, mpk_obj)?;
+
+    import_rekeyed_master_keys(
+        server,
+        owner,
+        params,
+        (msk_uid.clone(), msk_obj),
+        (mpk_uid.clone(), mpk_obj),
+    )
+    .await?;
+
+    Ok(mpk_uid)
 }
 
 async fn get_master_keys(
     kmip_server: &KMS,
-    msk_uid: String,
+    msk_uid: &String,
     owner: &str,
     params: Option<Arc<dyn SessionParams>>,
-) -> KResult<(KmipKeyUidObject, KmipKeyUidObject)> {
-    // Recover the master secret key
-    let msk = kmip_server
-        .get(Get::from(&msk_uid), owner, params.clone())
+) -> KResult<(Object, KmipKeyUidObject)> {
+    let msk_obj = kmip_server
+        .get(Get::from(msk_uid), owner, params.clone())
         .await?
         .object;
 
-    if msk.key_wrapping_data().is_some() {
+    if msk_obj.key_wrapping_data().is_some() {
         kms_bail!(KmsError::InconsistentOperation(
             "The server can't rekey: the key is wrapped".to_owned()
         ));
     }
 
-    // Recover the Master Public Key
-    let Object::PrivateKey { key_block } = &msk else {
-        return Err(KmsError::KmipError(
-            ErrorReason::Invalid_Object_Type,
-            "KmsError::KmipErrorIP Private Key".to_owned(),
-        ))
-    };
-
-    let mpk_uid = key_block
+    let mpk_uid = msk_obj
+        .key_block()?
         .get_linked_object_id(LinkType::PublicKeyLink)?
         .ok_or_else(|| {
             KmsError::KmipError(
@@ -239,12 +214,12 @@ async fn get_master_keys(
             )
         })?;
 
-    let mpk = kmip_server
-        .get(Get::from(mpk_uid.clone()), owner, params)
+    let mpk_obj = kmip_server
+        .get(Get::from(&mpk_uid), owner, params)
         .await?
         .object;
 
-    Ok(((msk_uid, msk), (mpk_uid, mpk)))
+    Ok((msk_obj, (mpk_uid, mpk_obj)))
 }
 
 /// Import the updated master keys in place of the old ones in the KMS
@@ -255,7 +230,6 @@ async fn import_rekeyed_master_keys(
     msk: KmipKeyUidObject,
     mpk: KmipKeyUidObject,
 ) -> KResult<()> {
-    // re-import master secret key
     let import_request = Import {
         unique_identifier: UniqueIdentifier::TextString(msk.0),
         object_type: ObjectType::PrivateKey,
@@ -264,11 +238,11 @@ async fn import_rekeyed_master_keys(
         attributes: msk.1.attributes()?.clone(),
         object: msk.1,
     };
-    let _import_response = kmip_server
+
+    kmip_server
         .import(import_request, owner, params.clone())
         .await?;
 
-    // re-import master public key
     let import_request = Import {
         unique_identifier: UniqueIdentifier::TextString(mpk.0),
         object_type: ObjectType::PublicKey,
@@ -277,7 +251,8 @@ async fn import_rekeyed_master_keys(
         attributes: mpk.1.attributes()?.clone(),
         object: mpk.1,
     };
-    let _import_response = kmip_server.import(import_request, owner, params).await?;
+
+    kmip_server.import(import_request, owner, params).await?;
 
     Ok(())
 }
@@ -285,15 +260,15 @@ async fn import_rekeyed_master_keys(
 /// Updates user secret keys for actions like rekeying or pruning.
 async fn update_all_active_usk(
     kmip_server: &KMS,
-    cover_crypt: Covercrypt,
-    msk_obj: &KmipKeyUidObject,
+    cover_crypt: &Covercrypt,
+    msk_uid: &String,
+    msk: &mut MasterSecretKey,
     owner: &str,
     params: Option<Arc<dyn SessionParams>>,
 ) -> KResult<()> {
-    // Search the user decryption keys that need to be refreshed
     let locate_response = locate_user_decryption_keys(
         kmip_server,
-        &msk_obj.0,
+        msk_uid,
         None,
         Some(StateEnumeration::Active),
         owner,
@@ -301,15 +276,11 @@ async fn update_all_active_usk(
     )
     .await?;
 
-    // Refresh the User Decryption Key that were found
     if let Some(unique_identifiers) = &locate_response {
-        //instantiate a CoverCrypt User Key Handler
-        let handler = &mut UserDecryptionKeysHandler::instantiate(cover_crypt, &msk_obj.1)?;
-
-        // Renew user decryption key previously found
+        let mut handler = UserDecryptionKeysHandler::instantiate(cover_crypt, msk);
         for user_decryption_key_uid in unique_identifiers {
             update_usk(
-                handler,
+                &mut handler,
                 user_decryption_key_uid,
                 kmip_server,
                 owner,
@@ -323,8 +294,8 @@ async fn update_all_active_usk(
 }
 
 /// Refresh an individual user secret key with a given handler to a master secret key
-async fn update_usk(
-    handler: &mut UserDecryptionKeysHandler,
+async fn update_usk<'a>(
+    handler: &mut UserDecryptionKeysHandler<'a>,
     user_decryption_key_uid: &str,
     kmip_server: &KMS,
     owner: &str,

--- a/crate/server/src/core/cover_crypt/rekey_keys.rs
+++ b/crate/server/src/core/cover_crypt/rekey_keys.rs
@@ -1,15 +1,15 @@
 use std::{ops::AsyncFn, sync::Arc};
 
-use cosmian_cover_crypt::{MasterPublicKey, MasterSecretKey, api::Covercrypt};
+use cosmian_cover_crypt::{api::Covercrypt, MasterPublicKey, MasterSecretKey};
 use cosmian_kmip::kmip_2_1::{
     kmip_objects::{Object, ObjectType},
     kmip_operations::{ErrorReason, Get, Import, ReKeyKeyPairResponse},
     kmip_types::{LinkType, StateEnumeration, UniqueIdentifier},
 };
 use cosmian_kms_crypto::crypto::cover_crypt::{
-    attributes::{RekeyEditAction, deserialize_access_policy},
+    attributes::{deserialize_access_policy, RekeyEditAction},
     master_keys::{
-        KmipKeyUidObject, cc_master_keypair_from_kmip_objects, kmip_objects_from_cc_master_keypair,
+        cc_master_keypair_from_kmip_objects, kmip_objects_from_cc_master_keypair, KmipKeyUidObject,
     },
     user_key::UserDecryptionKeysHandler,
 };

--- a/crate/server/src/core/cover_crypt/rekey_keys.rs
+++ b/crate/server/src/core/cover_crypt/rekey_keys.rs
@@ -27,6 +27,7 @@ use crate::{core::cover_crypt::locate_usk, error::KmsError, kms_bail, result::KR
 /// - `DisableAttribute`: Disable attributes in the access structure.
 /// - `AddAttribute`: Add new attributes to the access structure.
 /// - `RenameAttribute`: Rename attributes in the access structure.
+#[allow(clippy::large_futures)]
 pub(crate) async fn rekey_keypair_cover_crypt(
     kmip_server: &KMS,
     cover_crypt: Covercrypt,
@@ -258,7 +259,7 @@ async fn import_rekeyed_master_keys(
 async fn update_all_active_usk(
     kmip_server: &KMS,
     cover_crypt: &Covercrypt,
-    msk_uid: &String,
+    msk_uid: &str,
     msk: &mut MasterSecretKey,
     owner: &str,
     params: Option<Arc<dyn SessionParams>>,
@@ -284,8 +285,8 @@ async fn update_all_active_usk(
 }
 
 /// Refresh an individual USK with a given handler to a MSK.
-async fn update_usk<'a>(
-    handler: &mut UserDecryptionKeysHandler<'a>,
+async fn update_usk(
+    handler: &mut UserDecryptionKeysHandler<'_>,
     usk_uid: &str,
     kmip_server: &KMS,
     owner: &str,

--- a/crate/server/src/core/cover_crypt/revoke_user_decryption_keys.rs
+++ b/crate/server/src/core/cover_crypt/revoke_user_decryption_keys.rs
@@ -5,7 +5,7 @@ use cosmian_kms_interfaces::SessionParams;
 
 use super::locate_usk;
 use crate::{
-    core::{KMS, operations::recursively_revoke_key},
+    core::{operations::recursively_revoke_key, KMS},
     result::KResult,
 };
 

--- a/crate/server/src/core/cover_crypt/revoke_user_decryption_keys.rs
+++ b/crate/server/src/core/cover_crypt/revoke_user_decryption_keys.rs
@@ -3,9 +3,9 @@ use std::{collections::HashSet, sync::Arc};
 use cosmian_kmip::kmip_2_1::kmip_types::{RevocationReason, StateEnumeration, UniqueIdentifier};
 use cosmian_kms_interfaces::SessionParams;
 
-use super::locate_user_decryption_keys;
+use super::locate_usk;
 use crate::{
-    core::{operations::recursively_revoke_key, KMS},
+    core::{KMS, operations::recursively_revoke_key},
     result::KResult,
 };
 
@@ -19,7 +19,7 @@ pub(crate) async fn revoke_user_decryption_keys(
     params: Option<Arc<dyn SessionParams>>, // keys that should be skipped
     ids_to_skip: HashSet<String>,
 ) -> KResult<()> {
-    if let Some(ids) = locate_user_decryption_keys(
+    if let Some(ids) = locate_usk(
         kms,
         master_secret_key_id,
         None,

--- a/crate/server/src/core/kms/mod.rs
+++ b/crate/server/src/core/kms/mod.rs
@@ -14,7 +14,8 @@ use utimaco_pkcs11_loader::Utimaco;
 
 use crate::{config::ServerParams, error::KmsError, kms_bail, result::KResult};
 
-/// A Key Management System that partially implements KMIP 2.1:
+/// A Key Management System that partially implements KMIP 2.1
+///
 /// `https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=kmip`
 /// and other operations that are not part of KMIP such as Google CSE or Microsoft DKE.
 pub struct KMS {

--- a/crate/server/src/core/operations/create_key_pair.rs
+++ b/crate/server/src/core/operations/create_key_pair.rs
@@ -7,15 +7,15 @@ use cosmian_kmip::kmip_2_1::{
 };
 #[cfg(not(feature = "fips"))]
 use cosmian_kms_crypto::crypto::elliptic_curves::operation::{
-    create_x25519_key_pair, create_x448_key_pair,
+    create_x448_key_pair, create_x25519_key_pair,
 };
 use cosmian_kms_crypto::crypto::{
+    KeyPair,
     cover_crypt::master_keys::create_master_keypair,
     elliptic_curves::operation::{
-        create_approved_ecc_key_pair, create_ed25519_key_pair, create_ed448_key_pair,
+        create_approved_ecc_key_pair, create_ed448_key_pair, create_ed25519_key_pair,
     },
     rsa::operation::create_rsa_key_pair,
-    KeyPair,
 };
 use cosmian_kms_interfaces::{AtomicOperation, SessionParams};
 #[cfg(not(feature = "fips"))]
@@ -308,16 +308,16 @@ pub(crate) fn generate_key_pair_and_tags(
         ),
         CryptographicAlgorithm::CoverCrypt => create_master_keypair(
             &Covercrypt::default(),
-            private_key_uid,
+            private_key_uid.to_owned(),
             public_key_uid,
-            &Some(common_attributes),
-            &request.private_key_attributes,
-            &request.public_key_attributes,
+            common_attributes,
+            request.private_key_attributes,
+            request.public_key_attributes,
             sensitive,
         ),
         other => {
             kms_bail!(KmsError::NotSupported(format!(
-                "The creation of a key pair for algorithm: {other:?} is not supported"
+                "The creation of a keypair for algorithm: {other:?} is not supported"
             )))
         }
     }?;

--- a/crate/server/src/core/operations/create_key_pair.rs
+++ b/crate/server/src/core/operations/create_key_pair.rs
@@ -7,15 +7,15 @@ use cosmian_kmip::kmip_2_1::{
 };
 #[cfg(not(feature = "fips"))]
 use cosmian_kms_crypto::crypto::elliptic_curves::operation::{
-    create_x448_key_pair, create_x25519_key_pair,
+    create_x25519_key_pair, create_x448_key_pair,
 };
 use cosmian_kms_crypto::crypto::{
-    KeyPair,
     cover_crypt::master_keys::create_master_keypair,
     elliptic_curves::operation::{
-        create_approved_ecc_key_pair, create_ed448_key_pair, create_ed25519_key_pair,
+        create_approved_ecc_key_pair, create_ed25519_key_pair, create_ed448_key_pair,
     },
     rsa::operation::create_rsa_key_pair,
+    KeyPair,
 };
 use cosmian_kms_interfaces::{AtomicOperation, SessionParams};
 #[cfg(not(feature = "fips"))]

--- a/crate/server/src/core/operations/hash.rs
+++ b/crate/server/src/core/operations/hash.rs
@@ -63,7 +63,7 @@ pub(crate) async fn hash_operation(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used, clippy::panic_in_result_fn)]
 mod tests {
     use std::sync::Arc;
 

--- a/crate/server/src/core/operations/rekey_keypair.rs
+++ b/crate/server/src/core/operations/rekey_keypair.rs
@@ -11,7 +11,7 @@ use cosmian_kms_interfaces::SessionParams;
 use tracing::trace;
 
 use crate::{
-    core::{KMS, cover_crypt::rekey_keypair_cover_crypt},
+    core::{cover_crypt::rekey_keypair_cover_crypt, KMS},
     error::KmsError,
     kms_bail,
     result::{KResult, KResultHelper},

--- a/crate/server/src/core/operations/validate.rs
+++ b/crate/server/src/core/operations/validate.rs
@@ -378,9 +378,9 @@ fn verify_chain_signature(certificates: &[X509]) -> KResult<ValidityIndicator> {
     )?;
 
     if !result {
-        return Err(KmsError::Certificate(
-            format!("Result of the function verify_cert: {result:?}"),
-        ));
+        return Err(KmsError::Certificate(format!(
+            "Result of the function verify_cert: {result:?}"
+        )));
     }
 
     // verify signatures in cascade

--- a/crate/server/src/core/operations/validate.rs
+++ b/crate/server/src/core/operations/validate.rs
@@ -379,7 +379,7 @@ fn verify_chain_signature(certificates: &[X509]) -> KResult<ValidityIndicator> {
 
     if !result {
         return Err(KmsError::Certificate(
-            "Result of the function verify_cert: {result:?}".to_owned(),
+            format!("Result of the function verify_cert: {result:?}"),
         ));
     }
 

--- a/crate/server/src/lib.rs
+++ b/crate/server/src/lib.rs
@@ -52,7 +52,8 @@
     clippy::future_not_send,
     clippy::cognitive_complexity,
     clippy::significant_drop_tightening,
-    clippy::iter_with_drain
+    clippy::iter_with_drain,
+    clippy::ref_option, // to be uncommented after #384
 )]
 
 pub mod config;
@@ -67,6 +68,7 @@ pub mod telemetry;
 
 #[allow(
     clippy::panic,
+    clippy::panic_in_result_fn,
     clippy::unwrap_used,
     clippy::expect_used,
     unsafe_code,

--- a/crate/server/src/routes/google_cse/jwt.rs
+++ b/crate/server/src/routes/google_cse/jwt.rs
@@ -24,7 +24,7 @@ static APPLICATIONS: &[&str; 4] = &["meet", "drive", "gmail", "calendar"];
 
 fn get_jwks_uri(application: &str) -> String {
     std::env::var(format!("KMS_GOOGLE_CSE_{}_JWKS_URI", application.to_uppercase()))
-    .unwrap_or(format!("https://www.googleapis.com/service_accounts/v1/jwk/gsuitecse-tokenissuer-{application}@system.gserviceaccount.com"))
+    .unwrap_or_else(|_| format!("https://www.googleapis.com/service_accounts/v1/jwk/gsuitecse-tokenissuer-{application}@system.gserviceaccount.com"))
 }
 
 /// List the possible JWKS URI for all the supported application
@@ -45,9 +45,7 @@ fn jwt_authorization_config_application(
         "KMS_GOOGLE_CSE_{}_JWT_ISSUER",
         application.to_uppercase()
     ))
-    .unwrap_or(format!(
-        "gsuitecse-tokenissuer-{application}@system.gserviceaccount.com"
-    ));
+    .unwrap_or_else(|_| format!("gsuitecse-tokenissuer-{application}@system.gserviceaccount.com"));
 
     let jwt_audience = Some(
         std::env::var("KMS_GOOGLE_CSE_AUDIENCE").unwrap_or_else(|_| "cse-authorization".to_owned()),
@@ -348,7 +346,7 @@ mod tests {
         routes::google_cse::{
             self,
             jwt::{
-                decode_jwt_authorization_token, jwt_authorization_config, JWKS_URI, JWT_ISSUER_URI,
+                JWKS_URI, JWT_ISSUER_URI, decode_jwt_authorization_token, jwt_authorization_config,
             },
             operations::WrapRequest,
         },

--- a/crate/server/src/routes/google_cse/jwt.rs
+++ b/crate/server/src/routes/google_cse/jwt.rs
@@ -346,7 +346,7 @@ mod tests {
         routes::google_cse::{
             self,
             jwt::{
-                JWKS_URI, JWT_ISSUER_URI, decode_jwt_authorization_token, jwt_authorization_config,
+                decode_jwt_authorization_token, jwt_authorization_config, JWKS_URI, JWT_ISSUER_URI,
             },
             operations::WrapRequest,
         },

--- a/crate/server/src/routes/google_cse/operations.rs
+++ b/crate/server/src/routes/google_cse/operations.rs
@@ -563,6 +563,7 @@ pub struct DigestResponse {
 }
 
 /// Digest
+///
 /// Takes a Data Encryption Key (DEK) wrapped with the wrap API, and returns the base64 encoded resource key hash
 /// See [doc](https://developers.google.com/workspace/cse/reference/digest) and
 /// for more details, see [Encrypt & decrypt data](https://developers.google.com/workspace/cse/guides/encrypt-and-decrypt-data)
@@ -1007,11 +1008,11 @@ async fn cse_wrapped_key_decrypt(
 }
 
 /// Compute resource key hash
+///
 /// The resource key hash is a mechanism allowing Google to verify the integrity of the wrapped encryption keys without having access to the keys.
 ///
 /// Generating the resource key hash requires access to the unwrapped key including the DEK, the `resource_name` and the `perimeter_id` specified during the key wrapping operation.
-
-// We use the cryptographic function HMAC-SHA256 with unwrapped_dek as a key and the concatenation of metadata as data ("ResourceKeyDigest:", resource_name, ":", perimeter_id). The resource_name and perimeter_id should be UTF-8 encoded strings.
+/// We use the cryptographic function HMAC-SHA256 with `unwrapped_dek` as a key and the concatenation of metadata as data ("`ResourceKeyDigest`:", `resource_name`, ":", `perimeter_id`). The `resource_name` and `perimeter_id` should be UTF-8 encoded strings.
 ///
 /// # Arguments
 /// * `resource_name` - Bytes identifying the resource the key has been made for.

--- a/crate/server/src/routes/ms_dke/mod.rs
+++ b/crate/server/src/routes/ms_dke/mod.rs
@@ -100,7 +100,7 @@ pub(crate) async fn get_key(
     if key_name.is_empty() {
         "dke_key".clone_into(&mut key_name);
     }
-    match _get_key(&key_name, req_http, &kms).await {
+    match internal_get_key(&key_name, req_http, &kms).await {
         Ok(key_data) => {
             trace!(
                 "GET KEY /{} {:?}",
@@ -113,7 +113,7 @@ pub(crate) async fn get_key(
     }
 }
 
-async fn _get_key(key_tag: &str, req_http: HttpRequest, kms: &Arc<KMS>) -> KResult<KeyData> {
+async fn internal_get_key(key_tag: &str, req_http: HttpRequest, kms: &Arc<KMS>) -> KResult<KeyData> {
     let database_params = kms.get_sqlite_enc_secrets(&req_http)?;
     let user = kms.get_user(&req_http);
     let dke_service_url = kms
@@ -206,13 +206,13 @@ pub(crate) async fn decrypt(
     let (key_name, key_id) = path.into_inner();
     // let _key_id = key_id.into_inner();
     trace!("POST /{}/{}/Decrypt {:?}", key_name, key_id, encrypted_data);
-    match _decrypt(&key_name, encrypted_data, req_http, &kms).await {
+    match internal_decrypt(&key_name, encrypted_data, req_http, &kms).await {
         Ok(decrypted_data) => HttpResponse::Ok().json(decrypted_data),
         Err(e) => HttpResponse::from_error(e),
     }
 }
 
-async fn _decrypt(
+async fn internal_decrypt(
     key_tag: &str,
     encrypted_data: EncryptedData,
     req_http: HttpRequest,

--- a/crate/server/src/routes/ms_dke/mod.rs
+++ b/crate/server/src/routes/ms_dke/mod.rs
@@ -113,7 +113,11 @@ pub(crate) async fn get_key(
     }
 }
 
-async fn internal_get_key(key_tag: &str, req_http: HttpRequest, kms: &Arc<KMS>) -> KResult<KeyData> {
+async fn internal_get_key(
+    key_tag: &str,
+    req_http: HttpRequest,
+    kms: &Arc<KMS>,
+) -> KResult<KeyData> {
     let database_params = kms.get_sqlite_enc_secrets(&req_http)?;
     let user = kms.get_user(&req_http);
     let dke_service_url = kms

--- a/crate/server/src/tests/bulk_encrypt_decrypt_tests.rs
+++ b/crate/server/src/tests/bulk_encrypt_decrypt_tests.rs
@@ -19,6 +19,7 @@ use crate::{error::KmsError, result::KResult, tests::test_utils};
 const NUM_MESSAGES: usize = 1000;
 
 #[tokio::test]
+#[allow(clippy::panic_in_result_fn)]
 async fn bulk_encrypt_decrypt() -> KResult<()> {
     cosmian_logger::log_init(option_env!("RUST_LOG"));
     let app = test_utils::test_app(None).await;

--- a/crate/server/src/tests/cover_crypt_tests/integration_tests.rs
+++ b/crate/server/src/tests/cover_crypt_tests/integration_tests.rs
@@ -99,7 +99,7 @@ async fn integration_tests_use_ids_no_tags() -> KResult<()> {
         .data
         .context("There should be decrypted data")?;
 
-    assert_eq!(&*data, &**decrypted_data);
+    assert_eq!(data, &**decrypted_data);
 
     // revocation
 
@@ -168,7 +168,7 @@ async fn integration_tests_use_ids_no_tags() -> KResult<()> {
         .data
         .context("There should be decrypted data")?;
 
-    assert_eq!(&*data, &*decrypted_data);
+    assert_eq!(data, &*decrypted_data);
 
     // test user2 can decrypt
     let request = decrypt_request(
@@ -186,7 +186,7 @@ async fn integration_tests_use_ids_no_tags() -> KResult<()> {
         .data
         .context("There should be decrypted data")?;
 
-    assert_eq!(&*data, &*decrypted_data);
+    assert_eq!(data, &*decrypted_data);
 
     // Revoke key of user 1
     let _revoke_response: RevokeResponse = test_utils::post(
@@ -271,7 +271,7 @@ async fn integration_tests_use_ids_no_tags() -> KResult<()> {
         .data
         .context("There should be decrypted data")?;
 
-    assert_eq!(&*data, &*decrypted_data);
+    assert_eq!(data, &*decrypted_data);
 
     //
     // Prune old keys associated to the access policy

--- a/crate/server/src/tests/cover_crypt_tests/integration_tests.rs
+++ b/crate/server/src/tests/cover_crypt_tests/integration_tests.rs
@@ -2,8 +2,8 @@ use cosmian_cover_crypt::{AccessPolicy, EncryptionHint, QualifiedAttribute};
 use cosmian_kmip::kmip_2_1::{
     extra::tagging::EMPTY_TAGS,
     kmip_operations::{
-        CreateKeyPairResponse, CreateResponse, DecryptResponse, DecryptedData, DestroyResponse,
-        EncryptResponse, ReKeyKeyPairResponse, Revoke, RevokeResponse,
+        CreateKeyPairResponse, CreateResponse, DecryptResponse, DestroyResponse, EncryptResponse,
+        ReKeyKeyPairResponse, Revoke, RevokeResponse,
     },
     kmip_types::{
         CryptographicAlgorithm, CryptographicParameters, RevocationReason, UniqueIdentifier,
@@ -51,13 +51,11 @@ async fn integration_tests_use_ids_no_tags() -> KResult<()> {
     let authentication_data = b"cc the uid".to_vec();
     let data = b"Confidential MKG Data";
     let encryption_policy = "Security Level::Confidential && Department::MKG";
-    let header_metadata = vec![1, 2, 3];
 
     let request = encrypt_request(
         public_key_unique_identifier,
         Some(encryption_policy.to_owned()),
         data.to_vec(),
-        Some(header_metadata.clone()),
         None,
         Some(authentication_data.clone()),
         Some(CryptographicParameters {
@@ -97,14 +95,11 @@ async fn integration_tests_use_ids_no_tags() -> KResult<()> {
 
     let decrypt_response: DecryptResponse = test_utils::post(&app, request).await?;
 
-    let decrypted_data: DecryptedData = decrypt_response
+    let decrypted_data = decrypt_response
         .data
-        .context("There should be decrypted data")?
-        .as_slice()
-        .try_into()?;
+        .context("There should be decrypted data")?;
 
-    assert_eq!(data, &decrypted_data.plaintext[..]);
-    assert_eq!(header_metadata, decrypted_data.metadata);
+    assert_eq!(&*data, &**decrypted_data);
 
     // revocation
 
@@ -117,7 +112,6 @@ async fn integration_tests_use_ids_no_tags() -> KResult<()> {
         public_key_unique_identifier,
         Some(encryption_policy.to_owned()),
         data.to_vec(),
-        None,
         None,
         Some(authentication_data.clone()),
         None,
@@ -170,14 +164,11 @@ async fn integration_tests_use_ids_no_tags() -> KResult<()> {
     );
     let decrypt_response: DecryptResponse = test_utils::post(&app, &request).await?;
 
-    let decrypted_data: DecryptedData = decrypt_response
+    let decrypted_data = decrypt_response
         .data
-        .context("There should be decrypted data")?
-        .as_slice()
-        .try_into()?;
+        .context("There should be decrypted data")?;
 
-    assert_eq!(&data, &decrypted_data.plaintext.to_vec());
-    assert!(decrypted_data.metadata.is_empty());
+    assert_eq!(&*data, &*decrypted_data);
 
     // test user2 can decrypt
     let request = decrypt_request(
@@ -191,14 +182,11 @@ async fn integration_tests_use_ids_no_tags() -> KResult<()> {
 
     let decrypt_response: DecryptResponse = test_utils::post(&app, &request).await?;
 
-    let decrypted_data: DecryptedData = decrypt_response
+    let decrypted_data = decrypt_response
         .data
-        .context("There should be decrypted data")?
-        .as_slice()
-        .try_into()?;
+        .context("There should be decrypted data")?;
 
-    assert_eq!(&data, &decrypted_data.plaintext.to_vec());
-    assert!(decrypted_data.metadata.is_empty());
+    assert_eq!(&*data, &*decrypted_data);
 
     // Revoke key of user 1
     let _revoke_response: RevokeResponse = test_utils::post(
@@ -246,7 +234,6 @@ async fn integration_tests_use_ids_no_tags() -> KResult<()> {
         Some(encryption_policy.to_owned()),
         data.to_vec(),
         None,
-        None,
         Some(authentication_data.clone()),
         Some(CryptographicParameters {
             cryptographic_algorithm: Some(CryptographicAlgorithm::CoverCrypt),
@@ -280,14 +267,11 @@ async fn integration_tests_use_ids_no_tags() -> KResult<()> {
         None,
     );
     let decrypt_response: DecryptResponse = test_utils::post(&app, &request).await?;
-    let decrypted_data: DecryptedData = decrypt_response
+    let decrypted_data = decrypt_response
         .data
-        .context("There should be decrypted data")?
-        .as_slice()
-        .try_into()?;
+        .context("There should be decrypted data")?;
 
-    assert_eq!(&data, &decrypted_data.plaintext.to_vec());
-    assert!(decrypted_data.metadata.is_empty());
+    assert_eq!(&*data, &*decrypted_data);
 
     //
     // Prune old keys associated to the access policy
@@ -333,7 +317,6 @@ async fn integration_tests_use_ids_no_tags() -> KResult<()> {
         Some(encryption_policy.to_owned()),
         data.to_vec(),
         None,
-        None,
         Some(authentication_data.clone()),
         Some(CryptographicParameters {
             cryptographic_algorithm: Some(CryptographicAlgorithm::CoverCrypt),
@@ -365,7 +348,6 @@ async fn integration_tests_use_ids_no_tags() -> KResult<()> {
         Some(encryption_policy.to_owned()),
         data.to_vec(),
         None,
-        None,
         Some(authentication_data.clone()),
         Some(CryptographicParameters {
             cryptographic_algorithm: Some(CryptographicAlgorithm::CoverCrypt),
@@ -394,7 +376,6 @@ async fn integration_tests_use_ids_no_tags() -> KResult<()> {
         public_key_unique_identifier,
         Some(encryption_policy.to_owned()),
         data.to_vec(),
-        None,
         None,
         Some(authentication_data.clone()),
         Some(CryptographicParameters {
@@ -425,7 +406,6 @@ async fn integration_tests_use_ids_no_tags() -> KResult<()> {
         public_key_unique_identifier,
         Some(encryption_policy.to_owned()),
         data.to_vec(),
-        None,
         None,
         Some(authentication_data.clone()),
         Some(CryptographicParameters {

--- a/crate/server/src/tests/cover_crypt_tests/integration_tests_tags.rs
+++ b/crate/server/src/tests/cover_crypt_tests/integration_tests_tags.rs
@@ -142,7 +142,7 @@ async fn integration_tests_with_tags() -> KResult<()> {
         .data
         .context("There should be decrypted data")?;
 
-    assert_eq!(&*data, &**decrypted_data);
+    assert_eq!(data, &**decrypted_data);
 
     // revocation
 
@@ -205,7 +205,7 @@ async fn integration_tests_with_tags() -> KResult<()> {
         .data
         .context("There should be decrypted data")?;
 
-    assert_eq!(&*data, &*decrypted_data);
+    assert_eq!(data, &*decrypted_data);
 
     // test user2 can decrypt
     let request = decrypt_request(
@@ -222,7 +222,7 @@ async fn integration_tests_with_tags() -> KResult<()> {
         .data
         .context("There should be decrypted data")?;
 
-    assert_eq!(&*data, &*decrypted_data);
+    assert_eq!(data, &*decrypted_data);
 
     // Revoke key of user 1
     let _revoke_response: RevokeResponse = test_utils::post(
@@ -293,7 +293,7 @@ async fn integration_tests_with_tags() -> KResult<()> {
     let decrypted_data = decrypt_response
         .data
         .context("There should be decrypted data")?;
-    assert_eq!(&*data, &*decrypted_data);
+    assert_eq!(data, &*decrypted_data);
 
     //
     // Destroy user decryption key

--- a/crate/server/src/tests/cover_crypt_tests/integration_tests_tags.rs
+++ b/crate/server/src/tests/cover_crypt_tests/integration_tests_tags.rs
@@ -1,7 +1,7 @@
 use cosmian_kmip::kmip_2_1::{
     kmip_operations::{
-        CreateKeyPairResponse, CreateResponse, DecryptResponse, DecryptedData, DestroyResponse,
-        EncryptResponse, ReKeyKeyPairResponse, Revoke, RevokeResponse,
+        CreateKeyPairResponse, CreateResponse, DecryptResponse, DestroyResponse, EncryptResponse,
+        ReKeyKeyPairResponse, Revoke, RevokeResponse,
     },
     kmip_types::{RevocationReason, UniqueIdentifier},
     requests::{decrypt_request, encrypt_request},
@@ -63,7 +63,6 @@ async fn test_re_key_with_tags() -> KResult<()> {
         &mkp_json_tag,
         Some(encryption_policy.to_owned()),
         data.to_vec(),
-        None,
         Some(authentication_data.clone()),
         None,
         None,
@@ -100,13 +99,11 @@ async fn integration_tests_with_tags() -> KResult<()> {
     let authentication_data = b"cc the uid".to_vec();
     let data = b"Confidential MKG Data";
     let encryption_policy = "Security Level::Confidential && Department::MKG";
-    let header_metadata = vec![1, 2, 3];
 
     let request = encrypt_request(
         &mkp_json_tag,
         Some(encryption_policy.to_owned()),
         data.to_vec(),
-        Some(header_metadata.clone()),
         None,
         Some(authentication_data.clone()),
         None,
@@ -141,14 +138,11 @@ async fn integration_tests_with_tags() -> KResult<()> {
     );
     let decrypt_response: DecryptResponse = test_utils::post(&app, request).await?;
 
-    let decrypted_data: DecryptedData = decrypt_response
+    let decrypted_data = decrypt_response
         .data
-        .context("There should be decrypted data")?
-        .as_slice()
-        .try_into()?;
+        .context("There should be decrypted data")?;
 
-    assert_eq!(data, &decrypted_data.plaintext[..]);
-    assert_eq!(header_metadata, decrypted_data.metadata);
+    assert_eq!(&*data, &**decrypted_data);
 
     // revocation
 
@@ -161,7 +155,6 @@ async fn integration_tests_with_tags() -> KResult<()> {
         &mkp_json_tag,
         Some(encryption_policy.to_owned()),
         data.to_vec(),
-        None,
         None,
         Some(authentication_data.clone()),
         None,
@@ -208,15 +201,11 @@ async fn integration_tests_with_tags() -> KResult<()> {
     );
     let decrypt_response: DecryptResponse = test_utils::post(&app, &request).await?;
 
-    let decrypted_data: DecryptedData = decrypt_response
+    let decrypted_data = decrypt_response
         .data
-        .context("There should be decrypted data")?
-        .as_slice()
-        .try_into()
-        .unwrap();
+        .context("There should be decrypted data")?;
 
-    assert_eq!(&data, &decrypted_data.plaintext.to_vec());
-    assert!(decrypted_data.metadata.is_empty());
+    assert_eq!(&*data, &*decrypted_data);
 
     // test user2 can decrypt
     let request = decrypt_request(
@@ -229,15 +218,11 @@ async fn integration_tests_with_tags() -> KResult<()> {
     );
     let decrypt_response: DecryptResponse = test_utils::post(&app, &request).await?;
 
-    let decrypted_data: DecryptedData = decrypt_response
+    let decrypted_data = decrypt_response
         .data
-        .context("There should be decrypted data")?
-        .as_slice()
-        .try_into()
-        .unwrap();
+        .context("There should be decrypted data")?;
 
-    assert_eq!(&data, &decrypted_data.plaintext.to_vec());
-    assert!(decrypted_data.metadata.is_empty());
+    assert_eq!(&*data, &*decrypted_data);
 
     // Revoke key of user 1
     let _revoke_response: RevokeResponse = test_utils::post(
@@ -275,7 +260,6 @@ async fn integration_tests_with_tags() -> KResult<()> {
         Some(encryption_policy.to_owned()),
         data.to_vec(),
         None,
-        None,
         Some(authentication_data.clone()),
         None,
     )?;
@@ -306,14 +290,10 @@ async fn integration_tests_with_tags() -> KResult<()> {
         None,
     );
     let decrypt_response: DecryptResponse = test_utils::post(&app, &request).await?;
-    let decrypted_data: DecryptedData = decrypt_response
+    let decrypted_data = decrypt_response
         .data
-        .context("There should be decrypted data")?
-        .as_slice()
-        .try_into()?;
-
-    assert_eq!(&data, &decrypted_data.plaintext.to_vec());
-    assert!(decrypted_data.metadata.is_empty());
+        .context("There should be decrypted data")?;
+    assert_eq!(&*data, &*decrypted_data);
 
     //
     // Destroy user decryption key

--- a/crate/server/src/tests/cover_crypt_tests/unit_tests.rs
+++ b/crate/server/src/tests/cover_crypt_tests/unit_tests.rs
@@ -368,7 +368,7 @@ async fn test_abe_encrypt_decrypt() -> KResult<()> {
         .await?;
 
     let decrypted_data = dr.data.context("There should be decrypted data")?;
-    assert_eq!(&*confidential_mkg_data, &**decrypted_data);
+    assert_eq!(confidential_mkg_data, &**decrypted_data);
 
     // check it doesn't work with invalid tenant
     let dr = kms
@@ -405,7 +405,7 @@ async fn test_abe_encrypt_decrypt() -> KResult<()> {
 
     let decrypted_data = dr.data.context("There should be decrypted data")?;
 
-    assert_eq!(&*secret_fin_data, &**decrypted_data);
+    assert_eq!(secret_fin_data, &**decrypted_data);
 
     // check it doesn't work with invalid tenant
     let dr = kms
@@ -625,7 +625,7 @@ async fn test_import_decrypt() -> KResult<()> {
     // Decryption used to fails: import attributes were incorrect;
     // this seems fixed since #71. Leaving the test in case this pops-up again
     let decrypted_data = dr.data.context("There should be decrypted data")?;
-    assert_eq!(&*confidential_mkg_data, &**decrypted_data);
+    assert_eq!(confidential_mkg_data, &**decrypted_data);
 
     // ...and reimport it under custom uid (will work)
     let custom_sk_uid = Uuid::new_v4().to_string();
@@ -661,7 +661,7 @@ async fn test_import_decrypt() -> KResult<()> {
 
     let decrypted_data = dr.data.context("There should be decrypted data")?;
 
-    assert_eq!(&*confidential_mkg_data, &**decrypted_data);
+    assert_eq!(confidential_mkg_data, &**decrypted_data);
 
     Ok(())
 }

--- a/crate/server/src/tests/cover_crypt_tests/unit_tests.rs
+++ b/crate/server/src/tests/cover_crypt_tests/unit_tests.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use cosmian_kmip::kmip_2_1::{
     extra::tagging::EMPTY_TAGS,
     kmip_objects::{Object, ObjectType},
-    kmip_operations::{DecryptedData, Get, Import, Locate},
+    kmip_operations::{Get, Import, Locate},
     kmip_types::{
         Attributes, CryptographicAlgorithm, KeyFormatType, Link, LinkType, LinkedObjectIdentifier,
         UniqueIdentifier,
@@ -256,7 +256,6 @@ async fn test_abe_encrypt_decrypt() -> KResult<()> {
                 Some(confidential_mkg_policy_attributes.to_owned()),
                 confidential_mkg_data.to_vec(),
                 None,
-                None,
                 Some(confidential_authentication_data.clone()),
                 None,
             )?,
@@ -280,7 +279,6 @@ async fn test_abe_encrypt_decrypt() -> KResult<()> {
                 Some(confidential_mkg_policy_attributes.to_owned()),
                 confidential_mkg_data.to_vec(),
                 None,
-                None,
                 Some(confidential_authentication_data.clone()),
                 None,
             )?,
@@ -300,7 +298,6 @@ async fn test_abe_encrypt_decrypt() -> KResult<()> {
                 master_public_key_id,
                 Some(secret_fin_policy_attributes.to_owned()),
                 secret_fin_data.to_vec(),
-                None,
                 None,
                 Some(secret_authentication_data.clone()),
                 None,
@@ -324,7 +321,6 @@ async fn test_abe_encrypt_decrypt() -> KResult<()> {
                 master_public_key_id,
                 Some(secret_fin_policy_attributes.to_owned()),
                 secret_fin_data.to_vec(),
-                None,
                 None,
                 Some(secret_authentication_data.clone()),
                 None,
@@ -371,15 +367,8 @@ async fn test_abe_encrypt_decrypt() -> KResult<()> {
         )
         .await?;
 
-    let decrypted_data: DecryptedData = dr
-        .data
-        .context("There should be decrypted data")?
-        .as_slice()
-        .try_into()
-        .unwrap();
-
-    assert_eq!(confidential_mkg_data, &decrypted_data.plaintext[..]);
-    assert!(decrypted_data.metadata.is_empty());
+    let decrypted_data = dr.data.context("There should be decrypted data")?;
+    assert_eq!(&*confidential_mkg_data, &**decrypted_data);
 
     // check it doesn't work with invalid tenant
     let dr = kms
@@ -414,15 +403,9 @@ async fn test_abe_encrypt_decrypt() -> KResult<()> {
         )
         .await?;
 
-    let decrypted_data: DecryptedData = dr
-        .data
-        .context("There should be decrypted data")?
-        .as_slice()
-        .try_into()
-        .unwrap();
+    let decrypted_data = dr.data.context("There should be decrypted data")?;
 
-    assert_eq!(secret_fin_data, &decrypted_data.plaintext[..]);
-    assert!(decrypted_data.metadata.is_empty());
+    assert_eq!(&*secret_fin_data, &**decrypted_data);
 
     // check it doesn't work with invalid tenant
     let dr = kms
@@ -561,7 +544,6 @@ async fn test_import_decrypt() -> KResult<()> {
                 Some(confidential_mkg_policy_attributes.to_owned()),
                 confidential_mkg_data.to_vec(),
                 None,
-                None,
                 Some(confidential_authentication_data.clone()),
                 None,
             )?,
@@ -642,14 +624,8 @@ async fn test_import_decrypt() -> KResult<()> {
         .await?;
     // Decryption used to fails: import attributes were incorrect;
     // this seems fixed since #71. Leaving the test in case this pops-up again
-    let decrypted_data: DecryptedData = dr
-        .data
-        .context("There should be decrypted data")?
-        .as_slice()
-        .try_into()
-        .unwrap();
-    assert_eq!(confidential_mkg_data, &decrypted_data.plaintext[..]);
-    assert!(decrypted_data.metadata.is_empty());
+    let decrypted_data = dr.data.context("There should be decrypted data")?;
+    assert_eq!(&*confidential_mkg_data, &**decrypted_data);
 
     // ...and reimport it under custom uid (will work)
     let custom_sk_uid = Uuid::new_v4().to_string();
@@ -683,15 +659,9 @@ async fn test_import_decrypt() -> KResult<()> {
         )
         .await?;
 
-    let decrypted_data: DecryptedData = dr
-        .data
-        .context("There should be decrypted data")?
-        .as_slice()
-        .try_into()
-        .unwrap();
+    let decrypted_data = dr.data.context("There should be decrypted data")?;
 
-    assert_eq!(confidential_mkg_data, &decrypted_data.plaintext[..]);
-    assert!(decrypted_data.metadata.is_empty());
+    assert_eq!(&*confidential_mkg_data, &**decrypted_data);
 
     Ok(())
 }

--- a/crate/server_database/src/core/database_objects.rs
+++ b/crate/server_database/src/core/database_objects.rs
@@ -88,10 +88,7 @@ impl Database {
     /// # Errors
     ///
     /// This function will return an error if no object store is found for the given prefix or if no default object store is available.
-    async fn get_object_store(
-        &self,
-        uid: &str,
-    ) -> DbResult<Arc<dyn ObjectsStore + Sync + Send>> {
+    async fn get_object_store(&self, uid: &str) -> DbResult<Arc<dyn ObjectsStore + Sync + Send>> {
         // split the uid on the first ::
         let splits = uid.split_once("::");
         Ok(match splits {

--- a/crate/server_database/src/core/database_objects.rs
+++ b/crate/server_database/src/core/database_objects.rs
@@ -24,7 +24,7 @@ use crate::{
 /// # Methods
 ///
 /// - `register_objects_store`: Registers an `ObjectsStore` for objects with a specific prefix.
-/// - `unregister_object_store`: Unregisters the default objects store or a store for a given prefix.
+/// - `unregister_object_store`: Unregister the default objects store or a store for a given prefix.
 /// - `get_object_store`: Retrieves the appropriate object store based on the prefix of the `uid`.
 /// - `filename`: Returns the filename of the database or `None` if not supported.
 /// - `migrate`: Migrates all the databases to the latest version.
@@ -88,8 +88,8 @@ impl Database {
     /// # Errors
     ///
     /// This function will return an error if no object store is found for the given prefix or if no default object store is available.
-    async fn get_object_store<'a>(
-        &'a self,
+    async fn get_object_store(
+        &self,
         uid: &str,
     ) -> DbResult<Arc<dyn ObjectsStore + Sync + Send>> {
         // split the uid on the first ::

--- a/crate/server_database/src/core/unwrapped_cache.rs
+++ b/crate/server_database/src/core/unwrapped_cache.rs
@@ -111,6 +111,7 @@ impl UnwrappedCache {
 }
 
 #[cfg(test)]
+#[allow(clippy::panic_in_result_fn)]
 mod tests {
     use std::collections::{HashMap, HashSet};
 

--- a/crate/server_database/src/stores/cached_sqlite_struct.rs
+++ b/crate/server_database/src/stores/cached_sqlite_struct.rs
@@ -68,7 +68,7 @@ impl fmt::Debug for KMSSqliteCacheItem {
 }
 
 /// Give the time since EPOCH in secs
-pub(crate) fn _now() -> DbResult<u64> {
+pub(crate) fn now() -> DbResult<u64> {
     Ok(SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .map_err(|e| {
@@ -86,7 +86,7 @@ impl KMSSqliteCacheItem {
         Ok(Self {
             sqlite: Arc::new(sqlite),
             mac,
-            inserted_at: _now()?,
+            inserted_at: now()?,
             in_used: 0,
             last_used_at: 0,
             closed: false,
@@ -191,7 +191,7 @@ impl KMSSqliteCache {
         }
 
         item.in_used += 1;
-        item.last_used_at = _now()?;
+        item.last_used_at = now()?;
 
         Ok(Arc::clone(&item.sqlite))
     }
@@ -256,7 +256,7 @@ impl KMSSqliteCache {
                     .ok_or_else(|| db_error!("Key is not in the cache"))?;
 
                 item.closed = true;
-                item.closed_at = _now()?;
+                item.closed_at = now()?;
 
                 info!("CachedSQLCipher: freeing = {item:?}");
 
@@ -310,7 +310,7 @@ impl KMSSqliteCache {
             item.sqlite = Arc::new(pool);
             item.closed = false;
             item.in_used = 1;
-            item.last_used_at = _now()?;
+            item.last_used_at = now()?;
         } else {
             trace!("CachedSQLCipher: new group_id={id}");
 
@@ -327,7 +327,7 @@ impl KMSSqliteCache {
 
             // Make it usable (to avoid direct free after alloc in case of cache overflow)
             item.in_used = 1;
-            item.last_used_at = _now()?;
+            item.last_used_at = now()?;
 
             sqlites.insert(id, item);
         }

--- a/crate/server_database/src/stores/redis/permissions.rs
+++ b/crate/server_database/src/stores/redis/permissions.rs
@@ -144,7 +144,7 @@ impl PermissionsDB {
             .await?
             .into_iter()
             .next()
-            .unwrap_or((keyword, HashSet::new()))
+            .unwrap_or_else(|| (keyword, HashSet::new()))
             .1
             .iter()
             .map(Triple::try_from)

--- a/crate/test_server/benches/rsa_benches.rs
+++ b/crate/test_server/benches/rsa_benches.rs
@@ -287,7 +287,6 @@ pub(crate) async fn encrypt(
         cleartext,
         None,
         None,
-        None,
         Some(cryptographic_parameters.to_owned()),
     )
     .unwrap();
@@ -337,7 +336,6 @@ pub(crate) async fn message_encrypt(
         pk,
         None,
         plaintext.to_vec(),
-        None,
         None,
         None,
         Some(cryptographic_parameters.to_owned()),

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+nightly-2025-01-01

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly-2024-06-09
+nightly


### PR DESCRIPTION
This MR:
- drops the use of the encrypted header, hence removing the extraneous metadata argument up to the very KMS API
- removes the policy from the attributes of the master keys;
- makes use of a now stable feature: async closures. I chose to upgrade the nightly toolchain instead of activating yet another compilation flag and benefit from the last modification of this recent feature;
- removes lots of unnecessary clones by taking ownership everywhere it is needed. Some clones remain but the data flow is much cleaner (imho);
- renames a bunch of variables/procedures to use common short names (USK, MSK, MPK) : `update_usk` is arguably easier to read than `update_user_decryption_key`, while containing the same information;
- renames a bunch of variables which name is redundant with their type/context (e.g. `let req = build_create_covercrypt_master_keypair_request` instead of `let create_request = ...` which is shorter but does not loose information since the context already makes it clear).
- removes comment that are redundant with the code, e.g.: 
```        
        // only private keys
        if owm.object().object_type() != ObjectType::PrivateKey {
            continue
        }
```