### PR TITLE
fix: htmlStats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# (important) exclude from GitHub Linguist language stats
+crate/kmip/src/**/*.html  linguist-vendored
+crate/kmip/src/**/*.xml   linguist-vendored
+
+# Experimental: better hunk headers in diffs
+*.rs                 text diff=rust
+*.toml               text diff=toml
+Cargo.lock           text merge=union # avoid manually fixingmerge conflicts in Cargo.lock. Just run `cargo build` after a rebase should auto-fix any problem
+pnpm-lock.yaml       text eol=lf linguist-generated # UI: collapse lock file in PR diffs

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,3 @@
 # (important) exclude from GitHub Linguist language stats
 crate/kmip/src/**/*.html  linguist-vendored
 crate/kmip/src/**/*.xml   linguist-vendored
-
-# Experimental: better hunk headers in diffs
-*.rs                 text diff=rust
-*.toml               text diff=toml
-Cargo.lock           text merge=union # avoid manually fixingmerge conflicts in Cargo.lock. Just run `cargo build` after a rebase should auto-fix any problem
-pnpm-lock.yaml       text eol=lf linguist-generated # UI: collapse lock file in PR diffs


### PR DESCRIPTION
# Note: this PR is an immediate fix - please discuss is this issue for the final solution https://github.com/Cosmian/kms/issues/931

Note 2.0: exceptionally, this is makes more sense merged to master branch

___

# Summary

GitHub was reporting the repo as 85% HTML because the committed OASIS KMIP specification files (`crate/kmip/src/**/*.html` and `*.xml`, ~35 MB, ~286 files) were counted as source code. This marks them as vendored so Linguist ignores them.