### PR TITLE
ci: automate release workflow

### DIFF
--- a/.github/.markdown-link-check.json
+++ b/.github/.markdown-link-check.json
@@ -51,5 +51,13 @@
     {
       "pattern": "github.com/Cosmian/kms/pull"
     }
+  ],
+  "timeout": "20s",
+  "retryOn429": true,
+  "retryCount": 3,
+  "fallbackRetryDelay": "30s",
+  "aliveStatusCodes": [
+    200,
+    206
   ]
 }

--- a/.github/README_WORKFLOWS.md
+++ b/.github/README_WORKFLOWS.md
@@ -9,6 +9,7 @@ flowchart LR
     subgraph entry["Entry Point Workflows"]
         main["main.yml<br/>(Push CI)<br/><br/>Triggers:<br/>· Push<br/>· Schedule<br/>· Manual"]
         pr["pr.yml<br/>(PR CI)<br/><br/>Triggers:<br/>· Tags<br/>· Pull Requests<br/>· Schedule<br/>· Manual"]
+        release["release.yml<br/>(Automated Release)<br/><br/>Triggers:<br/>· Manual (workflow_dispatch)<br/>  with old_version + new_version"]
         cleanup["github_cache_cleanup.yml<br/><br/>Triggers:<br/>· Manual (workflow_dispatch)"]
     end
 ```
@@ -169,12 +170,12 @@ flowchart TB
 
 ### Packaging Matrix Visualization
 
-| Runner          | FIPS         | Non-FIPS     | Output        |
-|-----------------|:------------:|:------------:|---------------|
-| ubuntu-24.04    | ✓ (S+D)      | ✓ (S+D)      | .deb, .rpm    |
-| ubuntu-24.04-arm | ✓ (S+D)     | ✓ (S+D)      | .deb, .rpm    |
-| macos-15        | ✗            | ✓ (S+D)      | .dmg          |
-| windows-2022    | ✓ (DLLs)     | ✓            | .exe          |
+| Runner           | FIPS         | Non-FIPS     | Output        |
+|------------------|:------------:|:------------:|---------------|
+| ubuntu-24.04     | ✓ (S+D)      | ✓ (S+D)      | .deb, .rpm    |
+| ubuntu-24.04-arm | ✓ (S+D)      | ✓ (S+D)      | .deb, .rpm    |
+| macos-15         | ✗            | ✓ (S+D)      | .dmg          |
+| windows-2022     | ✓ (DLLs)     | ✓            | .exe          |
 
 > Note: (S+D) = Static and Dynamic linking variants
 
@@ -381,6 +382,7 @@ flowchart TB
 | ------------------------ | :-----: | :---: | :-----: | :---------: | :----: |
 | main.yml (Push CI)       |   ✓     |   -   |    -    |  ✓ (daily)  |   ✓    |
 | pr.yml (PR CI)           |   -     |   ✓   |    ✓    |  ✓ (daily)  |   ✓    |
+| release.yml (Release)    |   -     |   -   |    -    |      -      |   ✓    |
 | main_base.yml            |   -     |   -   |    -    |      -      | via WC |
 | packaging.yml            |   -     |   -   |    -    |      -      | ✓, WC  |
 | packaging-docker.yml     |   -     |   -   |    -    |      -      | ✓, WC  |
@@ -406,7 +408,7 @@ flowchart TB
 - **GPG_SIGNING_KEY**: Package signing
 - **GPG_SIGNING_KEY_PASSPHRASE**: Package signing
 - **CRATES_IO**: Cargo publish token
-- **PAT_TOKEN**: Public documentation deployment
+- **PAT_TOKEN**: Public documentation deployment and release automation
 
 ### HSM Secrets
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,23 +37,23 @@ curl -s -X POST -H "Content-Type: application/json" -d '{}' http://localhost:999
 
 ### Cargo aliases (`.cargo/config.toml`)
 
-| Alias | Expands to |
-|---|---|
-| `format` | `fmt --all -- --check` |
-| `build-all` | `build --workspace --all-targets --all-features --bins` |
-| `test-fips` | `test --lib --workspace` |
-| `test-non-fips` | `test --lib --workspace --features non-fips` |
-| `clippy-all` | `clippy --workspace --all-targets --all-features -- -D warnings` |
+| Alias           | Expands to                                                       |
+| --------------- | ---------------------------------------------------------------- |
+| `format`        | `fmt --all -- --check`                                           |
+| `build-all`     | `build --workspace --all-targets --all-features --bins`          |
+| `test-fips`     | `test --lib --workspace`                                         |
+| `test-non-fips` | `test --lib --workspace --features non-fips`                     |
+| `clippy-all`    | `clippy --workspace --all-targets --all-features -- -D warnings` |
 
 ### Database test environment
 
 Start backends with `docker compose up -d`, then set:
 
-| Variable | Value |
-|---|---|
+| Variable           | Value                                     |
+| ------------------ | ----------------------------------------- |
 | `KMS_POSTGRES_URL` | `postgresql://kms:kms@127.0.0.1:5432/kms` |
-| `KMS_MYSQL_URL` | `mysql://kms:kms@localhost:3306/kms` |
-| `KMS_SQLITE_PATH` | `data/shared` |
+| `KMS_MYSQL_URL`    | `mysql://kms:kms@localhost:3306/kms`      |
+| `KMS_SQLITE_PATH`  | `data/shared`                             |
 
 > MySQL tests are currently disabled in CI.
 > Redis-findex tests are skipped in FIPS mode.
