### PR TITLE
Add option to enable automatic unwrapping for Get and Export requests

### DIFF
--- a/crate/server/src/config/command_line/clap_config.rs
+++ b/crate/server/src/config/command_line/clap_config.rs
@@ -45,6 +45,7 @@ impl Default for ClapConfig {
             info: false,
             hsm: HsmConfig::default(),
             key_encryption_key: None,
+            default_unwrap_type: None,
             non_revocable_key_id: None,
             privileged_users: None,
         }
@@ -91,6 +92,20 @@ pub struct ClapConfig {
     /// Force all keys imported or created in the KMS, which are not protected by a key encryption key,
     /// to be wrapped by the specified key encryption key (KEK)
     pub key_encryption_key: Option<String>,
+
+    /// Specifies which KMIP object types should be automatically unwrapped when retrieved.
+    /// Repeat this option to specify multiple object types
+    ///
+    /// e.g.
+    /// ```sh
+    ///   --default_unwrap_type SecretData \
+    ///   --default_unwrap_type SymmetricKey
+    /// ```
+    #[clap(verbatim_doc_comment,
+        long,
+        value_parser(["PrivateKey", "PublicKey", "SymmetricKey", "SecretData"])
+    )]
+    pub default_unwrap_type: Option<Vec<String>>,
 
     /// The exposed URL of the KMS - this is required if Google CSE configuration is activated.
     /// If this server is running on the domain `cse.my_domain.com` with this public URL,
@@ -330,6 +345,7 @@ impl fmt::Debug for ClapConfig {
                 .collect::<Vec<&str>>(),
         );
         let x = x.field("key wrapping key", &self.key_encryption_key);
+        let x = x.field("default unwrap type", &self.default_unwrap_type);
         let x = x.field("non_revocable_key_id", &self.non_revocable_key_id);
         let x = x.field("privileged_users", &self.privileged_users);
 

