### PR TITLE
fix(bug) HSM key search fails after encountering incompatible key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1217,6 +1217,7 @@ dependencies = [
  "async-trait",
  "cosmian_kms_interfaces",
  "cosmian_logger",
+ "futures",
  "libloading",
  "lru",
  "pkcs11-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,7 @@ cosmian_crypto_core = { version = "10.2", default-features = false, features = [
 ] }
 cosmian_logger = "0.5"
 der = { version = "0.7", default-features = false }
+futures = "0.3"
 hex = { version = "0.4", default-features = false }
 lazy_static = "1.5"
 leb128 = "0.2"

--- a/crate/hsm/base_hsm/Cargo.toml
+++ b/crate/hsm/base_hsm/Cargo.toml
@@ -20,6 +20,7 @@ doctest = false
 async-trait = { workspace = true }
 cosmian_kms_interfaces = { path = "../../interfaces", version = "5.9.0" }
 cosmian_logger = { workspace = true }
+futures = { workspace = true }
 libloading = { workspace = true }
 lru = { workspace = true }
 pkcs11-sys = { workspace = true }

--- a/crate/hsm/base_hsm/src/kms_hsm.rs
+++ b/crate/hsm/base_hsm/src/kms_hsm.rs
@@ -36,6 +36,7 @@ use cosmian_kms_interfaces::{
     CryptoAlgorithm, EncryptedContent, HSM, HsmKeyAlgorithm, HsmKeypairAlgorithm, HsmObject,
     HsmObjectFilter, InterfaceError, InterfaceResult, KeyMetadata, KeyType,
 };
+use cosmian_logger::debug;
 use zeroize::Zeroizing;
 
 use crate::{AesKeySize, BaseHsm, RsaKeySize, hsm_capabilities::HsmProvider};
