### PR TITLE
Update README.md

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -30,6 +30,7 @@ wasm-pack build --target web --release --features non-fips
 Then copy the generated `pkg` directory into the React app's source tree:
 
 ```bash
+mkdir ../../ui/src/wasm/
 cp -R pkg ../../ui/src/wasm/
 ```
 


### PR DESCRIPTION
The wasm directory is not in the ui source tree. When you cp pkg in ui/src the directory get renamed and the ui does not buld.