### PR TITLE
feat: bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,6 +356,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.3",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,6 +671,15 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "backon"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd0b50b1b78dbadd44ab18b3c794e496f3a139abb9fbc27d9c94c4eebbb96496"
+dependencies = [
+ "fastrand",
 ]
 
 [[package]]
@@ -1034,7 +1056,7 @@ dependencies = [
  "async-trait",
  "cosmian_crypto_core 9.6.0",
  "cosmian_findex",
- "redis",
+ "redis 0.23.3",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -1539,7 +1561,7 @@ dependencies = [
  "num-bigint-dig",
  "num_cpus",
  "rawsql",
- "redis",
+ "redis 0.31.0",
  "serde",
  "serde_json",
  "sqlx",
@@ -4227,7 +4249,7 @@ version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f49cdc0bb3f412bf8e7d1bd90fe1d9eb10bc5c399ba90973c14662a27b3f8ba"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
  "arc-swap",
  "async-trait",
  "bytes",
@@ -4242,6 +4264,32 @@ dependencies = [
  "socket2 0.4.10",
  "tokio",
  "tokio-retry",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "redis"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bc1ea653e0b2e097db3ebb5b7f678be339620b8041f66b30a308c1d45d36a7f"
+dependencies = [
+ "ahash 0.8.12",
+ "arc-swap",
+ "backon",
+ "bytes",
+ "cfg-if",
+ "combine",
+ "futures-channel",
+ "futures-util",
+ "itoa",
+ "num-bigint",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
+ "sha1_smol",
+ "socket2 0.5.9",
+ "tokio",
  "tokio-util",
  "url",
 ]

--- a/crate/server_database/Cargo.toml
+++ b/crate/server_database/Cargo.toml
@@ -28,7 +28,7 @@ num-bigint-dig = { workspace = true, features = [
 ] }
 num_cpus = { workspace = true }
 rawsql = "0.1"
-redis = { version = "0.23", features = [
+redis = { version = "0.31", features = [
     "aio",
     "ahash",
     "script",


### PR DESCRIPTION
Redis version is being upgraded elsewhere ( https://github.com/Cosmian/findex-memories/pull/1 ) , so it's better to do this here too to avoid (probably non existant) future inconcistencies between dependencies of the different repositories

No hurry not obligation to fix this but it's apreciated

I will re-open this PR later