@@ -158,8 +159,10 @@ impl<P: HsmProvider> HSM for BaseHsm<P> {
         let handles = session.list_objects(object_filter)?;
         let mut object_ids = Vec::with_capacity(handles.len());
         for handle in handles {
-            if let Some(object_id) = session.get_object_id(handle)? {
+            if let Ok(Some(object_id)) = session.get_object_id(handle) {
                 object_ids.push(object_id);
+            } else {
+                debug!("Invalid object, skipping");
             }
         }
         Ok(object_ids)

--- a/crate/hsm/base_hsm/src/session/session_impl.rs
+++ b/crate/hsm/base_hsm/src/session/session_impl.rs
@@ -1695,13 +1695,16 @@ impl Session {
                 }
                 let key_length_in_bits = modulus.len() * 8;
 
-                let label = if label_len == 0 {
+                let mut label = if label_len == 0 {
                     String::new()
                 } else {
                     String::from_utf8(label_bytes).map_err(|e| {
                         HError::Default(format!("Failed to convert label to string: {e}"))
                     })?
                 };
+                if key_type == KeyType::RsaPublicKey && !label.trim().ends_with("_pk") {
+                    label = label.trim().to_owned().add("_pk");
+                }
                 let sensitive = sensitive == CK_TRUE;
                 Ok(Some(KeyMetadata {
                     key_type,

--- a/crate/hsm/proteccio/src/tests.rs
+++ b/crate/hsm/proteccio/src/tests.rs
@@ -44,6 +44,7 @@ fn test_hsm_proteccio_all() -> HResult<()> {
     test_hsm_proteccio_multi_threaded_rsa_encrypt_decrypt_test()?;
     test_hsm_proteccio_get_key_metadata()?;
     test_hsm_proteccio_list_objects()?;
+    test_hsm_proteccio_search_incompatible_key()?;
     test_hsm_proteccio_destroy_all()?;
     Ok(())
 }
@@ -134,6 +135,14 @@ fn test_hsm_proteccio_list_objects() -> HResult<()> {
 fn test_hsm_proteccio_get_key_metadata() -> HResult<()> {
     let slot = shared::instantiate_and_get_slot::<ProteccioCapabilityProvider>(&cfg()?)?;
     shared::get_key_metadata(&slot)
+}
+
+#[test]
+#[ignore = "Requires Linux, Proteccio PKCS#11 library, and HSM environment"]
+fn test_hsm_proteccio_search_incompatible_key() -> HResult<()> {
+    let config = &cfg()?;
+    let hsm = shared::instantiate::<ProteccioCapabilityProvider>(config)?;
+    shared::search_incompatible_key(&hsm, &cfg()?)
 }
 
 #[test]

--- a/crate/hsm/smartcardhsm/src/tests.rs
+++ b/crate/hsm/smartcardhsm/src/tests.rs
@@ -48,6 +48,7 @@ fn test_hsm_smartcardhsm_all() -> HResult<()> {
     test_hsm_smartcardhsm_multi_threaded_rsa_encrypt_decrypt_test()?;
     test_hsm_smartcardhsm_get_key_metadata()?;
     test_hsm_smartcardhsm_list_objects()?;
+    test_hsm_smartcardhsm_search_incompatible_key()?;
     test_hsm_smartcardhsm_destroy_all()?;
     Ok(())
 }
@@ -162,6 +163,14 @@ fn test_hsm_smartcardhsm_list_objects() -> HResult<()> {
 fn test_hsm_smartcardhsm_get_key_metadata() -> HResult<()> {
     let slot = shared::instantiate_and_get_slot::<SmartcardHsmCapabilityProvider>(&cfg()?)?;
     shared::get_key_metadata(&slot)
+}
+
+#[test]
+#[ignore = "Requires Linux, SmartcardHSM PKCS#11 library, and HSM environment"]
+fn test_hsm_smartcardhsm_search_incompatible_key() -> HResult<()> {
+    let config = &cfg()?;
+    let hsm = shared::instantiate::<SmartcardHsmCapabilityProvider>(config)?;
+    shared::search_incompatible_key(&hsm, &cfg()?)
 }
 
 #[test]

--- a/crate/hsm/softhsm2/src/tests.rs
+++ b/crate/hsm/softhsm2/src/tests.rs
@@ -48,6 +48,7 @@ fn test_hsm_softhsm2_all() -> HResult<()> {
     test_hsm_softhsm2_multi_threaded_rsa_encrypt_decrypt_test()?;
     test_hsm_softhsm2_get_key_metadata()?;
     test_hsm_softhsm2_list_objects()?;
+    test_hsm_softhsm2_search_incompatible_key()?;
     test_hsm_softhsm2_destroy_all()?;
     Ok(())
 }
@@ -167,6 +168,14 @@ fn test_hsm_softhsm2_list_objects() -> HResult<()> {
 fn test_hsm_softhsm2_get_key_metadata() -> HResult<()> {
     let slot = shared::instantiate_and_get_slot::<SofthsmCapabilityProvider>(&cfg()?)?;
     shared::get_key_metadata(&slot)
+}
+
+#[test]
+#[ignore = "Requires Linux, SoftHSM2 library, and HSM environment"]
+fn test_hsm_softhsm2_search_incompatible_key() -> HResult<()> {
+    let config = &cfg()?;
+    let hsm = shared::instantiate::<SofthsmCapabilityProvider>(config)?;
+    shared::search_incompatible_key(&hsm, &cfg()?)
 }
 
 #[test]

--- a/crate/hsm/utimaco/src/tests.rs
+++ b/crate/hsm/utimaco/src/tests.rs
@@ -43,6 +43,7 @@ fn test_hsm_utimaco_all() -> HResult<()> {
     test_hsm_utimaco_multi_threaded_rsa_encrypt_decrypt_test()?;
     test_hsm_utimaco_get_key_metadata()?;
     test_hsm_utimaco_list_objects()?;
+    test_hsm_utimaco_search_incompatible_key()?;
     test_hsm_utimaco_destroy_all()?;
     Ok(())
 }
@@ -129,6 +130,14 @@ fn test_hsm_utimaco_list_objects() -> HResult<()> {
 fn test_hsm_utimaco_get_key_metadata() -> HResult<()> {
     let slot = shared::instantiate_and_get_slot::<UtimacoCapabilityProvider>(&cfg()?)?;
     shared::get_key_metadata(&slot)
+}
+
+#[test]
+#[ignore = "Requires Linux, Utimaco PKCS#11 library, and HSM environment"]
+fn test_hsm_utimaco_search_incompatible_key() -> HResult<()> {
+    let config = &cfg()?;
+    let hsm = shared::instantiate::<UtimacoCapabilityProvider>(config)?;
+    shared::search_incompatible_key(&hsm, &cfg()?)
 }
 
 #[test]

--- a/crate/server/Cargo.toml
+++ b/crate/server/Cargo.toml
@@ -61,7 +61,7 @@ cosmian_kms_access = { path = "../access", version = "5.9.0" }
 cosmian_kms_server_database = { path = "../server_database", version = "5.9.0" }
 cosmian_logger = { workspace = true, features = ["full"] }
 dotenvy = "0.15"
-futures = "0.3"
+futures = { workspace = true }
 hex = { workspace = true, features = ["serde"] }
 jsonwebtoken = "9.3"
 num-bigint-dig = { workspace = true, features = [


### PR DESCRIPTION
Closes #573
Also fixes a bug that was discovered due to the reorganization of HSM tests where get_key_metadata wouldn't properly return the key label for private keys on SC HSM.