### PR TITLE
fix: freeze server_database version

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -6,6 +6,7 @@ OLD_VERSION="$1"
 NEW_VERSION="$2"
 
 sed -i "s/$OLD_VERSION/$NEW_VERSION/g" Cargo.toml
+sed -i "s/$OLD_VERSION/$NEW_VERSION/g" crate/server_database/Cargo.toml
 sed -i "s/$OLD_VERSION/$NEW_VERSION/g" Dockerfile
 sed -i "s/$OLD_VERSION/$NEW_VERSION/g" ui/package.json
 sed -i "s/$OLD_VERSION/$NEW_VERSION/g" documentation/docs/index.md

--- a/crate/server_database/Cargo.toml
+++ b/crate/server_database/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmian_kms_server_database"
-version.workspace = true
+version = "5.3.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ui",
-    "version": "5.2.0",
+    "version": "5.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ui",
-            "version": "5.2.0",
+            "version": "5.3.0",
             "dependencies": {
                 "@ant-design/icons": "^6.0.0",
                 "@tailwindcss/vite": "^4.1.4",


### PR DESCRIPTION
Since server_database crate is used in CLI repository, need to set manually the version (otherwise a "database migration error not supported" occurs)