### PR TITLE
feat: in JWT auth, change `audience` type from `String` to `Vec<String>` 

### DIFF
--- a/crate/server/src/routes/google_cse/jwt.rs
+++ b/crate/server/src/routes/google_cse/jwt.rs
@@ -475,10 +475,10 @@ mod tests {
         );
         assert_eq!(
             authentication_token.aud,
-            Some(
+            Some(vec![
                 "764086051850-6qr4p6gpi6hn506pt8ejuq83di341hur.apps.googleusercontent.com"
                     .to_owned()
-            )
+            ])
         );
 
         // Test authorization
@@ -507,10 +507,10 @@ mod tests {
         // prev: Some("cse-authorization".to_owned())
         assert_eq!(
             authorization_token.aud,
-            Some(
+            Some(vec![
                 "764086051850-6qr4p6gpi6hn506pt8ejuq83di341hur.apps.googleusercontent.com"
                     .to_owned()
-            )
+            ])
         );
     }
 }

--- a/crate/server/src/routes/google_cse/jwt.rs
+++ b/crate/server/src/routes/google_cse/jwt.rs
@@ -205,7 +205,7 @@ pub async fn validate_cse_authentication_token(
     cse_config: &Option<GoogleCseConfig>,
     google_cse_kacls_url: &str,
     kms_default_username: &str,
-    check_email: bool,
+    is_priv_unwrap: bool,
 ) -> KResult<String> {
     debug!("validate_cse_authentication_token: entering");
     let cse_config = cse_config.as_ref().ok_or_else(|| {
@@ -243,7 +243,20 @@ pub async fn validate_cse_authentication_token(
     // When the authentication token contains the optional `google_email` claim, it must be compared against the email claim in the authorization token using a case-insensitive approach.
     // Don't use the email claim within the authentication token for this comparison.
     // In scenarios where the authentication token lacks the optional google_email claim, the email claim within the authentication token should be compared with the email claim in the authorization token, using a case-insensitive method. (Google Documentation)
-    let authentication_email = if check_email {
+    let authentication_email = if is_priv_unwrap {
+        // For `privileged_unwrap`, check that aud is `kacls-migration`
+        if let Some(migration_audience) = authentication_token.aud {
+            kms_ensure!(
+                migration_audience == vec!["kacls-migration"],
+                KmsError::Unauthorized(format!(
+                    "Audience should match: expected: kacls-migration, got: {:?}",
+                    migration_audience.join(", ")
+                ))
+            );
+        }
+        // For `privileged_unwrap` endpoint, google_email or email claim are not provided in authentication token
+        kms_default_username.to_owned()
+    } else {
         authentication_token
             .google_email
             .or(authentication_token.email)
@@ -252,9 +265,6 @@ pub async fn validate_cse_authentication_token(
                     "Authentication token should contain a google_email or an email".to_owned(),
                 )
             })?
-    } else {
-        // For `privileged_unwrap` endpoint, google_email or email claim are not provided in authentication token
-        kms_default_username.to_owned()
     };
 
     trace!("authentication token validated for {authentication_email}");
@@ -367,7 +377,7 @@ pub(crate) async fn validate_tokens(
         cse_config,
         &google_cse_kacls_url,
         &kms.params.default_username,
-        true,
+        false,
     )
     .await?;
 

--- a/crate/server/src/routes/google_cse/operations.rs
+++ b/crate/server/src/routes/google_cse/operations.rs
@@ -698,7 +698,7 @@ pub async fn privileged_wrap(
         cse_config,
         &google_cse_kacls_url,
         &kms.params.default_username,
-        true,
+        false,
     )
     .await?;
 
@@ -749,7 +749,7 @@ pub async fn privileged_unwrap(
             cse_config,
             &google_cse_kacls_url,
             &kms.params.default_username,
-            false,
+            true,
         )
         .await?
     };
@@ -817,7 +817,7 @@ pub async fn privileged_private_key_decrypt(
         cse_config,
         &google_cse_kacls_url,
         &kms.params.default_username,
-        true,
+        false,
     )
     .await?;
 

--- a/crate/server/src/tests/google_cse/mod.rs
+++ b/crate/server/src/tests/google_cse/mod.rs
@@ -856,7 +856,7 @@ async fn test_cse_custom_jwt() -> KResult<()> {
 
     // Validate custom JWT
     let result =
-        validate_cse_authentication_token(&jwt_token, &Some(cse_config), kacls_url, "admin", false)
+        validate_cse_authentication_token(&jwt_token, &Some(cse_config), kacls_url, "admin", true)
             .await;
 
     assert!(


### PR DESCRIPTION
- [x] in JWT auth, change `audience` type from `String` to `Vec<String>` 
- [x] add a fix on Gmail migration by hardcoding audience to expected value `[kacls-migration]`