@@ -143,10 +143,10 @@ crate/server/src/core/kms/mod.rs              — KMS struct (params, database, 
 
 Enterprise routes:
 
-- `crate/server/src/routes/aws_xks/`   — AWS XKS
+- `crate/server/src/routes/aws_xks/` — AWS XKS
 - `crate/server/src/routes/azure_ekm/` — Azure EKM
 - `crate/server/src/routes/google_cse/` — Google CSE
-- `crate/server/src/routes/ms_dke/`    — Microsoft DKE
+- `crate/server/src/routes/ms_dke/` — Microsoft DKE
 
 You must always verify that changes related to KMIP protocol are compliant with KMIP specifications (HTML files found in crate/kmip/src)
 
@@ -156,8 +156,8 @@ You must always verify that changes related to KMIP protocol are compliant with 
 
 When you need to change something, start here:
 
-| Intent | File(s) |
-|---|---|
+| Intent                      | File(s)                                           |
+| --------------------------- | ------------------------------------------------- |
 | Add/change a KMIP operation | `crate/server/src/core/operations/<operation>.rs` |
 | KMIP operation dispatcher | `crate/server/src/core/operations/dispatch.rs` |
 | KMS struct definition | `crate/server/src/core/kms/mod.rs` |
@@ -181,13 +181,13 @@ When you need to change something, start here:
 
 ## 5. Feature flags
 
-| Flag | Default | Effect |
-|---|---|---|
-| *(none / fips)* | **on** | FIPS-140-3 mode; only NIST-approved algorithms; loads FIPS provider |
-| `non-fips` | off | Legacy OpenSSL provider, Covercrypt, Redis-findex, PQC CLI module, AES-XTS |
-| `interop` | **on** | Enables extra KMIP interoperability test operations (on by default; do not disable in tests) |
-| `insecure` | off | Skips OAuth token expiration check and allows self-signed TLS — **dev/test only** |
-| `timeout` | off | Makes the server binary expire at a compile-time-chosen date |
+| Flag            | Default | Effect                                                                                       |
+| --------------- | ------- | -------------------------------------------------------------------------------------------- |
+| _(none / fips)_ | **on**  | FIPS-140-3 mode; only NIST-approved algorithms; loads FIPS provider                          |
+| `non-fips`      | off     | Legacy OpenSSL provider, Covercrypt, Redis-findex, PQC CLI module, AES-XTS                   |
+| `interop`       | **on**  | Enables extra KMIP interoperability test operations (on by default; do not disable in tests) |
+| `insecure`      | off     | Skips OAuth token expiration check and allows self-signed TLS — **dev/test only**            |
+| `timeout`       | off     | Makes the server binary expire at a compile-time-chosen date                                 |
 
 Use `--features non-fips` to enable all non-approved algorithms.
 
@@ -224,23 +224,23 @@ bash .github/scripts/nix.sh [--variant fips|non-fips] [--link static|dynamic] CO
 
 ### Test types (`nix.sh test <type>`)
 
-| Type | FIPS? | Script | Notes |
-|---|---|---|---|
-| `sqlite` | yes | `test_sqlite.sh` | Default DB backend |
-| `psql` | yes | `test_psql.sh` | Requires PostgreSQL |
-| `mysql` | yes | `test_mysql.sh` | Disabled in CI |
-| `percona` | yes | `test_percona.sh` | Percona XtraDB |
-| `mariadb` | yes | `test_maria.sh` | MariaDB |
-| `wasm` | yes | `test_wasm.sh` | WASM package build + tests |
-| `google_cse` | yes | `test_google_cse.sh` | Requires OAuth creds |
-| `gcp_cmek` | yes | `test_gcp_cmek.sh` | GCP CMEK wrapping |
-| `otel_export` | yes | `test_otel_export.sh` | OpenTelemetry metrics |
-| `hsm [backend]` | yes | `test_hsm_*.sh` | softhsm2 / utimaco / proteccio / all |
-| `redis` | **no** | `test_redis.sh` | Redis-findex (non-FIPS only) |
-| `pykmip` | **no** | `test_pykmip.sh` | PyKMIP + Synology DSM |
-| `aws_xks` | **no** | `aws_xks_test.sh` | AWS XKS |
-| `azure_ekm` | **no** | `azure_ekm_test.sh` | Azure EKM |
-| `ui` | **no** | `test_ui.sh` | Playwright E2E (see §8) |
+| Type            | FIPS?  | Script                | Notes                                |
+| --------------- | ------ | --------------------- | ------------------------------------ |
+| `sqlite`        | yes    | `test_sqlite.sh`      | Default DB backend                   |
+| `psql`          | yes    | `test_psql.sh`        | Requires PostgreSQL                  |
+| `mysql`         | yes    | `test_mysql.sh`       | Disabled in CI                       |
+| `percona`       | yes    | `test_percona.sh`     | Percona XtraDB                       |
+| `mariadb`       | yes    | `test_maria.sh`       | MariaDB                              |
+| `wasm`          | yes    | `test_wasm.sh`        | WASM package build + tests           |
+| `google_cse`    | yes    | `test_google_cse.sh`  | Requires OAuth creds                 |
+| `gcp_cmek`      | yes    | `test_gcp_cmek.sh`    | GCP CMEK wrapping                    |
+| `otel_export`   | yes    | `test_otel_export.sh` | OpenTelemetry metrics                |
+| `hsm [backend]` | yes    | `test_hsm_*.sh`       | softhsm2 / utimaco / proteccio / all |
+| `redis`         | **no** | `test_redis.sh`       | Redis-findex (non-FIPS only)         |
+| `pykmip`        | **no** | `test_pykmip.sh`      | PyKMIP + Synology DSM                |
+| `aws_xks`       | **no** | `aws_xks_test.sh`     | AWS XKS                              |
+| `azure_ekm`     | **no** | `azure_ekm_test.sh`   | Azure EKM                            |
+| `ui`            | **no** | `test_ui.sh`          | Playwright E2E (see §8)              |
 
 ### Package types (`nix.sh package [type]`)
 
@@ -254,14 +254,14 @@ bash .github/scripts/nix.sh docker --variant non-fips --load --test
 
 ### Workflow files
 
-| Workflow | Purpose |
-|---|---|
+| Workflow                     | Purpose                                                              |
+| ---------------------------- | -------------------------------------------------------------------- |
 | `main.yml` → `main_base.yml` | Push/PR trigger; runs clippy, cargo-deny, cargo-test, test_all, docs |
-| `test_all.yml` | Nix-based test matrix: 15 types × 2 variants + HSM matrix |
-| `packaging.yml` | Multi-platform packaging (Linux/ARM/macOS), GPG-signed |
-| `packaging-docker.yml` | Docker image builds (fips + non-fips) |
-| `test_windows.yml` | Windows-only build + test |
-| `build_windows.yml` | Windows server + UI builder |
+| `test_all.yml`               | Nix-based test matrix: 15 types × 2 variants + HSM matrix            |
+| `packaging.yml`              | Multi-platform packaging (Linux/ARM/macOS), GPG-signed               |
+| `packaging-docker.yml`       | Docker image builds (fips + non-fips)                                |
+| `test_windows.yml`           | Windows-only build + test                                            |
+| `build_windows.yml`          | Windows server + UI builder                                          |
 
 ---
 
@@ -307,11 +307,11 @@ Update ui/tests/e2e/README.md according to ui/tests/e2e/ tests.
 
 The UI has three test layers — all must pass before merging:
 
-| Layer | Runner | Location | Config |
-|---|---|---|---|
-| E2E | Playwright | `ui/tests/e2e/` | `ui/playwright.config.ts` |
-| Integration | Vitest | `ui/tests/integration/` | `ui/tests/vitest.int.config.ts` |
-| Unit | Vitest | `ui/tests/unit/` | `ui/tests/vitest.unit.config.ts` |
+| Layer       | Runner     | Location                | Config                           |
+| ----------- | ---------- | ----------------------- | -------------------------------- |
+| E2E         | Playwright | `ui/tests/e2e/`         | `ui/playwright.config.ts`        |
+| Integration | Vitest     | `ui/tests/integration/` | `ui/tests/vitest.int.config.ts`  |
+| Unit        | Vitest     | `ui/tests/unit/`        | `ui/tests/vitest.unit.config.ts` |
 
 ### UI test conventions
 
@@ -383,11 +383,16 @@ GH_PAGER=cat gh run list --repo Cosmian/kms --limit 10
 
 ## 11. Updating CHANGELOG.md
 
-For each change, add a **one-line summary** in `CHANGELOG/<branch_name_without_slashes>.md` that will be committed (replace in branch name `/` with `_`), except if the change is already described in it. Use the formatting style of existing entries and respect the existing sections convention (Features, Bug Fixes, Build, Refactor, Documentation, Testing, CI, Security). Under a CHANGELOG section, try regrouping by sub-feature or component if multiple entries relate to the same area (e.g. "KMIP operations", "Web UI", "PostgreSQL backend"). This helps maintain readability as the number of entries grows.
+> **IMPORTANT — file location**: Changes go in `CHANGELOG/<branch_name_without_slashes>.md`
+> (replace `/` with `_` in the branch name, e.g. branch `feature/foo` → `CHANGELOG/feature_foo.md`).
+> The **root `CHANGELOG.md` is generated by `git-cliff` and must NEVER be edited manually.**
+> If the branch-specific file does not exist yet, create it.
 
-In addition, add when possible the GitHub PR or GitHub issue related and add on this CHANGELOG.md item at the EOL a link like this ([#XXX](https://github.com/Cosmian/kms/issues/XXX)) or ([#XXX](https://github.com/Cosmian/kms/pull/XXX)).
+For each change, add a **one-line summary** in the branch-specific file, except if the change is already described in it. Use the formatting style of existing CHANGELOG entries and respect the sections convention: `Features`, `Bug Fixes`, `Build`, `Refactor`, `Documentation`, `Testing`, `CI`, `Security`. Under a section, try regrouping by sub-feature or component when multiple entries relate to the same area (e.g. "KMIP operations", "Web UI", "PostgreSQL backend").
 
-Finally, add at bottom of the file if not already exists, the as many "Closes #xxx" it requires to automatically close the related issues when the PR is merged.
+In addition, add when possible the GitHub PR or GitHub issue related and add on this CHANGELOG item at the EOL a link like this ([#XXX](https://github.com/Cosmian/kms/issues/XXX)) or ([#XXX](https://github.com/Cosmian/kms/pull/XXX)).
+
+Finally, add at the bottom of the file, if not already present, as many `Closes #xxx` lines as needed to automatically close the related issues when the PR is merged.
 
 ---
 
@@ -439,14 +444,14 @@ Repeat for all four combinations (`fips`/`non-fips` × `dynamic`/`static`).
 
 ## 14. Common issues
 
-| Symptom | Cause | Fix |
-|---|---|---|
-| Usage mask errors (`Encrypt`, `Sign` denied) | Key missing required `CryptographicUsageMask` | Check the object's attributes |
-| `legacy.so` / `fips.so` not found | `OPENSSL_MODULES` not set | Ensure `apply_openssl_dir_env_if_needed()` in `openssl_providers.rs` is called before `Provider::try_load()` |
-| Stale Nix vendor hashes | `Cargo.lock` or version changed | Regenerate all four hash files (see §13) |
-| `gh` command hangs | Interactive pager opened | Use `GH_PAGER=cat gh ...` |
-| Playwright `toHaveText` type error with `exact` | Unsupported option in Playwright | Use anchored regex instead: `toHaveText(/^\s*Label\s*$/)` |
-| TypeScript unused-variable error in UI tests | `noUnusedLocals: true` in tsconfig | Remove the variable or prefix with `_` |
+| Symptom                                         | Cause                                         | Fix                                                                                                          |
+| ----------------------------------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Usage mask errors (`Encrypt`, `Sign` denied)    | Key missing required `CryptographicUsageMask` | Check the object's attributes                                                                                |
+| `legacy.so` / `fips.so` not found               | `OPENSSL_MODULES` not set                     | Ensure `apply_openssl_dir_env_if_needed()` in `openssl_providers.rs` is called before `Provider::try_load()` |
+| Stale Nix vendor hashes                         | `Cargo.lock` or version changed               | Regenerate all four hash files (see §13)                                                                     |
+| `gh` command hangs                              | Interactive pager opened                      | Use `GH_PAGER=cat gh ...`                                                                                    |
+| Playwright `toHaveText` type error with `exact` | Unsupported option in Playwright              | Use anchored regex instead: `toHaveText(/^\s*Label\s*$/)`                                                    |
+| TypeScript unused-variable error in UI tests    | `noUnusedLocals: true` in tsconfig            | Remove the variable or prefix with `_`                                                                       |
 
 ---
 
@@ -491,13 +496,13 @@ The integrations section is the most commonly extended area. Keep these four vie
 
 **README.md `## 🔗 Integrations` section categories must mirror mkdocs.yml exactly:**
 
-| README section | mkdocs.yml grouping | Files location |
-|---|---|---|
-| ☁️ Cloud Provider — External Key Management | `Cloud providers:` | `integrations/cloud_providers/` |
-| 🗄️ Database Integrations | `Databases:` | `integrations/databases/` |
-| 💿 Disk Encryption | `Disk encryption:` (under `Storage:`) | `integrations/disk_encryption/` |
-| 💾 Storage Integrations | `Storage:` | `integrations/storage/` |
-| 🔗 Other Integrations | `Other:` | `integrations/` root |
+| README section                              | mkdocs.yml grouping                   | Files location                  |
+| ------------------------------------------- | ------------------------------------- | ------------------------------- |
+| ☁️ Cloud Provider — External Key Management | `Cloud providers:`                    | `integrations/cloud_providers/` |
+| 🗄️ Database Integrations                    | `Databases:`                          | `integrations/databases/`       |
+| 💿 Disk Encryption                          | `Disk encryption:` (under `Storage:`) | `integrations/disk_encryption/` |
+| 💾 Storage Integrations                     | `Storage:`                            | `integrations/storage/`         |
+| 🔗 Other Integrations                       | `Other:`                              | `integrations/` root            |
 
 **When adding a new integration**:
 

--- a/.github/scripts/release/nix_build_update_hash.sh
+++ b/.github/scripts/release/nix_build_update_hash.sh
@@ -20,15 +20,27 @@ MAX_RETRIES=3
 OS="linux"
 [[ "$(uname -s)" == "Darwin" ]] && OS="darwin"
 
-# Ordered list of derivations to build: ui first, then cli, then server.
-ALL_ATTRS=(
-  ui-fips
-  ui-non-fips
-  kms-cli-fips-static-openssl
-  kms-cli-non-fips-dynamic-openssl
-  kms-server-fips-static-openssl
-  kms-server-non-fips-dynamic-openssl
-)
+# Ordered list of derivations to build, split by platform:
+#   Linux  — all derivations (server + cli + ui wasm + ui pnpm)
+#   macOS  — only UI (for ui.pnpm.darwin) + CLI (for cli.vendor.*.darwin)
+#             server derivations are Linux-only and must NOT run on macOS.
+if [[ "$OS" == "darwin" ]]; then
+  ALL_ATTRS=(
+    ui-fips
+    ui-non-fips
+    kms-cli-fips-static-openssl
+    kms-cli-non-fips-dynamic-openssl
+  )
+else
+  ALL_ATTRS=(
+    ui-fips
+    ui-non-fips
+    kms-cli-fips-static-openssl
+    kms-cli-non-fips-dynamic-openssl
+    kms-server-fips-static-openssl
+    kms-server-non-fips-dynamic-openssl
+  )
+fi
 
 # ── hash-file mapping ─────────────────────────────────────────────────────────
 # Map a Nix derivation name + the -A attribute to the expected-hash file it controls.
@@ -41,9 +53,12 @@ drv_to_hash_file() {
     echo "$EXPECTED_DIR/ui.pnpm.${OS}.sha256"; return
   fi
   if [[ "$drv_name" =~ ui-wasm-non-fips.*vendor ]]; then
+    # ui.vendor.*.sha256 are Linux-only; skip on macOS to avoid overwriting them.
+    [[ "$OS" != "linux" ]] && echo "" && return
     echo "$EXPECTED_DIR/ui.vendor.non-fips.sha256"; return
   fi
   if [[ "$drv_name" =~ ui-wasm-fips.*vendor ]]; then
+    [[ "$OS" != "linux" ]] && echo "" && return
     echo "$EXPECTED_DIR/ui.vendor.fips.sha256"; return
   fi
   if [[ "$drv_name" =~ (cosmian-kms-cli|ckms).*vendor|cli.*vendor ]]; then
@@ -55,6 +70,8 @@ drv_to_hash_file() {
     echo "$EXPECTED_DIR/cli.vendor.${link}.darwin.sha256"; return
   fi
   if [[ "$drv_name" =~ (kms-server|server).*vendor ]]; then
+    # server.vendor.*.sha256 are Linux-only; skip on macOS.
+    [[ "$OS" != "linux" ]] && echo "" && return
     local link="static"
     [[ "$drv_name" == *dynamic* || "$attr" == *dynamic* ]] && link="dynamic"
     echo "$EXPECTED_DIR/server.vendor.${link}.sha256"; return

--- a/.github/scripts/release/release.sh
+++ b/.github/scripts/release/release.sh
@@ -5,6 +5,14 @@ set -ex
 OLD_VERSION="$1"
 NEW_VERSION="$2"
 
+# When --ci is passed as a third argument, skip the pre-commit hooks section.
+# The CI workflow handles those checks (Nix hash updates, SBOM, UI build) as
+# dedicated jobs with the appropriate environments.
+CI_MODE=false
+if [ "${3:-}" = "--ci" ]; then
+  CI_MODE=true
+fi
+
 # Use SED_BINARY from environment if set, otherwise default to 'sed'
 # On MacOS - install gnu-sed with brew
 if command -v gsed >/dev/null 2>&1; then
@@ -60,6 +68,17 @@ ${SED_BINARY} "${SED_IN_PLACE[@]}" "s/$OLD_VERSION/$NEW_VERSION/g" cli_documenta
 
 ${SED_BINARY} "${SED_IN_PLACE[@]}" "s/$OLD_VERSION/$NEW_VERSION/g" README.md
 ${SED_BINARY} "${SED_IN_PLACE[@]}" "s/$OLD_VERSION/$NEW_VERSION/g" .github/copilot-instructions.md
+
+# Skip all pre-commit hooks when running in CI mode.
+# The workflow handles each concern as a dedicated job:
+#   - Nix hash updates  : the `update-nix-hashes` CI job
+#   - SBOM / CBOM       : the `commit-sbom` CI job
+#   - Full lint pass    : the regular CI pipeline that is already triggered
+#                         by the branch push
+if [ "$CI_MODE" = "true" ]; then
+  echo "CI mode: skipping pre-commit hooks (handled by dedicated CI jobs)"
+  exit 0
+fi
 
 # pre-commit run -a --hook-stage manual release-git-cliff
 pre-commit run -a --hook-stage manual cbom || true

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -40,12 +40,12 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Install dependencies (jq, bc)
+      - name: Install dependencies (jq, bc, OpenSSL)
         run: |
           if command -v apt-get >/dev/null 2>&1; then
-            sudo apt-get update -qq && sudo apt-get install -y -qq jq bc curl
+            sudo apt-get update -qq && sudo apt-get install -y -qq jq bc curl pkg-config libssl-dev
           elif command -v brew >/dev/null 2>&1; then
-            brew install jq bc
+            brew install jq bc openssl pkg-config
           fi
 
       - name: Run benchmark regression analysis

--- a/.github/workflows/main_base.yml
+++ b/.github/workflows/main_base.yml
@@ -67,14 +67,6 @@ jobs:
           fi
           cargo test --workspace --lib $FEATURES_FLAG -- --nocapture
 
-  cargo-publish:
-    name: Cargo Publish Workspace
-    uses: ./.github/workflows/cargo-publish.yml
-    with:
-      toolchain: ${{ inputs.toolchain }}
-    secrets:
-      token: ${{ secrets.CRATES_IO }}
-
   test: # Run all tests
     if: github.event.pull_request.head.repo.full_name == github.repository && !startsWith(github.ref_name, 'dependabot/') && github.actor != 'dependabot[bot]'
       || startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -20,12 +20,18 @@ jobs:
     uses: ./.github/workflows/packaging-docker.yml
     with:
       toolchain: 1.90.0
-    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' || startsWith(github.ref, 'refs/tags/')
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
+      || startsWith(github.ref, 'refs/tags/')
+      || github.event_name == 'workflow_dispatch'
 
   packages:
     name: ${{ matrix.runner }}-${{ matrix.features }}-${{ matrix.link }}
     runs-on: ${{ matrix.runner }}
-    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' || startsWith(github.ref, 'refs/tags/')
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
+      || startsWith(github.ref, 'refs/tags/')
+      || github.event_name == 'workflow_dispatch'
 
     strategy:
       fail-fast: false
@@ -103,7 +109,10 @@ jobs:
           if-no-files-found: error
 
   publish-release:
-    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' || startsWith(github.ref, 'refs/tags/')
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
+      || startsWith(github.ref, 'refs/tags/')
+      || github.event_name == 'workflow_dispatch'
 
     name: Publish ${{ matrix.runner }}-${{ matrix.features }}-${{ matrix.link }}
     needs: packages
@@ -216,7 +225,10 @@ jobs:
             ./nix/signing-keys/cosmian-kms-public.asc
 
   publish-sbom:
-    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' || startsWith(github.ref, 'refs/tags/')
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
+      || startsWith(github.ref, 'refs/tags/')
+      || github.event_name == 'workflow_dispatch'
 
     name: Publish SBOM ${{ matrix.features }}-${{ matrix.link }}
     needs: packages
@@ -266,6 +278,13 @@ jobs:
               sbom/${target}/${{ matrix.features }}/${{ matrix.link }}/* \
               cosmian@package.cosmian.com:"${remote_dir}/"
           done
+
+  cargo-publish:
+    uses: ./.github/workflows/cargo-publish.yml
+    with:
+      toolchain: 1.90.0
+    secrets:
+      token: ${{ secrets.CRATES_IO }}
 
   tests:
     needs: packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,559 @@
+---
+name: Release
+
+# Fully automated release workflow.
+#
+# What it does:
+#   1. Validates semver inputs and checks the release branch does not exist yet.
+#   2. Creates "release/<new_version>" from develop (matching the git-flow model).
+#   3. Runs the version-bump script (.github/scripts/release/release.sh).
+#   4. Commits the bumped versions on the release branch and pushes it.
+#   5. Regenerates the CBOM (cbom/cbom.cdx.json) via generate_cbom.sh.
+#   6. Runs `nix_build_update_hash.sh` on BOTH Linux and macOS runners in
+#      parallel to recompute all Nix vendor hashes (Linux writes server +
+#      linux-cli + UI wasm hashes; macOS writes darwin-cli + UI pnpm hashes)
+#      and commits the results.
+#   7. Dispatches pr.yml on the release branch to trigger the packaging CI,
+#      then polls until that run completes (the packaging CI publishes SBOMs
+#      to package.cosmian.com at last_build/release/<new_version>).
+#   8. Retrieves the generated SBOMs from package.cosmian.com and commits them.
+#   9. Git-flow finalisation (mirrors `git flow release finish`):
+#        a. Merges release/<new_version> into main (--no-ff).
+#        b. Creates the annotated tag X.Y.Z on main's merge commit.
+#           (conventional git-flow always tags the main merge commit, not the
+#            release branch — this also triggers pr.yml on:push:tags which
+#            builds the final packages and creates the GitHub Release)
+#        c. Merges release/<new_version> into develop (syncs version bump back).
+#        d. Deletes the release branch.
+#
+# Prerequisites (repository secrets):
+#   PAT_TOKEN — Personal Access Token with `repo` + `workflow` scopes.
+#               Required so that commits and tag pushes made by this workflow
+#               re-trigger other workflows (GITHUB_TOKEN pushes do not).
+#
+# Retry / recovery:
+#   Re-dispatching with the same inputs is safe as long as the tag has NOT
+#   been pushed yet:
+#   - `prepare` hard-stops if the tag already exists (tags are permanent and
+#     will NEVER be deleted by this workflow).
+#   - `prepare` deletes the release branch if it exists, then recreates it
+#     from scratch (clean-slate retry for jobs 1-4).
+#   - If the tag was already pushed (sync-branches got past the tagging step
+#     but then failed), re-dispatch is still safe: sync-branches is fully
+#     idempotent and skips steps that already succeeded (checks Cargo.toml
+#     version on main/develop and tag existence before acting).
+#
+# Inputs:
+#   old_version — current version in Cargo.toml (e.g. 5.19.0)
+#   new_version — version to release (e.g. 5.20.0)
+
+on:
+  workflow_dispatch:
+    inputs:
+      old_version:
+        description: Current version in Cargo.toml
+        required: true
+        type: string
+      new_version:
+        description: New version to release
+        required: true
+        type: string
+
+# Only one release can run at a time.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Job 1 — Validate inputs, create the release branch, bump versions
+  # ─────────────────────────────────────────────────────────────────────────────
+  prepare:
+    name: Prepare release branch & bump versions
+    runs-on: ubuntu-latest
+    outputs:
+      release_branch: ${{ steps.vars.outputs.release_branch }}
+
+    steps:
+      - name: Validate semver format
+        run: |
+          semver_re='^[0-9]+\.[0-9]+\.[0-9]+$'
+          if ! [[ "${{ inputs.old_version }}" =~ $semver_re ]]; then
+            echo "ERROR: old_version '${{ inputs.old_version }}' is not valid semver X.Y.Z" >&2
+            exit 1
+          fi
+          if ! [[ "${{ inputs.new_version }}" =~ $semver_re ]]; then
+            echo "ERROR: new_version '${{ inputs.new_version }}' is not valid semver X.Y.Z" >&2
+            exit 1
+          fi
+          if [ "${{ inputs.old_version }}" = "${{ inputs.new_version }}" ]; then
+            echo "ERROR: old_version and new_version are identical" >&2
+            exit 1
+          fi
+
+      # Use PAT_TOKEN so commits and tag pushes re-trigger other workflows.
+      - uses: actions/checkout@v6
+        with:
+          ref: develop
+          fetch-depth: 0
+          submodules: recursive
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Validate old_version matches Cargo.toml
+        run: |
+          actual=$(grep -A 20 '^\[workspace\.package\]' Cargo.toml \
+            | grep '^version' | head -1 \
+            | sed -E 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')
+          if [ "$actual" = "${{ inputs.old_version }}" ]; then
+            echo "develop is at $actual — OK."
+          elif [ "$actual" = "${{ inputs.new_version }}" ]; then
+            echo "NOTE: develop is already at ${{ inputs.new_version }}." \
+                 "A previous run already merged the version bump into develop." \
+                 "The version-bump step will be a no-op; continuing."
+          else
+            echo "ERROR: old_version '${{ inputs.old_version }}' does not match" \
+                 "workspace Cargo.toml version '$actual'" >&2
+            exit 1
+          fi
+
+      - name: Clean up any pre-existing state for this version
+        run: |
+          set -euo pipefail
+          BRANCH="release/${{ inputs.new_version }}"
+          TAG="${{ inputs.new_version }}"
+
+          # Hard-stop if the tag already exists: a tag on main is the proof
+          # that at least the merge + tagging step already succeeded.
+          # The workflow NEVER deletes tags — they are permanent release
+          # identifiers that cannot be reconstructed safely.
+          # If sync-branches failed AFTER tagging, re-run the workflow: the
+          # sync-branches idempotency guards will skip the merge + tag that
+          # already happened and only retry the remaining steps.
+          if git ls-remote --exit-code --tags origin "$TAG" >/dev/null 2>&1; then
+            echo "ERROR: Tag '$TAG' already exists on origin." >&2
+            echo "       The release tag is permanent and will never be deleted" \
+                 "by this workflow." >&2
+            echo "       If sync-branches failed after tagging, re-run the" \
+                 "workflow — the idempotency guards will skip completed steps." >&2
+            exit 1
+          fi
+
+          # Delete the release branch so we can start fresh (enables clean retry).
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "WARNING: Branch '$BRANCH' already exists — deleting for clean retry."
+            git push origin --delete "$BRANCH"
+          fi
+
+      - name: Set output variables
+        id: vars
+        run: echo "release_branch=release/${{ inputs.new_version }}" >> "$GITHUB_OUTPUT"
+
+      - name: Create release branch from develop
+        run: |
+          git checkout -b "release/${{ inputs.new_version }}"
+
+      - name: Run version-bump script
+        run: |
+          # release.sh performs sed-based substitutions across all Cargo.toml
+          # and other versioned files.  The --ci flag skips the pre-commit
+          # hooks section (nix-build-all, cbom, release-docker-build-ui) since
+          # those are handled by dedicated jobs in this workflow.
+          bash .github/scripts/release/release.sh \
+            "${{ inputs.old_version }}" \
+            "${{ inputs.new_version }}" \
+            --ci
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.90.0
+
+      - name: Regenerate Cargo.lock
+        run: cargo generate-lockfile
+
+      - name: Regenerate CBOM
+        run: |
+          # generate_cbom.sh runs cargo metadata (non-fips) + a Python scan of
+          # the source tree and emits cbom/cbom.cdx.json.  No Nix required.
+          pip install cyclonedx-bom --quiet
+          bash .github/scripts/release/generate_cbom.sh
+
+      - name: Commit version bump and push release branch
+        run: |
+          git add -A
+          if git diff --cached --quiet; then
+            # No diff: either old_version is wrong, or develop was already at
+            # new_version (previous run merged it back). Distinguish the two.
+            CURRENT=$(grep -A 20 '^\[workspace\.package\]' Cargo.toml \
+              | grep '^version' | head -1 \
+              | sed -E 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')
+            if [ "$CURRENT" = "${{ inputs.new_version }}" ]; then
+              echo "NOTE: version already at ${{ inputs.new_version }} — version bump"
+              echo "      was a no-op (develop already merged in a previous run)."
+              echo "      Pushing branch as-is and continuing."
+            else
+              echo "ERROR: Nothing changed after version bump. Check that" \
+                   "old_version='${{ inputs.old_version }}' is correct." >&2
+              exit 1
+            fi
+          else
+            git commit -m "build: release ${{ inputs.new_version }}"
+          fi
+          git push origin "release/${{ inputs.new_version }}"
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Job 2 — Recompute Nix vendor hashes (matrix: Linux + macOS)
+  #
+  # Hash files split by platform:
+  #   Linux  : server.vendor.{static,dynamic}.sha256
+  #             cli.vendor.linux.sha256
+  #             ui.vendor.{fips,non-fips}.sha256
+  #             ui.pnpm.linux.sha256
+  #   macOS  : cli.vendor.{static,dynamic}.darwin.sha256
+  #             ui.pnpm.darwin.sha256
+  #
+  # The two sets are disjoint, so both runners can commit concurrently without
+  # conflicts.  Each job pulls the latest HEAD before pushing.
+  # ─────────────────────────────────────────────────────────────────────────────
+  update-nix-hashes:
+    name: Update Nix vendor hashes (${{ matrix.runner }})
+    needs: prepare
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, macos-15]
+
+    steps:
+      - name: Nix installation
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            connect-timeout = 15
+            stalled-download-timeout = 15
+            narinfo-cache-negative-ttl = 0
+
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.release_branch }}
+          fetch-depth: 0
+          submodules: recursive
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Warm Nix store
+        run: |
+          sed -n 's/.*url *= *"\(https:\/\/[^"]*\.tar\.gz\)".*/\1/p' default.nix | sort -u \
+          | while read -r url; do
+            dest="/tmp/$(basename "$url")"
+            fallback=$(echo "$url" | sed \
+              's|https://package.cosmian.com/nixpkgs/|https://github.com/NixOS/nixpkgs/archive/|')
+            echo "Downloading $(basename "$url") …"
+            if ! curl --retry 3 --retry-delay 5 --retry-all-errors -fsSL -o "$dest" "$url"; then
+              echo "Mirror failed, falling back to GitHub …"
+              curl --retry 5 --retry-delay 10 --retry-max-time 300 \
+                   --retry-all-errors -fsSL -o "$dest" "$fallback"
+            fi
+            echo "Injecting into Nix store …"
+            nix-prefetch-url --unpack --name source "file://$dest"
+            rm -f "$dest"
+          done
+
+      - name: Recompute all Nix vendor hashes
+        run: bash .github/scripts/release/nix_build_update_hash.sh
+
+      - name: Commit updated Nix hashes
+        run: |
+          git add nix/expected-hashes/
+          if git diff --cached --quiet; then
+            echo "Nix hashes are already up-to-date, nothing to commit."
+          else
+            # Pull first to avoid non-fast-forward rejection if the other
+            # platform job committed concurrently (the two file sets are
+            # disjoint so rebase always succeeds cleanly).
+            git pull --rebase origin "${{ needs.prepare.outputs.release_branch }}"
+            git commit -m "build: update Nix vendor hashes (${{ runner.os }}) for ${{ inputs.new_version }}"
+            git push origin "${{ needs.prepare.outputs.release_branch }}"
+          fi
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Job 3 — Trigger packaging CI on the release branch and wait for completion
+  #
+  # pr.yml supports `workflow_dispatch` which allows us to trigger it on an
+  # arbitrary ref.  This makes packaging run (including the publish-sbom jobs
+  # that upload to package.cosmian.com) without requiring an open PR.
+  #
+  # The SBOMs are published at:
+  #   package.cosmian.com/kms/last_build/release/<new_version>/sbom/
+  # ─────────────────────────────────────────────────────────────────────────────
+  trigger-packaging:
+    name: Trigger & await packaging CI
+    needs: [prepare, update-nix-hashes]
+    # update-nix-hashes is a matrix job; GitHub waits for ALL instances before
+    # starting trigger-packaging.
+    runs-on: ubuntu-latest
+    outputs:
+      packaging_run_id: ${{ steps.dispatch.outputs.run_id }}
+
+    steps:
+      - name: Dispatch pr.yml on the release branch
+        id: dispatch
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          BRANCH: ${{ needs.prepare.outputs.release_branch }}
+        run: |
+          set -euo pipefail
+
+          echo "Dispatching pr.yml on branch '$BRANCH'…"
+
+          # Capture the timestamp before dispatch so we can find the new run
+          BEFORE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+          gh workflow run pr.yml \
+            --repo Cosmian/kms \
+            --ref "$BRANCH"
+
+          # Wait a few seconds for the run to register in the API
+          sleep 10
+
+          # Find the run that was created after our dispatch timestamp
+          RUN_ID=$(GH_PAGER=cat gh run list \
+            --repo Cosmian/kms \
+            --branch "$BRANCH" \
+            --workflow pr.yml \
+            --limit 5 \
+            --json databaseId,createdAt \
+            --jq "[.[] | select(.createdAt > \"$BEFORE\")] | .[0].databaseId // empty")
+
+          if [ -z "${RUN_ID:-}" ] || [ "$RUN_ID" = "null" ]; then
+            echo "ERROR: Could not find the dispatched pr.yml run." >&2
+            exit 1
+          fi
+
+          echo "Dispatched run ID: $RUN_ID"
+          echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for packaging run to complete
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          RUN_ID: ${{ steps.dispatch.outputs.run_id }}
+        run: |
+          set -euo pipefail
+
+          echo "Waiting for packaging run $RUN_ID to complete…"
+          echo "  (packaging takes 40-70 min; timeout set to 120 min)"
+
+          MAX_WAIT=7200
+          INTERVAL=60
+          elapsed=0
+
+          while true; do
+            STATUS=$(GH_PAGER=cat gh run view "$RUN_ID" \
+              --repo Cosmian/kms \
+              --json status,conclusion \
+              --jq '.status')
+            CONCLUSION=$(GH_PAGER=cat gh run view "$RUN_ID" \
+              --repo Cosmian/kms \
+              --json status,conclusion \
+              --jq '.conclusion // empty')
+
+            echo "  $(date -u +"%H:%M:%SZ") — Run $RUN_ID: status=$STATUS conclusion=${CONCLUSION:-pending}"
+
+            if [ "$STATUS" = "completed" ]; then
+              if [ "$CONCLUSION" = "success" ]; then
+                echo "Packaging run $RUN_ID completed successfully."
+                break
+              else
+                echo "ERROR: Packaging run $RUN_ID finished with conclusion '$CONCLUSION'." >&2
+                echo "       Review: https://github.com/Cosmian/kms/actions/runs/$RUN_ID" >&2
+                echo "       Fix the packaging failure and re-run this release workflow." >&2
+                exit 1
+              fi
+            fi
+
+            if [ "$elapsed" -ge "$MAX_WAIT" ]; then
+              echo "ERROR: Timed out waiting for packaging CI after ${MAX_WAIT}s." >&2
+              exit 1
+            fi
+
+            sleep "$INTERVAL"
+            elapsed=$((elapsed + INTERVAL))
+          done
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Job 4 — Retrieve SBOMs and commit them to the release branch
+  # ─────────────────────────────────────────────────────────────────────────────
+  commit-sbom:
+    name: Retrieve & commit SBOM
+    needs: [prepare, trigger-packaging]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.release_branch }}
+          fetch-depth: 0
+          submodules: recursive
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Retrieve SBOMs from package.cosmian.com
+        run: |
+          # The packaging CI publishes SBOMs under:
+          #   last_build/release/<version>/sbom/
+          bash .github/scripts/nix.sh sbom --retrieve \
+            --branch "last_build/${{ needs.prepare.outputs.release_branch }}"
+
+      - name: Commit SBOMs
+        run: |
+          git add sbom/
+          if git diff --cached --quiet; then
+            echo "SBOMs are already committed – nothing to do."
+          else
+            git commit -m "build: add SBOM reports for ${{ inputs.new_version }}"
+            git push origin "${{ needs.prepare.outputs.release_branch }}"
+          fi
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Job 5 — Git-flow finalisation: merge into main, tag, merge into develop
+  #
+  # Conventional git-flow: `git flow release finish X.Y.Z`
+  #   1. Merge release/<version> into main  (--no-ff)
+  #   2. Create the annotated tag on the resulting main merge commit
+  #      (git-flow always tags main, never the release branch)
+  #      The tag push triggers pr.yml (on:push:tags) which builds the final
+  #      packages and creates the GitHub Release.
+  #   3. Merge release/<version> into develop  (--no-ff, syncs version bump)
+  #   4. Delete the release branch
+  # ─────────────────────────────────────────────────────────────────────────────
+  sync-branches:
+    name: git-flow release finish ${{ inputs.new_version }}
+    needs: [prepare, trigger-packaging, commit-sbom]
+    runs-on: ubuntu-latest
+
+    steps:
+      # Use PAT_TOKEN so the push to `main` and `develop` re-triggers CI.
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+          submodules: recursive
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Merge release branch into main
+        run: |
+          RELEASE_BRANCH="${{ needs.prepare.outputs.release_branch }}"
+          TAG="${{ inputs.new_version }}"
+
+          git fetch origin main "$RELEASE_BRANCH"
+          git reset --hard origin/main
+
+          # Idempotency: skip if main already carries the new version.
+          # (Happens when retrying after this step succeeded but a later step
+          # failed in a previous run.)
+          MAIN_VERSION=$(git show origin/main:Cargo.toml \
+            | grep -A 20 '^\[workspace\.package\]' | grep '^version' | head -1 \
+            | sed -E 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')
+          if [ "$MAIN_VERSION" = "$TAG" ]; then
+            echo "main is already at $TAG — merge already done in a previous run, skipping."
+          else
+            # --no-ff creates an explicit merge commit on main for visibility.
+            git merge --no-ff "origin/$RELEASE_BRANCH" \
+              -m "build: merge $RELEASE_BRANCH into main"
+            git push origin main
+            echo "Merged '$RELEASE_BRANCH' into 'main'."
+          fi
+
+      - name: Create and push annotated tag on main
+        run: |
+          TAG="${{ inputs.new_version }}"
+
+          # Idempotency: skip if the tag was already pushed.
+          # (Happens when retrying after the tag was pushed but a later step
+          # failed in a previous run.)
+          if git ls-remote --exit-code --tags origin "$TAG" >/dev/null 2>&1; then
+            echo "Tag '$TAG' already exists — skipping."
+          else
+            # Ensure we are on the latest main HEAD before tagging.
+            git fetch origin main
+            git reset --hard origin/main
+            git tag -a "$TAG" -m "Release $TAG"
+            git push origin "$TAG"
+            echo "Tag '$TAG' pushed on main."
+            echo "pr.yml (on:push:tags) will now build and publish the release."
+          fi
+
+      - name: Merge release branch into develop
+        run: |
+          RELEASE_BRANCH="${{ needs.prepare.outputs.release_branch }}"
+          TAG="${{ inputs.new_version }}"
+
+          git fetch origin develop "$RELEASE_BRANCH"
+          git checkout develop
+          git reset --hard origin/develop
+
+          # Idempotency: skip if develop already carries the new version.
+          # (Happens when retrying after this step succeeded but branch
+          # deletion failed in a previous run.)
+          DEVELOP_VERSION=$(git show origin/develop:Cargo.toml \
+            | grep -A 20 '^\[workspace\.package\]' | grep '^version' | head -1 \
+            | sed -E 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')
+          if [ "$DEVELOP_VERSION" = "$TAG" ]; then
+            echo "develop is already at $TAG — merge already done in a previous run, skipping."
+          else
+            # --no-ff keeps the merge commit visible in develop history.
+            git merge --no-ff "origin/$RELEASE_BRANCH" \
+              -m "build: merge $RELEASE_BRANCH into develop"
+            git push origin develop
+            echo "Merged '$RELEASE_BRANCH' into 'develop'."
+          fi
+
+      - name: Delete release branch
+        run: |
+          RELEASE_BRANCH="${{ needs.prepare.outputs.release_branch }}"
+          # Idempotency: skip if already deleted (previous run deleted it but
+          # then failed in the workflow summary step, for example).
+          if git ls-remote --exit-code --heads origin "$RELEASE_BRANCH" >/dev/null 2>&1; then
+            git push origin --delete "$RELEASE_BRANCH"
+            echo "Deleted remote branch '$RELEASE_BRANCH'."
+          else
+            echo "Branch '$RELEASE_BRANCH' already deleted — nothing to do."
+          fi
+
+      - name: Workflow summary
+        env:
+          NEW_VERSION: ${{ inputs.new_version }}
+          OLD_VERSION: ${{ inputs.old_version }}
+          PKG_RUN_ID: ${{ needs.trigger-packaging.outputs.packaging_run_id }}
+        run: |
+          printf '## Release %s — all automated steps complete\n\n' "$NEW_VERSION" >> "$GITHUB_STEP_SUMMARY"
+          printf '| Step | Details |\n' >> "$GITHUB_STEP_SUMMARY"
+          printf '|------|---------|\n' >> "$GITHUB_STEP_SUMMARY"
+          printf '| Branch | `release/%s` from `develop`, merged into `main` & `develop`, deleted |\n' "$NEW_VERSION" >> "$GITHUB_STEP_SUMMARY"
+          printf '| Version bump | `%s` → `%s` |\n' "$OLD_VERSION" "$NEW_VERSION" >> "$GITHUB_STEP_SUMMARY"
+          printf '| Nix hashes | Updated and committed |\n' >> "$GITHUB_STEP_SUMMARY"
+          printf '| Packaging CI | Run [#%s](https://github.com/Cosmian/kms/actions/runs/%s) ✅ |\n' \
+            "$PKG_RUN_ID" "$PKG_RUN_ID" >> "$GITHUB_STEP_SUMMARY"
+          printf '| SBOMs | Retrieved and committed |\n' >> "$GITHUB_STEP_SUMMARY"
+          printf '| Tag | `%s` on `main` merge commit |\n\n' "$NEW_VERSION" >> "$GITHUB_STEP_SUMMARY"
+          printf 'The `pr.yml` on-tag pipeline is building the final packages and GitHub Release.\n\n' >> "$GITHUB_STEP_SUMMARY"
+          printf '### Remaining manual step\n\n' >> "$GITHUB_STEP_SUMMARY"
+          printf 'Once the tag pipeline completes, update the GitHub Release notes at:\n' >> "$GITHUB_STEP_SUMMARY"
+          printf 'https://github.com/Cosmian/kms/releases/tag/%s\n' "$NEW_VERSION" >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG/automate_release.md
+++ b/CHANGELOG/automate_release.md
@@ -1,0 +1,6 @@
+## CI
+
+- **Automated release workflow** (`release.yml`): new `workflow_dispatch` workflow that fully automates the release flow — creates the `release/<version>` branch from `develop`, bumps all versions via `release.sh --ci`, regenerates the CBOM (`generate_cbom.sh`), updates Nix vendor hashes on both Linux and macOS runners in parallel, triggers the packaging CI, retrieves SBOMs once packaging completes, commits everything, pushes the annotated tag, and finally performs the git-flow finalisation (merge into `main`, merge back into `develop`, delete release branch).
+- **`release.sh`**: added `--ci` third argument that skips local pre-commit hooks (nix-build-all, cbom, release-docker-build-ui) while keeping all version-bump sed substitutions intact.
+- **`packaging.yml`**: added `github.event_name == 'workflow_dispatch'` to the `if:` conditions of `docker`, `packages`, `publish-release`, and `publish-sbom` jobs so they execute when triggered by the release workflow dispatch.
+- **`RELEASE.md`**: restructured documentation — automated flow is now primary; manual git-flow steps preserved as legacy fallback.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,48 +2,101 @@
 
 [TOC]
 
-## Step by step
+## Automated release (recommended)
 
-To proceed a new release, please follow the steps below:
+The `.github/workflows/release.yml` workflow automates the entire release
+flow. Trigger it from the GitHub Actions UI or via the GitHub CLI:
 
-0. Pre-requisites installation:
-   1. Install git-flow: <https://skoch.github.io/Git-Workflow/>
-   2. Install git-cliff:
+```sh
+gh workflow run release.yml \
+  --repo Cosmian/kms \
+  --field old_version=5.19.0 \
+  --field new_version=5.20.0
+```
 
-    ```sh
-    cargo install git-cliff
-    ```
+### What the workflow does — in order
+
+1. **Validates** inputs (semver format, `old_version` matches `Cargo.toml`,
+   branch/tag do not already exist).
+2. **Creates** `release/<new_version>` from `develop`.
+3. **Bumps** all version references via `.github/scripts/release/release.sh --ci`
+   (sed-based substitutions across all `Cargo.toml` files and versioned docs)
+   and regenerates `Cargo.lock`.  Commits and pushes.
+4. **Updates Nix vendor hashes** by running `nix_build_update_hash.sh` on a
+   Linux runner (builds all derivations in order, auto-fixes hash mismatches).
+   Commits and pushes the updated `nix/expected-hashes/` files.
+5. **Triggers a packaging CI run** (`pr.yml` via `workflow_dispatch`) on the
+   release branch, then polls until it completes.  This run publishes packages
+   and SBOMs to `package.cosmian.com`.
+6. **Retrieves SBOMs** from `package.cosmian.com` and commits them.
+7. **Pushes the annotated Git tag** `<new_version>`.  This triggers `pr.yml`
+   (`on:push:tags`) which builds the final packages and creates the GitHub
+   Release.
+8. **Git-flow finalisation**: merges `release/<new_version>` into `main` (no-ff),
+   merges `release/<new_version>` back into `develop` (syncs the version bump),
+   then deletes the release branch.
+
+### Prerequisites
+
+- Repository secret `PAT_TOKEN` must have `repo` + `workflow` scopes so that
+  commits and tag pushes made by the workflow can re-trigger other workflows
+  (pushes made with `GITHUB_TOKEN` do not trigger them).
+
+### Remaining manual step
+
+Once the tag-triggered packaging pipeline completes, update the GitHub Release
+notes at `https://github.com/Cosmian/kms/releases/tag/<new_version>` (copy
+paste from `CHANGELOG.md`).
+
+---
+
+## Manual release (legacy)
+
+Follow these steps only if the automated workflow is unavailable or needs to be
+debugged.
+
+### Pre-requisites
+
+1. Install git-flow: <https://skoch.github.io/Git-Workflow/\>
+2. Install git-cliff:
+
+```sh
+cargo install git-cliff
+```
+
+### Step by step
 
 1. Create new release branch with git-flow:
 
-    ```sh
-    git checkout main
-    git pull
-    git checkout develop
-    git pull
-    git flow init
-    git flow release start X.Y.Z
-    ```
+   ```sh
+   git checkout main
+   git pull
+   git checkout develop
+   git pull
+   git flow init
+   git flow release start X.Y.Z
+   ```
 
 2. Update the version X.Y.Z almost everywhere:
 
-    ```sh
-    bash .github/scripts/release.sh <old_version> <new_version>
-    ```
+   ```sh
+   bash .github/scripts/release/release.sh <old_version> <new_version>
+   ```
 
 3. Commit the changes:
 
-    ```sh
-    git commit -m "build: release X.Y.Z"
-    git push
-    ```
+   ```sh
+   git commit -m "build: release X.Y.Z"
+   git push
+   ```
 
-    Make sure the CI pipeline is green.
+   Make sure the CI pipeline is green.
 
 4. Finish the release with git-flow:
 
-    ```sh
-    git flow release finish X.Y.Z --push
-    ```
+   ```sh
+   git flow release finish X.Y.Z --push
+   ```
 
-5. Do not forget to update GitHub CHANGELOG in <https://github.com/Cosmian/kms/releases/tag/X.Y.Z> (copy paste from CHANGELOG.md)
+5. Do not forget to update GitHub CHANGELOG at
+   <https://github.com/Cosmian/kms/releases/tag/X.Y.Z> (copy paste from CHANGELOG.md)


### PR DESCRIPTION
## CI

- **Automated release workflow** (`release.yml`): new `workflow_dispatch` workflow that fully automates the release flow — creates the `release/<version>` branch from `develop`, bumps all versions via `release.sh --ci`, regenerates the CBOM (`generate_cbom.sh`), updates Nix vendor hashes on both Linux and macOS runners in parallel, triggers the packaging CI, retrieves SBOMs once packaging completes, commits everything, pushes the annotated tag, and finally performs the git-flow finalisation (merge into `main`, merge back into `develop`, delete release branch).
- **`release.sh`**: added `--ci` third argument that skips local pre-commit hooks (nix-build-all, cbom, release-docker-build-ui) while keeping all version-bump sed substitutions intact.
- **`packaging.yml`**: added `github.event_name == 'workflow_dispatch'` to the `if:` conditions of `docker`, `packages`, `publish-release`, and `publish-sbom` jobs so they execute when triggered by the release workflow dispatch.
- **`RELEASE.md`**: restructured documentation — automated flow is now primary; manual git-flow steps preserved as legacy fallback.