--- a/crate/server/src/config/command_line/clap_config.rs
+++ b/crate/server/src/config/command_line/clap_config.rs
@@ -95,11 +95,10 @@ pub struct ClapConfig {
 
     /// Specifies which KMIP object types should be automatically unwrapped when retrieved.
     /// Repeat this option to specify multiple object types
-    ///
     /// e.g.
     /// ```sh
-    ///   --default_unwrap_type SecretData \
-    ///   --default_unwrap_type SymmetricKey
+    ///   --default-unwrap-type SecretData \
+    ///   --default-unwrap-type SymmetricKey
     /// ```
     #[clap(verbatim_doc_comment,
         long,

--- a/crate/server/src/config/command_line/hsm_config.rs
+++ b/crate/server/src/config/command_line/hsm_config.rs
@@ -7,7 +7,7 @@ const HSM_ADMIN_DEFAULT: &str = "admin";
 #[serde(default)]
 pub struct HsmConfig {
     /// The HSM model.
-    /// Trustway Proteccio and Utimaco General purpose HSMs are supported.
+    /// `Trustway Proteccio`, `Utimaco General Purpose HSM`, `Smartcard HSM`, and `SoftHSM2` are supported.
     #[clap(
         verbatim_doc_comment,
         long,
@@ -26,8 +26,8 @@ pub struct HsmConfig {
     /// while specifying a password for each slot (or an empty string for no password)
     /// e.g.
     /// ```sh
-    ///   --hsm_slot 1 --hsm_password password1 \
-    ///   --hsm_slot 2 --hsm_password password2
+    ///   --hsm-slot 1 --hsm-password password1 \
+    ///   --hsm-slot 2 --hsm-password password2
     /// ```
     #[clap(verbatim_doc_comment, long)]
     pub hsm_slot: Vec<usize>,

--- a/crate/server/src/config/params/server_params.rs
+++ b/crate/server/src/config/params/server_params.rs
@@ -97,6 +97,14 @@ pub struct ServerParams {
     /// The Key Wrapping Key, if any
     pub key_wrapping_key: Option<String>,
 
+    /// Specifies which KMIP object types should be automatically unwrapped when retrieved
+    ///
+    /// Each entry must be the string name of a KMIP `ObjectType`, for example:
+    /// `["SecretData", "SymmetricKey"]`.
+    ///
+    /// If `None`, no automatic unwrapping will be performed.
+    pub default_unwrap_types: Option<Vec<String>>,
+
     /// The non-revocable key ID used for demo purposes
     pub non_revocable_key_id: Option<Vec<String>>,
 
@@ -203,6 +211,7 @@ impl ServerParams {
             },
             slot_passwords,
             key_wrapping_key: conf.key_encryption_key,
+            default_unwrap_types: conf.default_unwrap_type,
             non_revocable_key_id: conf.non_revocable_key_id,
             privileged_users: conf.privileged_users,
             proxy_params: ProxyParams::try_from(&conf.proxy)
@@ -229,7 +238,9 @@ impl fmt::Debug for ServerParams {
             .field("main_db_params", &self.main_db_params)
             .field("clear_db_on_start", &self.clear_db_on_start)
             .field("unwrapped_cache_max_age", &self.unwrapped_cache_max_age)
-            .field("non_revocable_key_id", &self.non_revocable_key_id);
+            .field("non_revocable_key_id", &self.non_revocable_key_id)
+            .field("key_wrapping_key", &self.key_wrapping_key)
+            .field("default_unwrap_types", &self.default_unwrap_types);
 
         if self.start_socket_server {
             debug_struct

--- a/crate/server/src/main.rs
+++ b/crate/server/src/main.rs
@@ -267,6 +267,7 @@ mod tests {
                 hsm_password: vec![],
             },
             key_encryption_key: Some("key wrapping key".to_owned()),
+            default_unwrap_type: None,
             non_revocable_key_id: None,
             privileged_users: None,
         };

--- a/crate/server/src/tests/hsm/ec_dek.rs
+++ b/crate/server/src/tests/hsm/ec_dek.rs
@@ -1,14 +1,6 @@
 use std::sync::Arc;
 
-use cosmian_kms_server_database::reexport::cosmian_kmip::kmip_2_1::{
-    kmip_operations::Operation,
-    kmip_types::{
-        CryptographicAlgorithm, CryptographicParameters, RecommendedCurve, UniqueIdentifier,
-    },
-    requests::{create_ec_key_pair_request, decrypt_request, encrypt_request},
-};
-use uuid::Uuid;
-
+use crate::tests::hsm::export_object;
 use crate::{
     config::ServerParams,
     core::KMS,
@@ -19,6 +11,15 @@ use crate::{
         test_utils::get_tmp_sqlite_path,
     },
 };
+use cosmian_kms_client_utils::reexport::cosmian_kmip::kmip_2_1::kmip_objects::ObjectType;
+use cosmian_kms_server_database::reexport::cosmian_kmip::kmip_2_1::{
+    kmip_operations::Operation,
+    kmip_types::{
+        CryptographicAlgorithm, CryptographicParameters, RecommendedCurve, UniqueIdentifier,
+    },
+    requests::{create_ec_key_pair_request, decrypt_request, encrypt_request},
+};
+use uuid::Uuid;
 
 pub(super) async fn test_wrapped_ec_dek() -> KResult<()> {
     let kek_uuid = Uuid::new_v4();
@@ -53,9 +54,7 @@ pub(super) async fn test_wrapped_ec_dek() -> KResult<()> {
     // re-instantiate the kms
     let mut clap_config = hsm_clap_config(&owner, Some(kek_uuid))?;
     clap_config.db.sqlite_path = sqlite_path.clone();
-    let Some(kek_uid) = clap_config.key_encryption_key.clone() else {
-        return Err(KmsError::Default("Missing KEK".to_owned()));
-    };
+
     let kms = Arc::new(KMS::instantiate(Arc::new(ServerParams::try_from(clap_config)?)).await?);
 
     // Encrypt with the DEK - unwrapping the DEK reloaded from the DB
@@ -65,6 +64,32 @@ pub(super) async fn test_wrapped_ec_dek() -> KResult<()> {
     // Decrypt with the DEK - using the unwrapped DEK in cache
     let plaintext = ec_decrypt(&dek_uid, &owner, &kms, &ciphertext).await?;
     assert_eq!(data.to_vec(), plaintext);
+
+    let exported_sk = export_object(&kms, &owner, &dek_uid).await?;
+    assert_eq!(exported_sk.object_type(), ObjectType::PrivateKey);
+    assert!(exported_sk.is_wrapped());
+
+    let exported_pk = export_object(&kms, &owner, &format!("{dek_uid}_pk")).await?;
+    assert_eq!(exported_pk.object_type(), ObjectType::PublicKey);
+    assert!(exported_pk.is_wrapped());
+
+    drop(kms);
+    let mut clap_config = hsm_clap_config(&owner, Some(kek_uuid))?;
+    clap_config.db.sqlite_path = sqlite_path.clone();
+    clap_config.default_unwrap_type =
+        Some(["PrivateKey".to_owned(), "PublicKey".to_owned()].to_vec());
+    let Some(kek_uid) = clap_config.key_encryption_key.clone() else {
+        return Err(KmsError::Default("Missing KEK".to_owned()));
+    };
+    let kms = Arc::new(KMS::instantiate(Arc::new(ServerParams::try_from(clap_config)?)).await?);
+
+    let exported_sk = export_object(&kms, &owner, &dek_uid).await?;
+    assert_eq!(exported_sk.object_type(), ObjectType::PrivateKey);
+    assert!(!exported_sk.is_wrapped());
+
+    let exported_pk = export_object(&kms, &owner, &format!("{dek_uid}_pk")).await?;
+    assert_eq!(exported_pk.object_type(), ObjectType::PublicKey);
+    assert!(!exported_pk.is_wrapped());
 
     // Revoke and destroy all
     revoke_key(&dek_uid, &owner, &kms).await?;

--- a/crate/server/src/tests/hsm/rsa_dek.rs
+++ b/crate/server/src/tests/hsm/rsa_dek.rs
@@ -1,15 +1,6 @@
 use std::sync::Arc;
 
-use cosmian_kms_server_database::reexport::cosmian_kmip::{
-    kmip_0::kmip_types::PaddingMethod,
-    kmip_2_1::{
-        kmip_operations::Operation,
-        kmip_types::{CryptographicAlgorithm, CryptographicParameters, UniqueIdentifier},
-        requests::{create_rsa_key_pair_request, decrypt_request, encrypt_request},
-    },
-};
-use uuid::Uuid;
-
+use crate::tests::hsm::export_object;
 use crate::{
     config::ServerParams,
     core::KMS,
@@ -20,6 +11,16 @@ use crate::{
         test_utils::get_tmp_sqlite_path,
     },
 };
+use cosmian_kms_client_utils::reexport::cosmian_kmip::kmip_2_1::kmip_objects::ObjectType;
+use cosmian_kms_server_database::reexport::cosmian_kmip::{
+    kmip_0::kmip_types::PaddingMethod,
+    kmip_2_1::{
+        kmip_operations::Operation,
+        kmip_types::{CryptographicAlgorithm, CryptographicParameters, UniqueIdentifier},
+        requests::{create_rsa_key_pair_request, decrypt_request, encrypt_request},
+    },
+};
+use uuid::Uuid;
 
 pub(super) async fn test_wrapped_rsa_dek() -> KResult<()> {
     let kek_uuid = Uuid::new_v4();
@@ -54,9 +55,6 @@ pub(super) async fn test_wrapped_rsa_dek() -> KResult<()> {
     // re-instantiate the kms
     let mut clap_config = hsm_clap_config(&owner, Some(kek_uuid))?;
     clap_config.db.sqlite_path = sqlite_path.clone();
-    let Some(kek_uid) = clap_config.key_encryption_key.clone() else {
-        return Err(KmsError::Default("Missing KEK".to_owned()));
-    };
     let kms = Arc::new(KMS::instantiate(Arc::new(ServerParams::try_from(clap_config)?)).await?);
 
     // Encrypt with the DEK - unwrapping the DEK reloaded from the DB
@@ -66,6 +64,32 @@ pub(super) async fn test_wrapped_rsa_dek() -> KResult<()> {
     // Decrypt with the DEK - using the unwrapped DEK in cache
     let plaintext = rsa_decrypt(&dek_uid, &owner, &kms, &ciphertext).await?;
     assert_eq!(data.to_vec(), plaintext);
+
+    let exported_sk = export_object(&kms, &owner, &dek_uid).await?;
+    assert_eq!(exported_sk.object_type(), ObjectType::PrivateKey);
+    assert!(exported_sk.is_wrapped());
+
+    let exported_pk = export_object(&kms, &owner, &format!("{dek_uid}_pk")).await?;
+    assert_eq!(exported_pk.object_type(), ObjectType::PublicKey);
+    assert!(exported_pk.is_wrapped());
+
+    drop(kms);
+    let mut clap_config = hsm_clap_config(&owner, Some(kek_uuid))?;
+    clap_config.db.sqlite_path = sqlite_path.clone();
+    clap_config.default_unwrap_type =
+        Some(["PrivateKey".to_owned(), "PublicKey".to_owned()].to_vec());
+    let Some(kek_uid) = clap_config.key_encryption_key.clone() else {
+        return Err(KmsError::Default("Missing KEK".to_owned()));
+    };
+    let kms = Arc::new(KMS::instantiate(Arc::new(ServerParams::try_from(clap_config)?)).await?);
+
+    let exported_sk = export_object(&kms, &owner, &dek_uid).await?;
+    assert_eq!(exported_sk.object_type(), ObjectType::PrivateKey);
+    assert!(!exported_sk.is_wrapped());
+
+    let exported_pk = export_object(&kms, &owner, &format!("{dek_uid}_pk")).await?;
+    assert_eq!(exported_pk.object_type(), ObjectType::PublicKey);
+    assert!(!exported_pk.is_wrapped());
 
     // Revoke and destroy all
     revoke_key(&dek_uid, &owner, &kms).await?;

--- a/crate/server/src/tests/hsm/secret_data_dek.rs
+++ b/crate/server/src/tests/hsm/secret_data_dek.rs
@@ -1,0 +1,127 @@
+use std::sync::Arc;
+
+use crate::tests::hsm::{export_object, import_object, revoke_key};
+use crate::{
+    config::ServerParams,
+    core::KMS,
+    error::KmsError,
+    result::KResult,
+    tests::{
+        hsm::{create_kek, delete_key, hsm_clap_config},
+        test_utils::get_tmp_sqlite_path,
+    },
+};
+use cosmian_kms_client_utils::reexport::cosmian_kmip::kmip_0::kmip_types::SecretDataType;
+use cosmian_kms_client_utils::reexport::cosmian_kmip::kmip_2_1::kmip_attributes::Attributes;
+use cosmian_kms_client_utils::reexport::cosmian_kmip::kmip_2_1::kmip_data_structures::{
+    KeyBlock, KeyMaterial, KeyValue,
+};
+use cosmian_kms_client_utils::reexport::cosmian_kmip::kmip_2_1::kmip_objects::{
+    Object, ObjectType, SecretData,
+};
+use cosmian_kms_client_utils::reexport::cosmian_kmip::kmip_2_1::kmip_types::KeyFormatType;
+use cosmian_kms_server_database::reexport::cosmian_kmip::kmip_2_1::kmip_types::UniqueIdentifier;
+use uuid::Uuid;
+use zeroize::Zeroizing;
+
+pub(super) async fn test_wrapped_secret_data() -> KResult<()> {
+    let kek_uuid = Uuid::new_v4();
+    let owner = Uuid::new_v4().to_string();
+
+    let sqlite_path = get_tmp_sqlite_path();
+
+    let mut clap_config = hsm_clap_config(&owner, Some(kek_uuid))?;
+    clap_config.db.sqlite_path = sqlite_path.clone();
+    let Some(kek_uid) = clap_config.key_encryption_key.clone() else {
+        return Err(KmsError::Default("Missing KEK".to_owned()));
+    };
+
+    let kms = Arc::new(KMS::instantiate(Arc::new(ServerParams::try_from(clap_config)?)).await?);
+
+    create_kek(&kek_uid, &owner, &kms).await?;
+
+    // create a DEK
+    let secret_id = format!("test-secret-wrapped-{}", Uuid::new_v4());
+    let data = b"Some_secret_data".to_vec();
+    let secret_data = create_secret_data(&secret_id, data.clone());
+    let imported_uid = import_object(
+        &kms,
+        &owner,
+        &secret_id,
+        &secret_data,
+        ObjectType::SecretData,
+    )
+    .await?;
+    assert_eq!(
+        imported_uid,
+        UniqueIdentifier::TextString(secret_id.clone())
+    );
+    let exported = export_object(&kms, &owner, &secret_id).await?;
+    assert_eq!(exported.object_type(), secret_data.object_type());
+
+    // stop the kms
+    drop(kms);
+    // re-instantiate the kms
+    let mut clap_config = hsm_clap_config(&owner, Some(kek_uuid))?;
+    clap_config.db.sqlite_path = sqlite_path.clone();
+    let kms = Arc::new(KMS::instantiate(Arc::new(ServerParams::try_from(clap_config)?)).await?);
+
+    let exported = export_object(&kms, &owner, &secret_id).await?;
+    assert_eq!(exported.object_type(), secret_data.object_type());
+    assert!(exported.is_wrapped());
+
+    // stop the kms
+    drop(kms);
+    // re-instantiate the kms
+    let mut clap_config = hsm_clap_config(&owner, Some(kek_uuid))?;
+    clap_config.db.sqlite_path = sqlite_path.clone();
+    clap_config.default_unwrap_type = Some(["SecretData".to_owned()].to_vec());
+    let Some(kek_uid) = clap_config.key_encryption_key.clone() else {
+        return Err(KmsError::Default("Missing KEK".to_owned()));
+    };
+    let kms = Arc::new(KMS::instantiate(Arc::new(ServerParams::try_from(clap_config)?)).await?);
+
+    let exported = export_object(&kms, &owner, &secret_id).await?;
+    assert_eq!(exported.object_type(), secret_data.object_type());
+    assert!(!exported.is_wrapped());
+    assert_eq!(
+        exported
+            .key_block()?
+            .key_value
+            .clone()
+            .unwrap()
+            .raw_bytes()?
+            .to_vec(),
+        data
+    );
+
+    // Revoke and destroy all
+    revoke_key(secret_id.as_str(), &owner, &kms).await?;
+    delete_key(secret_id.as_str(), &owner, &kms).await?;
+    delete_key(&kek_uid, &owner, &kms).await?;
+
+    Ok(())
+}
+
+fn create_secret_data(secret_id: &str, data: Vec<u8>) -> Object {
+    // create the data encryption key
+
+    Object::SecretData(SecretData {
+        secret_data_type: SecretDataType::Password,
+        key_block: KeyBlock {
+            key_format_type: KeyFormatType::Opaque,
+            key_compression_type: None,
+            key_value: Some(KeyValue::Structure {
+                key_material: KeyMaterial::ByteString(Zeroizing::from(data)),
+                attributes: Some(Attributes {
+                    object_type: Some(ObjectType::SecretData),
+                    unique_identifier: Some(UniqueIdentifier::TextString(secret_id.to_owned())),
+                    ..Default::default()
+                }),
+            }),
+            cryptographic_algorithm: None,
+            cryptographic_length: None,
+            key_wrapping_data: None,
+        },
+    })
+}

--- a/crate/server/src/tests/hsm/symmetric_dek.rs
+++ b/crate/server/src/tests/hsm/symmetric_dek.rs
@@ -1,15 +1,6 @@
 use std::sync::Arc;
 
-use cosmian_kms_server_database::reexport::cosmian_kmip::{
-    kmip_0::kmip_types::BlockCipherMode,
-    kmip_2_1::{
-        kmip_operations::Operation,
-        kmip_types::{CryptographicAlgorithm, CryptographicParameters, UniqueIdentifier},
-        requests::{decrypt_request, encrypt_request, symmetric_key_create_request},
-    },
-};
-use uuid::Uuid;
-
+use crate::tests::hsm::export_object;
 use crate::{
     config::ServerParams,
     core::KMS,
@@ -20,6 +11,16 @@ use crate::{
         test_utils::get_tmp_sqlite_path,
     },
 };
+use cosmian_kms_client_utils::reexport::cosmian_kmip::kmip_2_1::kmip_objects::ObjectType;
+use cosmian_kms_server_database::reexport::cosmian_kmip::{
+    kmip_0::kmip_types::BlockCipherMode,
+    kmip_2_1::{
+        kmip_operations::Operation,
+        kmip_types::{CryptographicAlgorithm, CryptographicParameters, UniqueIdentifier},
+        requests::{decrypt_request, encrypt_request, symmetric_key_create_request},
+    },
+};
+use uuid::Uuid;
 
 pub(super) async fn test_wrapped_symmetric_dek() -> KResult<()> {
     let kek_uuid = Uuid::new_v4();
@@ -54,9 +55,7 @@ pub(super) async fn test_wrapped_symmetric_dek() -> KResult<()> {
     // re-instantiate the kms
     let mut clap_config = hsm_clap_config(&owner, Some(kek_uuid))?;
     clap_config.db.sqlite_path = sqlite_path.clone();
-    let Some(kek_uid) = clap_config.key_encryption_key.clone() else {
-        return Err(KmsError::Default("Missing KEK".to_owned()));
-    };
+
     let kms = Arc::new(KMS::instantiate(Arc::new(ServerParams::try_from(clap_config)?)).await?);
 
     // Encrypt with the DEK - unwrapping the DEK reloaded from the DB
@@ -66,6 +65,23 @@ pub(super) async fn test_wrapped_symmetric_dek() -> KResult<()> {
     // Decrypt with the DEK - using the unwrapped DEK in cache
     let plaintext = symmetric_decrypt(&dek_uid, &owner, &kms, &ciphertext).await?;
     assert_eq!(data.to_vec(), plaintext);
+
+    let exported = export_object(&kms, &owner, &dek_uid).await?;
+    assert_eq!(exported.object_type(), ObjectType::SymmetricKey);
+    assert!(exported.is_wrapped());
+
+    drop(kms);
+    let mut clap_config = hsm_clap_config(&owner, Some(kek_uuid))?;
+    clap_config.db.sqlite_path = sqlite_path.clone();
+    clap_config.default_unwrap_type = Some(["SymmetricKey".to_owned()].to_vec());
+    let Some(kek_uid) = clap_config.key_encryption_key.clone() else {
+        return Err(KmsError::Default("Missing KEK".to_owned()));
+    };
+    let kms = Arc::new(KMS::instantiate(Arc::new(ServerParams::try_from(clap_config)?)).await?);
+
+    let exported = export_object(&kms, &owner, &dek_uid).await?;
+    assert_eq!(exported.object_type(), ObjectType::SymmetricKey);
+    assert!(!exported.is_wrapped());
 
     // Revoke and destroy all
     revoke_key(&dek_uid, &owner, &kms).await?;
@@ -87,7 +103,7 @@ async fn create_symmetric_dek(
         256,
         CryptographicAlgorithm::AES,
         EMPTY_TAGS,
-        true,
+        false,
         Some(&kek_uid.to_owned()),
     )?;
     let response =

--- a/crate/server/src/tests/secret_data_tests.rs
+++ b/crate/server/src/tests/secret_data_tests.rs
@@ -1,10 +1,21 @@
 #![allow(clippy::unwrap_in_result)]
 
-use std::sync::Arc;
-
-use cosmian_kms_client_utils::reexport::cosmian_kmip::kmip_2_1::kmip_types::{
-    CryptographicAlgorithm, EncodingOption, EncryptionKeyInformation,
+use crate::{
+    config::ServerParams, core::KMS, result::KResult, tests::test_utils::https_clap_config,
 };
+use cosmian_kms_client_utils::reexport::cosmian_kmip::kmip_0::kmip_types::{
+    KeyWrapType, SecretDataType,
+};
+use cosmian_kms_client_utils::reexport::cosmian_kmip::kmip_2_1::kmip_attributes::Attributes;
+use cosmian_kms_client_utils::reexport::cosmian_kmip::kmip_2_1::kmip_data_structures::{
+    KeyBlock, KeyMaterial, KeyValue,
+};
+use cosmian_kms_client_utils::reexport::cosmian_kmip::kmip_2_1::kmip_objects::SecretData;
+use cosmian_kms_client_utils::reexport::cosmian_kmip::kmip_2_1::kmip_operations::Import;
+use cosmian_kms_client_utils::reexport::cosmian_kmip::kmip_2_1::kmip_types::{
+    CryptographicAlgorithm, EncodingOption, EncryptionKeyInformation, KeyFormatType,
+};
+use cosmian_kms_server_database::reexport::cosmian_kmip::kmip_2_1::kmip_objects::ObjectType;
 use cosmian_kms_server_database::reexport::cosmian_kmip::{
     kmip_0::kmip_types::{RevocationReason, RevocationReasonCode},
     kmip_2_1::{
@@ -16,11 +27,10 @@ use cosmian_kms_server_database::reexport::cosmian_kmip::{
         requests::{secret_data_create_request, symmetric_key_create_request},
     },
 };
+use cosmian_logger::log_init;
+use std::sync::Arc;
 use uuid::Uuid;
-
-use crate::{
-    config::ServerParams, core::KMS, result::KResult, tests::test_utils::https_clap_config,
-};
+use zeroize::Zeroizing;
 
 #[tokio::test]
 async fn test_secret_data_create_basic() -> KResult<()> {
@@ -106,6 +116,7 @@ async fn test_secret_data_create_basic() -> KResult<()> {
 
 #[tokio::test]
 async fn test_secret_data_with_wrapping() -> KResult<()> {
+    log_init(option_env!("RUST_LOG"));
     // Instantiate KMS
     let clap_config = https_clap_config();
     let kms = Arc::new(KMS::instantiate(Arc::new(ServerParams::try_from(clap_config)?)).await?);
@@ -162,7 +173,185 @@ async fn test_secret_data_with_wrapping() -> KResult<()> {
 
     let export_response = kms.export(export_request, owner, None).await?;
     assert_ne!(export_response.unique_identifier, wrapping_key_id);
+    assert_eq!(export_response.unique_identifier, secret_id.clone());
     assert!(matches!(export_response.object, Object::SecretData(_)));
+    assert!(export_response.object.is_wrapped());
+
+    let revoke_request = Revoke {
+        unique_identifier: Some(secret_id.clone()),
+        revocation_reason: RevocationReason {
+            revocation_reason_code: RevocationReasonCode::Unspecified,
+            revocation_message: None,
+        },
+        compromise_occurrence_date: None,
+    };
+
+    kms.revoke(revoke_request, owner, None).await?;
+
+    let destroy_request = Destroy {
+        unique_identifier: Some(secret_id.clone()),
+        remove: true,
+    };
+
+    kms.destroy(destroy_request, owner, None).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_secret_data_import_export_with_kek() -> KResult<()> {
+    log_init(option_env!("RUST_LOG"));
+    // Instantiate KMS
+    let clap_config = https_clap_config();
+    let sqlite_path = clap_config.db.sqlite_path.clone();
+    let kms = Arc::new(KMS::instantiate(Arc::new(ServerParams::try_from(clap_config)?)).await?);
+    let key_material = Zeroizing::from(b"TestData".to_vec());
+    let owner = "test_secret_data_wrapping@example.com";
+
+    // create the wrapping key
+    let create_wrapping_key_request = symmetric_key_create_request(
+        None,
+        256,
+        CryptographicAlgorithm::AES,
+        EMPTY_TAGS,
+        false,
+        None,
+    )?;
+    let create_wrapping_key_response = kms
+        .create(create_wrapping_key_request, owner, None, None)
+        .await?;
+    assert!(
+        create_wrapping_key_response
+            .unique_identifier
+            .as_str()
+            .is_some()
+    );
+    let wrapping_key_id = create_wrapping_key_response.unique_identifier;
+    drop(kms);
+    let mut clap_config_kek = https_clap_config();
+    clap_config_kek.db.sqlite_path = sqlite_path.clone();
+    clap_config_kek.key_encryption_key = Some(wrapping_key_id.to_string());
+    let kms = Arc::new(KMS::instantiate(Arc::new(ServerParams::try_from(clap_config_kek)?)).await?);
+
+    let secret_id = UniqueIdentifier::TextString(format!("test-secret-wrapped-{}", Uuid::new_v4()));
+    let secret_data = Object::SecretData(SecretData {
+        secret_data_type: SecretDataType::Password,
+        key_block: KeyBlock {
+            key_format_type: KeyFormatType::Opaque,
+            key_compression_type: None,
+            key_value: Some(KeyValue::Structure {
+                key_material: KeyMaterial::ByteString(key_material.clone()),
+                attributes: Some(Attributes {
+                    object_type: Some(ObjectType::SecretData),
+                    unique_identifier: Some(secret_id.clone()),
+                    ..Default::default()
+                }),
+            }),
+            cryptographic_algorithm: None,
+            cryptographic_length: None,
+            key_wrapping_data: None,
+        },
+    });
+
+    let import_request = Import {
+        unique_identifier: secret_id.clone(),
+        object_type: ObjectType::SecretData,
+        attributes: Attributes {
+            object_type: Some(ObjectType::SecretData),
+            ..Default::default()
+        },
+        replace_existing: None,
+        key_wrap_type: None,
+        object: secret_data,
+    };
+
+    let import_response = kms.import(import_request, owner, None, None).await?;
+    assert_eq!(import_response.unique_identifier, secret_id);
+
+    // Test Export operation with wrapping enabled
+    let export_request = Export {
+        unique_identifier: Some(secret_id.clone()),
+        key_format_type: None,
+        key_compression_type: None,
+        key_wrap_type: None,
+        key_wrapping_specification: None,
+    };
+
+    let export_response = kms.export(export_request, owner, None).await?;
+    assert_eq!(
+        export_response.unique_identifier,
+        import_response.unique_identifier
+    );
+    assert!(matches!(export_response.object, Object::SecretData(_)));
+    assert!(export_response.object.is_wrapped());
+
+    // Test Export operation without wrapping
+    let export_request_unwrap = Export {
+        unique_identifier: Some(secret_id.clone()),
+        key_format_type: None,
+        key_compression_type: None,
+        key_wrap_type: Some(KeyWrapType::NotWrapped),
+        key_wrapping_specification: None,
+    };
+
+    let export_response_unwrap = kms.export(export_request_unwrap, owner, None).await?;
+    assert_eq!(
+        export_response_unwrap.unique_identifier,
+        import_response.unique_identifier
+    );
+    assert!(matches!(
+        export_response_unwrap.object,
+        Object::SecretData(_)
+    ));
+    assert!(!export_response_unwrap.object.is_wrapped());
+    assert_eq!(
+        export_response_unwrap
+            .object
+            .key_block()?
+            .key_value
+            .clone()
+            .unwrap()
+            .raw_bytes()?
+            .to_vec(),
+        key_material.to_vec()
+    );
+
+    drop(kms);
+    let mut clap_config_unwrap = https_clap_config();
+    clap_config_unwrap.db.sqlite_path = sqlite_path;
+    clap_config_unwrap.key_encryption_key = Some(wrapping_key_id.to_string());
+    clap_config_unwrap.default_unwrap_type = Some(["SecretData".to_owned()].to_vec());
+    let kms =
+        Arc::new(KMS::instantiate(Arc::new(ServerParams::try_from(clap_config_unwrap)?)).await?);
+
+    // Test Export operation with default unwrapping
+    let export_request_default_unwrap = Export {
+        unique_identifier: Some(secret_id.clone()),
+        key_format_type: None,
+        key_compression_type: None,
+        key_wrap_type: None,
+        key_wrapping_specification: None,
+    };
+
+    let export_response_default_unwrap = kms
+        .export(export_request_default_unwrap, owner, None)
+        .await?;
+    assert!(matches!(
+        export_response_default_unwrap.object,
+        Object::SecretData(_)
+    ));
+    assert!(!export_response_default_unwrap.object.is_wrapped());
+    assert_eq!(
+        export_response_default_unwrap
+            .object
+            .key_block()?
+            .key_value
+            .clone()
+            .unwrap()
+            .raw_bytes()?
+            .to_vec(),
+        key_material.to_vec()
+    );
 
     let revoke_request = Revoke {
         unique_identifier: Some(secret_id.clone()),

--- a/documentation/docs/server_cli.md
+++ b/documentation/docs/server_cli.md
@@ -162,7 +162,7 @@ Options:
           Print the server configuration information and exit
       --hsm-model <HSM_MODEL>
           The HSM model.
-          Trustway Proteccio and Utimaco General purpose HSMs are supported. [default: proteccio] [possible values: proteccio, utimaco]
+          Trustway Proteccio, Utimaco General purpose HSM, Smartcard HSM, and SoftHSM2 are supported. [default: proteccio] [possible values: proteccio, utimaco, softhsm2, smartcardhsm]--hsm-admin <HSM_ADMIN>
       --hsm-admin <HSM_ADMIN>
           The username of the HSM admin. The HSM admin can create objects on the HSM, destroy them, and potentially export them [env: KMS_HSM_ADMIN=] [default: admin]
       --hsm-slot <HSM_SLOT>
@@ -170,14 +170,19 @@ Options:
           Repeat this option to specify multiple slots
           while specifying a password for each slot (or an empty string for no password)
           e.g.
-          ```sh
-            --hsm_slot 1 --hsm_password password1 \
-            --hsm_slot 2 --hsm_password password2
-          ```
+            --hsm-slot 1 --hsm-password password1 \
+            --hsm-slot 2 --hsm-password password2
       --hsm-password <HSM_PASSWORD>
           Password for the user logging in to the HSM Slot specified with `--hsm_slot`
           Provide an empty string for no password
           see `--hsm_slot` for more information
+      --default-unwrap-type <DEFAULT_UNWRAP_TYPE>
+          Specifies which KMIP object types should be automatically unwrapped when retrieved.
+          Repeat this option to specify multiple object types
+          e.g.
+            --default-unwrap-type SecretData \
+            --default-unwrap-type SymmetricKey
+          [possible values: PrivateKey, PublicKey, SymmetricKey, SecretData]
       --kms-public-url <KMS_PUBLIC_URL>
           The exposed URL of the KMS - this is required if Google CSE configuration is activated.
           If this server is running on the domain `cse.my_domain.com` with this public URL,

--- a/documentation/docs/server_configuration_file.md
+++ b/documentation/docs/server_configuration_file.md
@@ -60,6 +60,10 @@ hsm_password = ["<password_of_1st_slot1>", "<password_of_2bd_slot2>", ...]
 # Note: This setting is ignored when a key is imported in JSON TTLV format and is already wrapped.
 key_encryption_key = "kek ID"
 
+# Specifies which KMIP object types should be automatically unwrapped when retrieved.
+# Valid values: ["PrivateKey", "PublicKey", "SymmetricKey", "SecretData"]
+default_unwrap_type = []
+
 # All users can create and import objects in the KMS by default.
 # Only these users can create and import objects when this setting contains a user ID list.
 privileged_users = ["<user_id_1>", "<user_id_2>"]


### PR DESCRIPTION
Closes #578
This PR introduces a new configuration option, `default_unwrap_types`, which enables automatic unwrapping of objects for specified ObjectTypes when performing a `Get` or `Export` operation without explicitly providing a `KeyWrapType`.

Added tests for object export and unwrap behavior.

Updated documentation to describe the new configuration option.