### PR TITLE
feat: add KMIP RBAC support with OPA/Rego policy engine

### DIFF
--- a/CHANGELOG/feat_rbac_with_opa.md
+++ b/CHANGELOG/feat_rbac_with_opa.md
@@ -1,0 +1,14 @@
+## Features
+
+### KMIP RBAC (Role-Based Access Control)
+
+- Add RBAC support following NIST SP 800-162 using OPA/Rego policy language
+- New `cosmian_kms_rbac` crate with embedded Rego evaluation via Microsoft `regorus` crate
+- Optional external OPA server support via `--opa-url` configuration flag
+- Server configuration: `--rbac-policy-path` to enable RBAC with custom Rego policies
+- Default Rego policy with 4 built-in roles: Administrator, Operator, Auditor, ReadOnly
+- `RoleStore` trait with implementations for SQLite, PostgreSQL, MySQL, and Redis
+- RBAC works alongside existing per-object ACL (OR logic: either RBAC or ACL allowing grants access)
+- REST API endpoints: `POST/DELETE/GET /rbac/roles`, `GET /rbac/status`
+- CLI subcommands: `ckms rbac assign-role`, `remove-role`, `list`, `list-all`, `status`
+- Web UI: RBAC role management page and status page under new "RBAC" menu section

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,6 +722,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chacha20"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1253,6 +1259,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "cosmian_kms_rbac"
+version = "5.21.0"
+dependencies = [
+ "cosmian_kmip",
+ "cosmian_logger",
+ "regorus",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+]
+
+[[package]]
 name = "cosmian_kms_server"
 version = "5.21.0"
 dependencies = [
@@ -1273,6 +1293,7 @@ dependencies = [
  "cosmian_kms_base_hsm",
  "cosmian_kms_client_utils",
  "cosmian_kms_interfaces",
+ "cosmian_kms_rbac",
  "cosmian_kms_server_database",
  "cosmian_logger",
  "crypt2pay_pkcs11_loader",
@@ -2581,6 +2602,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3063,6 +3085,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3158,6 +3186,15 @@ dependencies = [
  "rand_core 0.6.4",
  "sha3",
  "zeroize",
+]
+
+[[package]]
+name = "msvc_spectre_libs"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29e871a9861f3664f18b7e04e9301d4edd55090c2dadb4b1c602e26ab32b1f5b"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -4027,6 +4064,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.6.1",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring 0.17.14",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.1",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4186,6 +4278,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "regorus"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656c9768f1d2113590ebc05e2e342a9f76baa97a445f2928f24eec9ae1fb14ac"
+dependencies = [
+ "anyhow",
+ "lazy_static",
+ "msvc_spectre_libs",
+ "num-bigint",
+ "num-traits",
+ "rand 0.9.4",
+ "serde",
+ "serde_json",
+ "spin 0.9.8",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4209,6 +4319,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4216,6 +4328,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower 0.5.2",
  "tower-http",
  "tower-service",
@@ -4223,6 +4336,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4310,6 +4424,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4347,6 +4467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
  "once_cell",
+ "ring 0.17.14",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -4359,6 +4480,7 @@ version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -5796,6 +5918,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,7 +1262,6 @@ dependencies = [
 name = "cosmian_kms_rbac"
 version = "5.21.0"
 dependencies = [
- "cosmian_kmip",
  "cosmian_logger",
  "regorus",
  "reqwest",
@@ -4486,9 +4485,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring 0.17.14",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
   "crate/clients/pkcs11/provider",
   # Server crates
   "crate/access",
+  "crate/rbac",
   "crate/crypto",
   "crate/hsm/proteccio",
   "crate/hsm/crypt2pay",
@@ -189,6 +190,7 @@ opentelemetry_sdk = { version = "0.27", features = ["metrics", "rt-tokio"] }
 pem = "3.0"
 pkcs11-sys = "0.2"
 rand = "0.9"
+regorus = { version = "0.9", default-features = false, features = ["std"] }
 reqwest = { version = "0.12", default-features = false }
 scratchstack-aws-signature = "=0.10" # Must stay 0.10 for now (Feb 2026)
 serde = "1.0"

--- a/crate/clients/clap/src/actions/kms_actions.rs
+++ b/crate/clients/clap/src/actions/kms_actions.rs
@@ -15,7 +15,7 @@ use crate::{
         azure::AzureCommands, bench::BenchAction, certificates::CertificatesCommands,
         console::Stdout, derive_key::DeriveKeyAction, elliptic_curves::EllipticCurveCommands,
         google::GoogleCommands, hash::HashAction, login::LoginAction, mac::MacCommands,
-        opaque_object::OpaqueObjectCommands, rng::RngAction, rsa::RsaCommands,
+        opaque_object::OpaqueObjectCommands, rbac::RbacAction, rng::RngAction, rsa::RsaCommands,
         secret_data::SecretDataCommands, shared::LocateObjectsAction, symmetric::SymmetricCommands,
         version::ServerVersionAction,
     },
@@ -73,6 +73,8 @@ pub enum KmsActions {
     Rsa(RsaCommands),
     #[command(subcommand)]
     OpaqueObject(OpaqueObjectCommands),
+    #[command(subcommand)]
+    Rbac(RbacAction),
     #[command(subcommand)]
     SecretData(SecretDataCommands),
     #[command(subcommand)]
@@ -298,6 +300,7 @@ impl KmsActions {
                 }
             },
             Self::Rsa(action) => Box::pin(action.process(kms_rest_client)).await?,
+            Self::Rbac(action) => Box::pin(action.process(kms_rest_client)).await?,
             Self::OpaqueObject(action) => Box::pin(action.process(kms_rest_client)).await?,
             Self::Sym(action) => Box::pin(action.process(kms_rest_client)).await?,
             Self::SecretData(action) => Box::pin(action.process(kms_rest_client)).await?,

--- a/crate/clients/clap/src/actions/mod.rs
+++ b/crate/clients/clap/src/actions/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod labels;
 pub mod login;
 pub mod mac;
 pub mod opaque_object;
+pub mod rbac;
 pub mod rng;
 pub mod rsa;
 pub mod secret_data;

--- a/crate/clients/clap/src/actions/rbac.rs
+++ b/crate/clients/clap/src/actions/rbac.rs
@@ -1,0 +1,203 @@
+use std::fmt::Write as _;
+
+use clap::Parser;
+use cosmian_kms_client::KmsClient;
+
+use super::console;
+use crate::error::result::{KmsCliResult, KmsCliResultHelper};
+
+/// Manage RBAC (Role-Based Access Control) role assignments.
+///
+/// Only privileged users (administrators) can manage roles.
+/// Available built-in roles: administrator, operator, auditor, readonly.
+/// Custom roles may be defined in the Rego policy.
+#[derive(Parser, Debug)]
+pub enum RbacAction {
+    /// Assign a role to a user
+    Assign(AssignRole),
+    /// Remove a role from a user
+    Remove(RemoveRole),
+    /// List roles assigned to a specific user
+    #[command(name = "list")]
+    ListUser(ListUserRoles),
+    /// List all role assignments across all users
+    #[command(name = "list-all")]
+    ListAll(ListAllRoles),
+    /// Show RBAC enforcement status on the server
+    Status(RbacStatusAction),
+}
+
+impl RbacAction {
+    /// Processes the RBAC action.
+    pub async fn process(&self, kms_rest_client: KmsClient) -> KmsCliResult<()> {
+        match self {
+            Self::Assign(action) => action.run(kms_rest_client).await?,
+            Self::Remove(action) => action.run(kms_rest_client).await?,
+            Self::ListUser(action) => action.run(kms_rest_client).await?,
+            Self::ListAll(action) => action.run(kms_rest_client).await?,
+            Self::Status(action) => action.run(kms_rest_client).await?,
+        }
+        Ok(())
+    }
+}
+
+/// Assign a role to a user.
+///
+/// Example:
+///   ckms rbac assign alice@example.com operator
+#[derive(Parser, Debug)]
+pub struct AssignRole {
+    /// The user identifier to assign the role to
+    #[clap(required = true)]
+    pub user_id: String,
+
+    /// The role name to assign (e.g. administrator, operator, auditor, readonly)
+    #[clap(required = true)]
+    pub role: String,
+}
+
+impl AssignRole {
+    pub async fn run(&self, kms_rest_client: KmsClient) -> KmsCliResult<()> {
+        kms_rest_client
+            .rbac_assign_role(&self.user_id, &self.role)
+            .await
+            .with_context(|| "Failed to assign RBAC role")?;
+
+        console::Stdout::new(&format!(
+            "Role '{}' successfully assigned to user '{}'",
+            self.role, self.user_id
+        ))
+        .write()?;
+
+        Ok(())
+    }
+}
+
+/// Remove a role from a user.
+///
+/// Example:
+///   ckms rbac remove alice@example.com operator
+#[derive(Parser, Debug)]
+pub struct RemoveRole {
+    /// The user identifier to remove the role from
+    #[clap(required = true)]
+    pub user_id: String,
+
+    /// The role name to remove
+    #[clap(required = true)]
+    pub role: String,
+}
+
+impl RemoveRole {
+    pub async fn run(&self, kms_rest_client: KmsClient) -> KmsCliResult<()> {
+        kms_rest_client
+            .rbac_remove_role(&self.user_id, &self.role)
+            .await
+            .with_context(|| "Failed to remove RBAC role")?;
+
+        console::Stdout::new(&format!(
+            "Role '{}' successfully removed from user '{}'",
+            self.role, self.user_id
+        ))
+        .write()?;
+
+        Ok(())
+    }
+}
+
+/// List the roles assigned to a specific user.
+///
+/// Example:
+///   ckms rbac list alice@example.com
+#[derive(Parser, Debug)]
+pub struct ListUserRoles {
+    /// The user identifier to list roles for
+    #[clap(required = true)]
+    pub user_id: String,
+}
+
+impl ListUserRoles {
+    pub async fn run(&self, kms_rest_client: KmsClient) -> KmsCliResult<()> {
+        let roles = kms_rest_client
+            .rbac_list_user_roles(&self.user_id)
+            .await
+            .with_context(|| "Failed to list user roles")?;
+
+        if roles.is_empty() {
+            console::Stdout::new(&format!("No roles assigned to user '{}'", self.user_id))
+                .write()?;
+        } else {
+            let mut output = format!("Roles assigned to user '{}':\n", self.user_id);
+            for role in &roles {
+                let _ = writeln!(output, "  - {role}");
+            }
+            console::Stdout::new(&output).write()?;
+        }
+
+        Ok(())
+    }
+}
+
+/// List all role assignments across all users.
+///
+/// Example:
+///   ckms rbac list-all
+#[derive(Parser, Debug)]
+pub struct ListAllRoles;
+
+impl ListAllRoles {
+    pub async fn run(&self, kms_rest_client: KmsClient) -> KmsCliResult<()> {
+        let assignments = kms_rest_client
+            .rbac_list_all_roles()
+            .await
+            .with_context(|| "Failed to list all role assignments")?;
+
+        if assignments.is_empty() {
+            console::Stdout::new("No role assignments found.").write()?;
+        } else {
+            let mut output = String::from("Role assignments:\n");
+            for entry in &assignments {
+                let user_id = entry.get("user_id").and_then(|v| v.as_str()).unwrap_or("?");
+                let role = entry.get("role").and_then(|v| v.as_str()).unwrap_or("?");
+                let _ = writeln!(output, "  {user_id} -> {role}");
+            }
+            console::Stdout::new(&output).write()?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Show whether RBAC enforcement is enabled on the server.
+///
+/// Example:
+///   ckms rbac status
+#[derive(Parser, Debug)]
+pub struct RbacStatusAction;
+
+impl RbacStatusAction {
+    pub async fn run(&self, kms_rest_client: KmsClient) -> KmsCliResult<()> {
+        let status = kms_rest_client
+            .rbac_status()
+            .await
+            .with_context(|| "Failed to get RBAC status")?;
+
+        let enabled = status
+            .get("enabled")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false);
+        let engine = status
+            .get("engine")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+
+        let output = if enabled {
+            format!("RBAC enforcement is ENABLED (engine: {engine})")
+        } else {
+            "RBAC enforcement is DISABLED".to_owned()
+        };
+        console::Stdout::new(&output).write()?;
+
+        Ok(())
+    }
+}

--- a/crate/clients/client/src/kms_rest_client.rs
+++ b/crate/clients/client/src/kms_rest_client.rs
@@ -674,6 +674,48 @@ impl KmsClient {
         self.get_no_ttlv("/google_cse/status", None::<&()>).await
     }
 
+    // ── RBAC (Role-Based Access Control) ────────────────────────────────
+
+    /// Assign a role to a user.
+    /// Only privileged users (administrators) may call this endpoint.
+    pub async fn rbac_assign_role(
+        &self,
+        user_id: &str,
+        role: &str,
+    ) -> Result<serde_json::Value, KmsClientError> {
+        let body = serde_json::json!({ "user_id": user_id, "role": role });
+        self.post_no_ttlv("/rbac/roles", Some(&body)).await
+    }
+
+    /// Remove a role from a user.
+    /// Only privileged users (administrators) may call this endpoint.
+    pub async fn rbac_remove_role(
+        &self,
+        user_id: &str,
+        role: &str,
+    ) -> Result<serde_json::Value, KmsClientError> {
+        let body = serde_json::json!({ "user_id": user_id, "role": role });
+        self.delete_no_ttlv("/rbac/roles", &body).await
+    }
+
+    /// List the roles assigned to a specific user.
+    /// Only privileged users (administrators) may call this endpoint.
+    pub async fn rbac_list_user_roles(&self, user_id: &str) -> Result<Vec<String>, KmsClientError> {
+        self.get_no_ttlv(&format!("/rbac/roles/{user_id}"), None::<&()>)
+            .await
+    }
+
+    /// List all role assignments across all users.
+    /// Only privileged users (administrators) may call this endpoint.
+    pub async fn rbac_list_all_roles(&self) -> Result<Vec<serde_json::Value>, KmsClientError> {
+        self.get_no_ttlv("/rbac/roles", None::<&()>).await
+    }
+
+    /// Check whether RBAC enforcement is enabled on the server.
+    pub async fn rbac_status(&self) -> Result<serde_json::Value, KmsClientError> {
+        self.get_no_ttlv("/rbac/status", None::<&()>).await
+    }
+
     pub async fn get_no_ttlv<R, O>(
         &self,
         endpoint: &str,

--- a/crate/interfaces/src/lib.rs
+++ b/crate/interfaces/src/lib.rs
@@ -11,7 +11,7 @@ pub use hsm::{
     HSM, HsmCryptoOracle, HsmKeyAlgorithm, HsmKeypairAlgorithm, HsmObject, HsmObjectFilter,
     HsmStore, KeyMaterial, RsaPrivateKeyMaterial, RsaPublicKeyMaterial,
 };
-pub use stores::{AtomicOperation, ObjectWithMetadata, ObjectsStore, PermissionsStore};
+pub use stores::{AtomicOperation, ObjectWithMetadata, ObjectsStore, PermissionsStore, RoleStore};
 
 /// Supported cryptographic object types
 /// in plugins

--- a/crate/interfaces/src/stores/mod.rs
+++ b/crate/interfaces/src/stores/mod.rs
@@ -1,7 +1,9 @@
 pub(crate) mod object_with_metadata;
 mod objects_store;
 mod permissions_store;
+mod role_store;
 
 pub use object_with_metadata::ObjectWithMetadata;
 pub use objects_store::{AtomicOperation, ObjectsStore};
 pub use permissions_store::PermissionsStore;
+pub use role_store::RoleStore;

--- a/crate/interfaces/src/stores/role_store.rs
+++ b/crate/interfaces/src/stores/role_store.rs
@@ -1,0 +1,28 @@
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+
+use crate::InterfaceResult;
+
+/// Trait that the stores must implement to manage RBAC role assignments.
+///
+/// Role assignments map users to roles (e.g. "administrator", "operator").
+/// Each user can have multiple roles. Roles are used by the RBAC policy engine
+/// to evaluate authorization decisions.
+#[async_trait(?Send)]
+pub trait RoleStore {
+    /// Assign a role to a user.
+    /// If the assignment already exists, this is a no-op.
+    async fn assign_role(&self, user: &str, role: &str) -> InterfaceResult<()>;
+
+    /// Remove a role from a user.
+    /// If the assignment does not exist, this is a no-op.
+    async fn remove_role(&self, user: &str, role: &str) -> InterfaceResult<()>;
+
+    /// List all roles assigned to a user.
+    async fn list_user_roles(&self, user: &str) -> InterfaceResult<Vec<String>>;
+
+    /// List all role assignments in the system.
+    /// Returns a map of `user_id` → list of assigned roles.
+    async fn list_all_role_assignments(&self) -> InterfaceResult<HashMap<String, Vec<String>>>;
+}

--- a/crate/rbac/Cargo.toml
+++ b/crate/rbac/Cargo.toml
@@ -22,7 +22,6 @@ doctest = false
 [features]
 
 [dependencies]
-cosmian_kmip = { path = "../kmip", version = "5.21.0", default-features = true }
 cosmian_logger = { workspace = true }
 regorus = { version = "0.9", default-features = false, features = ["std"] }
 reqwest = { workspace = true, features = ["json", "rustls-tls"] }

--- a/crate/rbac/Cargo.toml
+++ b/crate/rbac/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "cosmian_kms_rbac"
+version.workspace = true
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+readme = "README.md"
+description = "Cosmian KMS RBAC - Role-Based Access Control with OPA/Rego policy engine"
+
+[lints]
+workspace = true
+
+[lib]
+# doc test linking as a separate binary is extremely slow
+# and is not needed for internal lib
+doctest = false
+
+[features]
+
+[dependencies]
+cosmian_kmip = { path = "../kmip", version = "5.21.0", default-features = true }
+cosmian_logger = { workspace = true }
+regorus = { version = "0.9", default-features = false, features = ["std"] }
+reqwest = { workspace = true, features = ["json", "rustls-tls"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["fs", "rt-multi-thread"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt", "macros"] }

--- a/crate/rbac/README.md
+++ b/crate/rbac/README.md
@@ -1,0 +1,1 @@
+# Cosmian KMS RBAC\n\nRole-Based Access Control with OPA/Rego policy engine for Cosmian KMS.

--- a/crate/rbac/src/engine.rs
+++ b/crate/rbac/src/engine.rs
@@ -1,0 +1,13 @@
+use crate::{RbacResult, input::RbacInput};
+
+/// Trait for RBAC policy engines.
+///
+/// Implementations evaluate an authorization request (as [`RbacInput`]) against
+/// loaded Rego policies and return whether the action is allowed.
+pub trait RbacEngine: Send + Sync {
+    /// Evaluate the RBAC policy for the given input.
+    ///
+    /// Returns `Ok(true)` if the policy allows the action,
+    /// `Ok(false)` if the policy denies it, or `Err` on evaluation error.
+    fn evaluate(&self, input: &RbacInput) -> RbacResult<bool>;
+}

--- a/crate/rbac/src/error.rs
+++ b/crate/rbac/src/error.rs
@@ -1,0 +1,30 @@
+use thiserror::Error;
+
+pub type RbacResult<T> = Result<T, RbacError>;
+
+#[derive(Error, Debug)]
+pub enum RbacError {
+    #[error("RBAC policy evaluation error: {0}")]
+    PolicyEvaluation(String),
+
+    #[error("RBAC policy file error: {0}")]
+    PolicyFile(String),
+
+    #[error("RBAC serialization error: {0}")]
+    Serialization(String),
+
+    #[error("RBAC external OPA error: {0}")]
+    ExternalOpa(String),
+}
+
+impl From<serde_json::Error> for RbacError {
+    fn from(e: serde_json::Error) -> Self {
+        Self::Serialization(e.to_string())
+    }
+}
+
+impl From<std::io::Error> for RbacError {
+    fn from(e: std::io::Error) -> Self {
+        Self::PolicyFile(e.to_string())
+    }
+}

--- a/crate/rbac/src/external_opa.rs
+++ b/crate/rbac/src/external_opa.rs
@@ -1,0 +1,97 @@
+use cosmian_logger::{debug, warn};
+use reqwest::Client;
+
+use crate::{RbacResult, engine::RbacEngine, error::RbacError, input::RbacInput};
+
+/// OPA response structure.
+#[derive(serde::Deserialize)]
+struct OpaResponse {
+    result: bool,
+}
+
+/// RBAC engine that delegates evaluation to an external OPA server over HTTP.
+///
+/// The OPA server is expected to expose a REST API at
+/// `{base_url}/v1/data/cosmian/kms/rbac/allow` that accepts a JSON body
+/// with an `input` field and returns `{"result": true|false}`.
+pub struct ExternalOpaEngine {
+    /// HTTP client for calling OPA
+    client: Client,
+    /// Full URL of the OPA decision endpoint
+    decision_url: String,
+}
+
+impl ExternalOpaEngine {
+    /// Create a new external OPA engine.
+    ///
+    /// # Arguments
+    /// * `base_url` — The OPA server base URL (e.g. `http://localhost:8181`).
+    ///   The decision path `/v1/data/cosmian/kms/rbac/allow` is appended automatically.
+    #[must_use]
+    pub fn new(base_url: &str) -> Self {
+        let base = base_url.trim_end_matches('/');
+        let decision_url = format!("{base}/v1/data/cosmian/kms/rbac/allow");
+
+        Self {
+            client: Client::new(),
+            decision_url,
+        }
+    }
+
+    /// Evaluate asynchronously (for use in async contexts).
+    ///
+    /// This is the underlying async implementation used by the synchronous
+    /// [`RbacEngine::evaluate`] trait method via `tokio::task::block_in_place`.
+    async fn evaluate_async(&self, input: &RbacInput) -> RbacResult<bool> {
+        let body = serde_json::json!({ "input": input });
+
+        debug!("RBAC: calling external OPA at {}", self.decision_url);
+
+        let response = self
+            .client
+            .post(&self.decision_url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| {
+                RbacError::ExternalOpa(format!("failed to call OPA at {}: {e}", self.decision_url))
+            })?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body_text = response.text().await.unwrap_or_default();
+            return Err(RbacError::ExternalOpa(format!(
+                "OPA returned HTTP {status}: {body_text}"
+            )));
+        }
+
+        let opa_response: OpaResponse = response
+            .json()
+            .await
+            .map_err(|e| RbacError::ExternalOpa(format!("failed to parse OPA response: {e}")))?;
+
+        debug!(
+            "RBAC: OPA decision for user={}, op={}: allowed={}",
+            input.subject.user_id, input.action.operation, opa_response.result
+        );
+
+        Ok(opa_response.result)
+    }
+}
+
+impl RbacEngine for ExternalOpaEngine {
+    fn evaluate(&self, input: &RbacInput) -> RbacResult<bool> {
+        // Use tokio's Handle to run the async call from a sync context.
+        // This is safe because we are called from within a tokio runtime.
+        let handle = tokio::runtime::Handle::try_current()
+            .map_err(|e| RbacError::ExternalOpa(format!("no tokio runtime available: {e}")))?;
+
+        // Use block_in_place to avoid blocking a worker thread when called
+        // from an actix-web handler (which runs on a tokio runtime).
+        tokio::task::block_in_place(|| handle.block_on(self.evaluate_async(input))).inspect_err(
+            |e| {
+                warn!("RBAC: external OPA evaluation failed: {e}");
+            },
+        )
+    }
+}

--- a/crate/rbac/src/input.rs
+++ b/crate/rbac/src/input.rs
@@ -1,0 +1,71 @@
+use serde::{Deserialize, Serialize};
+
+/// RBAC input following NIST SP 800-162 ABAC attribute categories.
+///
+/// This structure is serialized to JSON and passed as `input` to the
+/// Rego policy engine (either embedded regorus or external OPA).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RbacInput {
+    /// Subject attributes (the authenticated user)
+    pub subject: SubjectAttrs,
+    /// Action attributes (the requested KMIP operation)
+    pub action: ActionAttrs,
+    /// Resource attributes (the target object, if any)
+    pub resource: ResourceAttrs,
+    /// Environment attributes (contextual)
+    pub environment: EnvironmentAttrs,
+}
+
+/// Subject (user) attributes per NIST SP 800-162 §4.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubjectAttrs {
+    /// Authenticated user identifier
+    pub user_id: String,
+    /// Roles assigned to the user (from the `role_assignments` store)
+    pub roles: Vec<String>,
+    /// Whether the user owns the target object
+    pub is_owner: bool,
+    /// Whether the user is in the `privileged_users` list
+    pub is_privileged: bool,
+}
+
+/// Action attributes per NIST SP 800-162 §4.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActionAttrs {
+    /// The KMIP operation being requested (lowercase, e.g. "encrypt")
+    pub operation: String,
+}
+
+/// Resource (object) attributes per NIST SP 800-162 §4.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ResourceAttrs {
+    /// Object unique identifier (empty for Create operations)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unique_identifier: Option<String>,
+    /// KMIP object type (e.g. `SymmetricKey`, `PrivateKey`)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub object_type: Option<String>,
+    /// Object lifecycle state (e.g. `Active`, `PreActive`)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<String>,
+    /// Object owner
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
+    /// Whether the key is marked as sensitive
+    #[serde(default)]
+    pub sensitive: bool,
+    /// Whether the key is extractable
+    #[serde(default)]
+    pub extractable: bool,
+}
+
+/// Environment attributes per NIST SP 800-162 §4.
+///
+/// Currently a placeholder; can be extended with time-of-day,
+/// source IP, etc. for more advanced policies.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct EnvironmentAttrs {
+    /// Reserved for future attributes (time-of-day, source IP, etc.)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra: Option<String>,
+}

--- a/crate/rbac/src/lib.rs
+++ b/crate/rbac/src/lib.rs
@@ -1,0 +1,11 @@
+mod engine;
+mod error;
+mod external_opa;
+mod input;
+mod regorus_engine;
+
+pub use engine::RbacEngine;
+pub use error::{RbacError, RbacResult};
+pub use external_opa::ExternalOpaEngine;
+pub use input::{ActionAttrs, EnvironmentAttrs, RbacInput, ResourceAttrs, SubjectAttrs};
+pub use regorus_engine::RegorusEngine;

--- a/crate/rbac/src/regorus_engine.rs
+++ b/crate/rbac/src/regorus_engine.rs
@@ -1,0 +1,284 @@
+use std::path::{Path, PathBuf};
+
+use cosmian_logger::{debug, info};
+use regorus::Engine;
+
+use crate::{RbacResult, engine::RbacEngine, error::RbacError, input::RbacInput};
+
+/// The default Rego policy shipped with the KMS.
+const DEFAULT_POLICY: &str = include_str!("../../../resources/rbac/default_rbac.rego");
+
+/// A named policy source (filename + Rego source code).
+struct PolicySource {
+    name: String,
+    source: String,
+}
+
+/// Embedded Rego policy engine backed by `regorus`.
+///
+/// Loads `.rego` policy files at construction time and evaluates
+/// authorization requests by creating a fresh interpreter per call.
+/// `regorus::Engine` is neither `Send` nor `Sync`, so we store the
+/// parsed policy sources and build a short-lived engine for each evaluation.
+pub struct RegorusEngine {
+    /// Parsed policy sources to load into each fresh engine.
+    policies: Vec<PolicySource>,
+    /// Path(s) from which policies were loaded (for diagnostics).
+    policy_paths: Vec<PathBuf>,
+}
+
+impl RegorusEngine {
+    /// Create a new engine from a path to a `.rego` file or a directory
+    /// containing `.rego` files.
+    ///
+    /// If `policy_path` is `None`, the built-in default policy is loaded.
+    ///
+    /// # Errors
+    /// Returns an error if policy files cannot be read or parsed.
+    pub fn new(policy_path: Option<&Path>) -> RbacResult<Self> {
+        let mut policies = Vec::new();
+        let mut policy_paths = Vec::new();
+
+        // Validate policies by loading them into a throw-away engine
+        let mut validation_engine = Engine::new();
+
+        match policy_path {
+            Some(path) if path.is_dir() => {
+                let entries = std::fs::read_dir(path).map_err(|e| {
+                    RbacError::PolicyFile(format!(
+                        "cannot read RBAC policy directory {}: {e}",
+                        path.display()
+                    ))
+                })?;
+                for entry in entries {
+                    let entry = entry.map_err(|e| {
+                        RbacError::PolicyFile(format!("cannot read directory entry: {e}"))
+                    })?;
+                    let file_path = entry.path();
+                    if file_path.extension().is_some_and(|ext| ext == "rego") {
+                        let source = std::fs::read_to_string(&file_path).map_err(|e| {
+                            RbacError::PolicyFile(format!(
+                                "cannot read policy file {}: {e}",
+                                file_path.display()
+                            ))
+                        })?;
+                        let name = file_path.to_string_lossy().to_string();
+                        validation_engine
+                            .add_policy(name.clone(), source.clone())
+                            .map_err(|e| {
+                                RbacError::PolicyEvaluation(format!(
+                                    "failed to parse policy {}: {e}",
+                                    file_path.display()
+                                ))
+                            })?;
+                        info!("RBAC: loaded policy file {:?}", file_path);
+                        policies.push(PolicySource { name, source });
+                        policy_paths.push(file_path);
+                    }
+                }
+                if policy_paths.is_empty() {
+                    return Err(RbacError::PolicyFile(format!(
+                        "no .rego files found in directory {}",
+                        path.display()
+                    )));
+                }
+            }
+            Some(path) => {
+                let source = std::fs::read_to_string(path).map_err(|e| {
+                    RbacError::PolicyFile(format!(
+                        "cannot read policy file {}: {e}",
+                        path.display()
+                    ))
+                })?;
+                let name = path.to_string_lossy().to_string();
+                validation_engine
+                    .add_policy(name.clone(), source.clone())
+                    .map_err(|e| {
+                        RbacError::PolicyEvaluation(format!(
+                            "failed to parse policy {}: {e}",
+                            path.display()
+                        ))
+                    })?;
+                info!("RBAC: loaded policy file {:?}", path);
+                policies.push(PolicySource { name, source });
+                policy_paths.push(path.to_path_buf());
+            }
+            None => {
+                validation_engine
+                    .add_policy("default_rbac.rego".to_owned(), DEFAULT_POLICY.to_owned())
+                    .map_err(|e| {
+                        RbacError::PolicyEvaluation(format!(
+                            "failed to parse built-in default policy: {e}"
+                        ))
+                    })?;
+                info!("RBAC: loaded built-in default policy");
+                policies.push(PolicySource {
+                    name: "default_rbac.rego".to_owned(),
+                    source: DEFAULT_POLICY.to_owned(),
+                });
+                policy_paths.push(PathBuf::from("(built-in default)"));
+            }
+        }
+
+        Ok(Self {
+            policies,
+            policy_paths,
+        })
+    }
+
+    /// Return the paths of policies that were loaded.
+    #[must_use]
+    pub fn policy_paths(&self) -> &[PathBuf] {
+        &self.policy_paths
+    }
+
+    /// Build a fresh regorus engine with all policies loaded.
+    fn build_engine(&self) -> RbacResult<Engine> {
+        let mut engine = Engine::new();
+        for policy in &self.policies {
+            engine
+                .add_policy(policy.name.clone(), policy.source.clone())
+                .map_err(|e| {
+                    RbacError::PolicyEvaluation(format!(
+                        "failed to load policy '{}': {e}",
+                        policy.name
+                    ))
+                })?;
+        }
+        Ok(engine)
+    }
+}
+
+impl RbacEngine for RegorusEngine {
+    fn evaluate(&self, input: &RbacInput) -> RbacResult<bool> {
+        let input_json = serde_json::to_string(input)?;
+
+        let mut engine = self.build_engine()?;
+
+        engine
+            .set_input_json(&input_json)
+            .map_err(|e| RbacError::Serialization(format!("failed to set RBAC input: {e}")))?;
+
+        let result = engine
+            .eval_rule("data.cosmian.kms.rbac.allow".to_owned())
+            .map_err(|e| {
+                RbacError::PolicyEvaluation(format!(
+                    "failed to evaluate RBAC policy rule 'data.cosmian.kms.rbac.allow': {e}"
+                ))
+            })?;
+
+        let allowed = matches!(result, regorus::Value::Bool(true));
+        debug!(
+            "RBAC evaluation for user={}, op={}: allowed={}",
+            input.subject.user_id, input.action.operation, allowed
+        );
+
+        Ok(allowed)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::input::{ActionAttrs, EnvironmentAttrs, ResourceAttrs, SubjectAttrs};
+
+    fn make_input(user: &str, roles: &[&str], operation: &str, is_owner: bool) -> RbacInput {
+        RbacInput {
+            subject: SubjectAttrs {
+                user_id: user.to_owned(),
+                roles: roles.iter().map(|r| (*r).to_owned()).collect(),
+                is_owner,
+                is_privileged: false,
+            },
+            action: ActionAttrs {
+                operation: operation.to_owned(),
+            },
+            resource: ResourceAttrs {
+                unique_identifier: Some("key-123".to_owned()),
+                object_type: Some("SymmetricKey".to_owned()),
+                state: Some("Active".to_owned()),
+                owner: Some("owner@example.com".to_owned()),
+                sensitive: false,
+                extractable: true,
+            },
+            environment: EnvironmentAttrs::default(),
+        }
+    }
+
+    #[test]
+    fn test_administrator_allows_all() {
+        let engine = RegorusEngine::new(None).unwrap();
+        let input = make_input("admin@example.com", &["administrator"], "encrypt", false);
+        assert!(engine.evaluate(&input).unwrap());
+    }
+
+    #[test]
+    fn test_administrator_allows_destroy() {
+        let engine = RegorusEngine::new(None).unwrap();
+        let input = make_input("admin@example.com", &["administrator"], "destroy", false);
+        assert!(engine.evaluate(&input).unwrap());
+    }
+
+    #[test]
+    fn test_operator_allows_key_operations() {
+        let engine = RegorusEngine::new(None).unwrap();
+        for op in &[
+            "create", "encrypt", "decrypt", "sign", "get", "import", "export", "locate", "destroy",
+        ] {
+            let input = make_input("op@example.com", &["operator"], op, false);
+            assert!(
+                engine.evaluate(&input).unwrap(),
+                "operator should be allowed to {op}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_auditor_read_only() {
+        let engine = RegorusEngine::new(None).unwrap();
+        let input = make_input("auditor@example.com", &["auditor"], "get", false);
+        assert!(engine.evaluate(&input).unwrap());
+
+        let input = make_input("auditor@example.com", &["auditor"], "get_attributes", false);
+        assert!(engine.evaluate(&input).unwrap());
+
+        let input = make_input("auditor@example.com", &["auditor"], "encrypt", false);
+        assert!(!engine.evaluate(&input).unwrap());
+    }
+
+    #[test]
+    fn test_readonly_minimal() {
+        let engine = RegorusEngine::new(None).unwrap();
+        let input = make_input("reader@example.com", &["readonly"], "get_attributes", false);
+        assert!(engine.evaluate(&input).unwrap());
+
+        let input = make_input("reader@example.com", &["readonly"], "locate", false);
+        assert!(engine.evaluate(&input).unwrap());
+
+        let input = make_input("reader@example.com", &["readonly"], "get", false);
+        assert!(!engine.evaluate(&input).unwrap());
+    }
+
+    #[test]
+    fn test_no_roles_denied() {
+        let engine = RegorusEngine::new(None).unwrap();
+        let input = make_input("nobody@example.com", &[], "get", false);
+        assert!(!engine.evaluate(&input).unwrap());
+    }
+
+    #[test]
+    fn test_multiple_roles() {
+        let engine = RegorusEngine::new(None).unwrap();
+        let input = make_input("multi@example.com", &["readonly", "auditor"], "get", false);
+        // auditor role grants get
+        assert!(engine.evaluate(&input).unwrap());
+    }
+
+    #[test]
+    fn test_unknown_role_denied() {
+        let engine = RegorusEngine::new(None).unwrap();
+        let input = make_input("user@example.com", &["custom_role"], "encrypt", false);
+        assert!(!engine.evaluate(&input).unwrap());
+    }
+}

--- a/crate/server/Cargo.toml
+++ b/crate/server/Cargo.toml
@@ -72,6 +72,7 @@ clap = { workspace = true, features = [
 ] }
 cosmian_kms_access = { path = "../access", version = "5.21.0" }
 cosmian_kms_base_hsm = { path = "../hsm/base_hsm", version = "5.21.0" }
+cosmian_kms_rbac = { path = "../rbac", version = "5.21.0" }
 cosmian_kms_server_database = { path = "../server_database", version = "5.21.0" }
 cosmian_logger = { workspace = true, features = ["full"] }
 crypt2pay_pkcs11_loader = { path = "../hsm/crypt2pay", version = "5.21.0" }

--- a/crate/server/src/config/command_line/clap_config.rs
+++ b/crate/server/src/config/command_line/clap_config.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{
     GoogleCseConfig, HsmConfig, HttpConfig, IdpAuthConfig, KmipPolicyConfig, MainDBConfig,
-    WorkspaceConfig, logging::LoggingConfig, ui_config::UiConfig,
+    RbacConfig, WorkspaceConfig, logging::LoggingConfig, ui_config::UiConfig,
 };
 use crate::{
     config::{AzureEkmConfig, ProxyConfig, SocketServerConfig, TlsConfig},
@@ -69,6 +69,7 @@ impl Default for ClapConfig {
             aws_xks_config: AwsXksConfig::default(),
             kmip_policy: KmipPolicyConfig::default(),
             azure_ekm_config: AzureEkmConfig::default(),
+            rbac: RbacConfig::default(),
         }
     }
 }
@@ -202,6 +203,13 @@ pub struct ClapConfig {
     #[clap(flatten)]
     #[serde(rename = "kmip")]
     pub kmip_policy: KmipPolicyConfig,
+
+    /// RBAC (Role-Based Access Control) configuration.
+    ///
+    /// Enable RBAC by setting `--rbac-policy-path` to a `.rego` file or directory.
+    /// Optionally delegate policy evaluation to an external OPA server via `--opa-url`.
+    #[clap(flatten)]
+    pub rbac: RbacConfig,
 }
 
 impl ClapConfig {
@@ -642,6 +650,8 @@ impl fmt::Debug for ClapConfig {
             x.field("aws_xks_enable", &self.aws_xks_config.aws_xks_enable)
         };
         let x = x.field("kmip", &self.kmip_policy);
+        let x = x.field("rbac_policy_path", &self.rbac.rbac_policy_path);
+        let x = x.field("opa_url", &self.rbac.opa_url);
 
         x.finish()
     }

--- a/crate/server/src/config/command_line/mod.rs
+++ b/crate/server/src/config/command_line/mod.rs
@@ -8,6 +8,7 @@ mod idp_auth_config;
 mod kmip_policy_config;
 mod logging;
 mod proxy_config;
+mod rbac_config;
 mod socket_server_config;
 mod tls_config;
 mod ui_config;
@@ -27,6 +28,7 @@ pub use kmip_policy_config::{
 };
 pub use logging::LoggingConfig;
 pub use proxy_config::ProxyConfig;
+pub use rbac_config::RbacConfig;
 pub use socket_server_config::SocketServerConfig;
 pub use tls_config::TlsConfig;
 pub use ui_config::{OidcConfig, UiConfig, get_default_ui_dist_path};

--- a/crate/server/src/config/command_line/rbac_config.rs
+++ b/crate/server/src/config/command_line/rbac_config.rs
@@ -1,0 +1,42 @@
+use std::path::PathBuf;
+
+use clap::Args;
+use serde::{Deserialize, Serialize};
+
+/// RBAC (Role-Based Access Control) configuration.
+///
+/// When enabled, the KMS enforces role-based access control alongside
+/// the existing per-object ACL grants. Access is granted if **either**
+/// the RBAC policy **or** the existing ACL allows the operation (OR logic).
+///
+/// Roles are evaluated using OPA (Open Policy Agent) Rego policies,
+/// following the NIST SP 800-162 attribute-based access control model.
+#[derive(Args, Clone, Default, Deserialize, Serialize)]
+#[serde(default)]
+pub struct RbacConfig {
+    /// Path to a Rego (.rego) policy file or directory of Rego files
+    /// for RBAC evaluation. Setting this flag enables RBAC enforcement.
+    ///
+    /// A default policy with four roles (administrator, operator, auditor, readonly)
+    /// is shipped at `resources/rbac/default_rbac.rego`.
+    #[clap(long, env = "KMS_RBAC_POLICY_PATH", verbatim_doc_comment)]
+    pub rbac_policy_path: Option<PathBuf>,
+
+    /// URL of an external OPA server for RBAC policy evaluation.
+    /// When set, the KMS forwards authorization decisions to this OPA instance
+    /// instead of using the embedded Rego engine.
+    ///
+    /// Example: `http://localhost:8181`
+    ///
+    /// The decision endpoint queried is `/v1/data/cosmian/kms/rbac/allow`.
+    #[clap(long, env = "KMS_OPA_URL", verbatim_doc_comment)]
+    pub opa_url: Option<String>,
+}
+
+impl RbacConfig {
+    /// Returns `true` if RBAC is enabled (either embedded or external OPA).
+    #[must_use]
+    pub const fn is_enabled(&self) -> bool {
+        self.rbac_policy_path.is_some() || self.opa_url.is_some()
+    }
+}

--- a/crate/server/src/config/params/server_params.rs
+++ b/crate/server/src/config/params/server_params.rs
@@ -8,7 +8,7 @@ use cosmian_logger::{debug, warn};
 use super::{KmipPolicyParams, TlsParams};
 use crate::{
     config::{
-        AzureEkmConfig, ClapConfig, GoogleCseConfig, IdpConfig, OidcConfig,
+        AzureEkmConfig, ClapConfig, GoogleCseConfig, IdpConfig, OidcConfig, RbacConfig,
         params::{
             OpenTelemetryConfig, kmip_policy_params::KmipAllowlistsParams,
             proxy_params::ProxyParams,
@@ -155,6 +155,10 @@ pub struct ServerParams {
     /// Client-supplied `MaximumItems` is clamped to this value; when absent the cap is
     /// applied automatically. Prevents unbounded DB queries and large response payloads.
     pub max_locate_items: u32,
+
+    /// RBAC (Role-Based Access Control) configuration.
+    /// When enabled, the KMS enforces role-based access control via OPA Rego policies.
+    pub rbac: RbacConfig,
 }
 
 /// Represents the server parameters.
@@ -378,6 +382,7 @@ impl ServerParams {
             rate_limit_per_second: conf.http.rate_limit_per_second,
             cors_allowed_origins: conf.http.cors_allowed_origins.unwrap_or_default(),
             max_locate_items: 1000,
+            rbac: conf.rbac,
         };
 
         debug!("{res:#?}");
@@ -596,6 +601,18 @@ impl fmt::Debug for ServerParams {
         debug_struct.field("rate_limit_per_second", &self.rate_limit_per_second);
         debug_struct.field("cors_allowed_origins", &self.cors_allowed_origins);
         debug_struct.field("max_locate_items", &self.max_locate_items);
+
+        // RBAC configuration
+        if self.rbac.is_enabled() {
+            if let Some(ref policy_path) = self.rbac.rbac_policy_path {
+                debug_struct.field("rbac_policy_path", policy_path);
+            }
+            if let Some(ref opa_url) = self.rbac.opa_url {
+                debug_struct.field("opa_url", opa_url);
+            }
+        } else {
+            debug_struct.field("rbac", &"disabled");
+        }
 
         debug_struct.finish()
     }

--- a/crate/server/src/core/kms/mod.rs
+++ b/crate/server/src/core/kms/mod.rs
@@ -40,6 +40,9 @@ static GLOBAL_HSM: OnceCell<Arc<dyn HSM + Send + Sync>> = OnceCell::const_new();
 
 use crate::{config::ServerParams, core::OtelMetrics, error::KmsError, kms_bail, result::KResult};
 
+/// Type alias for a thread-safe, dynamically dispatched RBAC engine.
+pub(crate) type BoxedRbacEngine = Box<dyn cosmian_kms_rbac::RbacEngine + Sync + Send>;
+
 /// Macro to instantiate an HSM with support for environment variable override
 /// Allows overriding PKCS#11 lib path via env for testing (falls back to default constant)
 #[cfg(any(all(target_os = "linux", target_arch = "x86_64"), target_os = "macos"))]
@@ -87,6 +90,11 @@ pub struct KMS {
     /// Optional HSM instance for PKCS#11 operations.
     /// This is used for KMIP PKCS#11 operations like `C_Initialize`, `C_GetInfo`, `C_Finalize`.
     pub(crate) hsm: Option<Arc<dyn HSM + Send + Sync>>,
+
+    /// Optional RBAC engine for role-based access control.
+    /// When enabled, authorization decisions consult OPA/Rego policies
+    /// in addition to the existing per-object ACL grants.
+    pub(crate) rbac_engine: Option<BoxedRbacEngine>,
 }
 
 impl KMS {
@@ -140,12 +148,16 @@ impl KMS {
             );
         }
 
+        // Initialize RBAC engine if configured
+        let rbac_engine = Self::instantiate_rbac_engine(&server_params)?;
+
         Ok(Self {
             params: server_params.clone(),
             database,
             crypto_oracles: RwLock::new(crypto_oracles),
             hsm: hsm.clone(),
             metrics: Self::create_otel_metrics(&server_params)?,
+            rbac_engine,
         })
     }
 
@@ -278,5 +290,38 @@ impl KMS {
             }
         };
         Ok(hsm)
+    }
+
+    /// Initialize the RBAC engine based on server configuration.
+    ///
+    /// Returns `None` if RBAC is not configured. When an external OPA URL is set,
+    /// the engine forwards decisions to the remote OPA server. Otherwise, the
+    /// embedded `regorus` Rego engine is used with policy files loaded from
+    /// `rbac_policy_path`.
+    fn instantiate_rbac_engine(server_params: &ServerParams) -> KResult<Option<BoxedRbacEngine>> {
+        if !server_params.rbac.is_enabled() {
+            return Ok(None);
+        }
+
+        // External OPA server takes precedence if both are set
+        if let Some(ref opa_url) = server_params.rbac.opa_url {
+            cosmian_logger::info!("RBAC: using external OPA server at {opa_url}");
+            let engine = cosmian_kms_rbac::ExternalOpaEngine::new(opa_url);
+            return Ok(Some(Box::new(engine)));
+        }
+
+        // Embedded regorus engine with Rego policy files
+        let policy_path = server_params.rbac.rbac_policy_path.as_deref();
+        cosmian_logger::info!(
+            "RBAC: loading Rego policy from {}",
+            policy_path.map_or("(default)", |p| p.to_str().unwrap_or("?"))
+        );
+
+        let engine = cosmian_kms_rbac::RegorusEngine::new(policy_path)
+            .map_err(|e| KmsError::ServerError(format!("RBAC: failed to create engine: {e}")))?;
+
+        cosmian_logger::info!("RBAC: embedded Rego engine initialized");
+
+        Ok(Some(Box::new(engine)))
     }
 }

--- a/crate/server/src/core/retrieve_object_utils.rs
+++ b/crate/server/src/core/retrieve_object_utils.rs
@@ -160,15 +160,20 @@ pub(crate) async fn retrieve_object_for_operation(
 }
 
 /// Check if a user has permission to perform an operation on an object.
-///  If the user is the owner of the object, it will always return true.
-///  If the user has the `Get` permission, it will always return true.
-///  Otherwise, it will check the permissions in the database.
+///
+/// Authorization follows OR logic:
+///   1. **Owner check** — the object owner always has full access.
+///   2. **RBAC check** — if an RBAC engine is configured, the user's roles
+///      are loaded from the database and evaluated against the Rego policy.
+///   3. **ACL check** — existing per-object permission grants in the database.
+///
+/// Access is granted if *any* of the above checks succeed.
+///
 ///  # Arguments
 ///  * `user` - The user to check the permission for.
 ///  * `owm` - The object to check the permission on.
 ///  * `operation_type` - The operation to check the permission for.
 ///  * `kms` - The KMS instance.
-///  * `params` - The extra store params.
 ///  # Returns
 ///  * `Ok(true)` if the user has permission to perform the operation on the object.
 ///  * `Ok(false)` if the user does not have permission to perform the operation on the object.
@@ -178,15 +183,103 @@ pub(crate) async fn user_has_permission(
     operation_type: &KmipOperation,
     kms: &KMS,
 ) -> KResult<bool> {
+    // 1. Owner always has full access
     let id = match owm {
         Some(object) if user == object.owner() => return Ok(true),
         Some(object) => object.id(),
         None => "*",
     };
 
+    // 2. RBAC check (if engine is configured)
+    if let Some(ref rbac_engine) = kms.rbac_engine {
+        if rbac_check(rbac_engine.as_ref(), user, owm, operation_type, kms).await? {
+            return Ok(true);
+        }
+    }
+
+    // 3. Legacy ACL check
     let permissions = kms
         .database
         .list_user_operations_on_object(id, user, false)
         .await?;
     Ok(permissions.contains(operation_type) || permissions.contains(&KmipOperation::Get))
+}
+
+/// Evaluate the RBAC engine for a given user, object, and operation.
+///
+/// Builds an [`RbacInput`] following the NIST SP 800-162 attribute model
+/// and delegates to the configured RBAC engine (embedded regorus or external OPA).
+async fn rbac_check(
+    engine: &(dyn cosmian_kms_rbac::RbacEngine + Sync + Send),
+    user: &str,
+    owm: Option<&ObjectWithMetadata>,
+    operation_type: &KmipOperation,
+    kms: &KMS,
+) -> KResult<bool> {
+    use cosmian_kms_rbac::{ActionAttrs, EnvironmentAttrs, RbacInput, ResourceAttrs, SubjectAttrs};
+
+    // Load user roles from the database
+    let roles = kms.database.list_user_roles(user).await.unwrap_or_default();
+    if roles.is_empty() {
+        // No roles assigned — RBAC cannot grant access
+        return Ok(false);
+    }
+
+    let is_privileged = kms
+        .params
+        .privileged_users
+        .as_ref()
+        .is_some_and(|pu| pu.contains(&user.to_owned()));
+
+    let is_owner = owm.is_some_and(|o| o.owner() == user);
+
+    let subject = SubjectAttrs {
+        user_id: user.to_owned(),
+        roles,
+        is_owner,
+        is_privileged,
+    };
+
+    // Convert KmipOperation to lowercase snake_case for Rego
+    let op_name = format!("{operation_type:?}")
+        .chars()
+        .fold(String::new(), |mut acc, c| {
+            if c.is_uppercase() && !acc.is_empty() {
+                acc.push('_');
+            }
+            acc.push(c.to_ascii_lowercase());
+            acc
+        });
+
+    let action = ActionAttrs { operation: op_name };
+
+    let resource = owm.map_or_else(ResourceAttrs::default, |obj| ResourceAttrs {
+        unique_identifier: Some(obj.id().to_owned()),
+        object_type: Some(format!("{:?}", obj.object().object_type())),
+        state: obj.attributes().state.map(|s| format!("{s:?}")),
+        owner: Some(obj.owner().to_owned()),
+        sensitive: obj.attributes().sensitive.unwrap_or(false),
+        extractable: obj.attributes().extractable.unwrap_or(true),
+    });
+
+    let environment = EnvironmentAttrs::default();
+
+    let input = RbacInput {
+        subject,
+        action,
+        resource,
+        environment,
+    };
+
+    match engine.evaluate(&input) {
+        Ok(allowed) => {
+            trace!("RBAC decision for user={user}, operation={operation_type:?}: {allowed}");
+            Ok(allowed)
+        }
+        Err(e) => {
+            warn!("RBAC evaluation error for user={user}: {e}");
+            // On RBAC error, fall through to ACL check
+            Ok(false)
+        }
+    }
 }

--- a/crate/server/src/main.rs
+++ b/crate/server/src/main.rs
@@ -155,7 +155,7 @@ mod tests {
     use cosmian_kms_server::{
         config::{
             AzureEkmConfig, ClapConfig, GoogleCseConfig, HttpConfig, IdpAuthConfig,
-            KmipPolicyConfig, LoggingConfig, MainDBConfig, OidcConfig, ProxyConfig,
+            KmipPolicyConfig, LoggingConfig, MainDBConfig, OidcConfig, ProxyConfig, RbacConfig,
             SocketServerConfig, TlsConfig, UiConfig, WorkspaceConfig,
         },
         routes::aws_xks::AwsXksConfig,
@@ -248,6 +248,7 @@ mod tests {
             force_default_username: false,
             vendor_identification: VENDOR_ID_COSMIAN.to_owned(),
             kmip_policy: KmipPolicyConfig::default(),
+            rbac: RbacConfig::default(),
             ms_dke_service_url: Some("[ms dke service url]".to_owned()),
             logging: LoggingConfig {
                 rust_log: Some("info,cosmian_kms=debug".to_owned()),

--- a/crate/server/src/routes/mod.rs
+++ b/crate/server/src/routes/mod.rs
@@ -25,6 +25,7 @@ pub mod google_cse;
 pub mod health;
 pub mod kmip;
 pub mod ms_dke;
+pub mod rbac;
 pub mod root_redirect;
 pub mod ui_auth;
 mod utils;

--- a/crate/server/src/routes/rbac.rs
+++ b/crate/server/src/routes/rbac.rs
@@ -1,0 +1,242 @@
+use std::{collections::HashMap, sync::Arc};
+
+use actix_web::{
+    HttpRequest, delete, get, post,
+    web::{Data, Json, Path},
+};
+use cosmian_logger::info;
+use serde::{Deserialize, Serialize};
+
+use crate::{core::KMS, error::KmsError, result::KResult};
+
+// ---------------------------------------------------------------------------
+// Request / response types
+// ---------------------------------------------------------------------------
+
+/// Request body for assigning or removing a role.
+#[derive(Debug, Deserialize)]
+pub(crate) struct RoleRequest {
+    /// The user to assign/remove the role to/from.
+    pub user_id: String,
+    /// The role name (e.g. "administrator", "operator", "auditor", "readonly").
+    pub role: String,
+}
+
+/// Response for a successful role operation.
+#[derive(Debug, Serialize)]
+pub(crate) struct RoleResponse {
+    pub success: bool,
+    pub message: String,
+}
+
+/// A single role assignment entry.
+#[derive(Debug, Serialize)]
+pub(crate) struct RoleAssignment {
+    pub user_id: String,
+    pub role: String,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — only administrators (privileged users) may manage roles
+// ---------------------------------------------------------------------------
+
+fn require_admin(kms: &KMS, user: &str) -> KResult<()> {
+    let is_admin = kms
+        .params
+        .privileged_users
+        .as_ref()
+        .is_some_and(|pu| pu.contains(&user.to_owned()));
+
+    if !is_admin {
+        return Err(KmsError::Unauthorized(
+            "Only privileged users may manage RBAC roles".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Route handlers
+// ---------------------------------------------------------------------------
+
+/// Assign a role to a user.
+///
+/// `POST /rbac/roles`
+///
+/// Only privileged users (administrators) may call this endpoint.
+#[post("/rbac/roles")]
+pub(crate) async fn assign_role(
+    req: HttpRequest,
+    kms: Data<Arc<KMS>>,
+    body: Json<RoleRequest>,
+) -> KResult<Json<RoleResponse>> {
+    let span = tracing::span!(tracing::Level::ERROR, "assign_role");
+    let _enter = span.enter();
+
+    let caller = kms.get_user(&req);
+    require_admin(&kms, &caller)?;
+
+    info!(
+        user = caller,
+        target_user = body.user_id,
+        role = body.role,
+        "POST /rbac/roles — assign"
+    );
+
+    kms.database
+        .assign_role(&body.user_id, &body.role)
+        .await
+        .map_err(|e| KmsError::ServerError(format!("Failed to assign role: {e}")))?;
+
+    Ok(Json(RoleResponse {
+        success: true,
+        message: format!("Role '{}' assigned to user '{}'", body.role, body.user_id),
+    }))
+}
+
+/// Remove a role from a user.
+///
+/// `DELETE /rbac/roles`
+///
+/// Only privileged users (administrators) may call this endpoint.
+#[delete("/rbac/roles")]
+pub(crate) async fn remove_role(
+    req: HttpRequest,
+    kms: Data<Arc<KMS>>,
+    body: Json<RoleRequest>,
+) -> KResult<Json<RoleResponse>> {
+    let span = tracing::span!(tracing::Level::ERROR, "remove_role");
+    let _enter = span.enter();
+
+    let caller = kms.get_user(&req);
+    require_admin(&kms, &caller)?;
+
+    info!(
+        user = caller,
+        target_user = body.user_id,
+        role = body.role,
+        "DELETE /rbac/roles — remove"
+    );
+
+    kms.database
+        .remove_role(&body.user_id, &body.role)
+        .await
+        .map_err(|e| KmsError::ServerError(format!("Failed to remove role: {e}")))?;
+
+    Ok(Json(RoleResponse {
+        success: true,
+        message: format!("Role '{}' removed from user '{}'", body.role, body.user_id),
+    }))
+}
+
+/// List roles assigned to a specific user.
+///
+/// `GET /rbac/roles/{user_id}`
+///
+/// Only privileged users (administrators) may call this endpoint.
+#[get("/rbac/roles/{user_id}")]
+pub(crate) async fn list_user_roles(
+    req: HttpRequest,
+    kms: Data<Arc<KMS>>,
+    path: Path<String>,
+) -> KResult<Json<Vec<String>>> {
+    let span = tracing::span!(tracing::Level::ERROR, "list_user_roles");
+    let _enter = span.enter();
+
+    let caller = kms.get_user(&req);
+    require_admin(&kms, &caller)?;
+
+    let target_user = path.into_inner();
+    info!(
+        user = caller,
+        target_user = target_user,
+        "GET /rbac/roles/{target_user}"
+    );
+
+    let roles = kms
+        .database
+        .list_user_roles(&target_user)
+        .await
+        .map_err(|e| KmsError::ServerError(format!("Failed to list user roles: {e}")))?;
+
+    Ok(Json(roles))
+}
+
+/// List all role assignments across all users.
+///
+/// `GET /rbac/roles`
+///
+/// Only privileged users (administrators) may call this endpoint.
+#[get("/rbac/roles")]
+pub(crate) async fn list_all_roles(
+    req: HttpRequest,
+    kms: Data<Arc<KMS>>,
+) -> KResult<Json<Vec<RoleAssignment>>> {
+    let span = tracing::span!(tracing::Level::ERROR, "list_all_roles");
+    let _enter = span.enter();
+
+    let caller = kms.get_user(&req);
+    require_admin(&kms, &caller)?;
+
+    info!(user = caller, "GET /rbac/roles");
+
+    let assignments: HashMap<String, Vec<String>> = kms
+        .database
+        .list_all_role_assignments()
+        .await
+        .map_err(|e| KmsError::ServerError(format!("Failed to list role assignments: {e}")))?;
+
+    let mut result: Vec<RoleAssignment> = Vec::new();
+    for (user_id, roles) in assignments {
+        for role in roles {
+            result.push(RoleAssignment {
+                user_id: user_id.clone(),
+                role,
+            });
+        }
+    }
+
+    // Sort for deterministic output
+    result.sort_by(|a, b| a.user_id.cmp(&b.user_id).then(a.role.cmp(&b.role)));
+
+    Ok(Json(result))
+}
+
+/// Check whether RBAC enforcement is enabled on this server.
+///
+/// `GET /rbac/status`
+///
+/// This endpoint is accessible to all authenticated users.
+#[get("/rbac/status")]
+pub(crate) async fn rbac_status(
+    req: HttpRequest,
+    kms: Data<Arc<KMS>>,
+) -> KResult<Json<RbacStatusResponse>> {
+    let span = tracing::span!(tracing::Level::ERROR, "rbac_status");
+    let _enter = span.enter();
+
+    let caller = kms.get_user(&req);
+    info!(user = caller, "GET /rbac/status");
+
+    Ok(Json(RbacStatusResponse {
+        enabled: kms.rbac_engine.is_some(),
+        engine: if kms.rbac_engine.is_some() {
+            if kms.params.rbac.opa_url.is_some() {
+                "external_opa".to_owned()
+            } else {
+                "embedded_regorus".to_owned()
+            }
+        } else {
+            "none".to_owned()
+        },
+    }))
+}
+
+/// RBAC status information.
+#[derive(Debug, Serialize)]
+pub(crate) struct RbacStatusResponse {
+    /// Whether RBAC enforcement is active.
+    pub enabled: bool,
+    /// The engine type: `"embedded_regorus"`, `"external_opa"`, or `"none"`.
+    pub engine: String,
+}

--- a/crate/server/src/start_kms_server.rs
+++ b/crate/server/src/start_kms_server.rs
@@ -62,7 +62,7 @@ use crate::{
         google_cse::{self, GoogleCseConfig},
         health,
         kmip::{self, handle_ttlv_bytes},
-        ms_dke, root_redirect,
+        ms_dke, rbac, root_redirect,
         ui_auth::configure_auth_routes,
     },
     socket_server::{SocketServer, SocketServerParams},
@@ -1028,6 +1028,11 @@ pub async fn prepare_kms_server(kms_server: Arc<KMS>) -> KResult<actix_web::dev:
             .service(access::revoke_access)
             .service(access::get_create_access)
             .service(access::get_privileged_access)
+            .service(rbac::assign_role)
+            .service(rbac::remove_role)
+            .service(rbac::list_user_roles)
+            .service(rbac::list_all_roles)
+            .service(rbac::rbac_status)
             .service(
                 web::resource("/download-cli")
                     .route(web::get().to(cli_archive_download))

--- a/crate/server/src/tests/test_utils.rs
+++ b/crate/server/src/tests/test_utils.rs
@@ -232,7 +232,12 @@ pub(crate) async fn test_app(
         .service(routes::access::grant_access)
         .service(routes::access::revoke_access)
         .service(routes::access::get_create_access)
-        .service(routes::access::get_privileged_access);
+        .service(routes::access::get_privileged_access)
+        .service(routes::rbac::assign_role)
+        .service(routes::rbac::remove_role)
+        .service(routes::rbac::list_user_roles)
+        .service(routes::rbac::list_all_roles)
+        .service(routes::rbac::rbac_status);
 
     let google_cse_jwt_config = google_cse_auth(None)
         .await
@@ -296,7 +301,12 @@ pub(crate) async fn test_app_with_clap_config(
         .service(routes::access::grant_access)
         .service(routes::access::revoke_access)
         .service(routes::access::get_create_access)
-        .service(routes::access::get_privileged_access);
+        .service(routes::access::get_privileged_access)
+        .service(routes::rbac::assign_role)
+        .service(routes::rbac::remove_role)
+        .service(routes::rbac::list_user_roles)
+        .service(routes::rbac::list_all_roles)
+        .service(routes::rbac::rbac_status);
 
     let google_cse_jwt_config = google_cse_auth(None)
         .await

--- a/crate/server_database/src/core/database_roles.rs
+++ b/crate/server_database/src/core/database_roles.rs
@@ -1,0 +1,27 @@
+use std::collections::HashMap;
+
+use super::Database;
+use crate::error::DbResult;
+
+/// Methods that manipulate RBAC role assignments
+impl Database {
+    /// Assign a role to a user.
+    pub async fn assign_role(&self, user: &str, role: &str) -> DbResult<()> {
+        Ok(self.roles.assign_role(user, role).await?)
+    }
+
+    /// Remove a role from a user.
+    pub async fn remove_role(&self, user: &str, role: &str) -> DbResult<()> {
+        Ok(self.roles.remove_role(user, role).await?)
+    }
+
+    /// List all roles assigned to a user.
+    pub async fn list_user_roles(&self, user: &str) -> DbResult<Vec<String>> {
+        Ok(self.roles.list_user_roles(user).await?)
+    }
+
+    /// List all role assignments in the system.
+    pub async fn list_all_role_assignments(&self) -> DbResult<HashMap<String, Vec<String>>> {
+        Ok(self.roles.list_all_role_assignments().await?)
+    }
+}

--- a/crate/server_database/src/core/mod.rs
+++ b/crate/server_database/src/core/mod.rs
@@ -2,13 +2,14 @@
 //! permission checks, and caching mechanisms for unwrapped keys.
 mod database_objects;
 mod database_permissions;
+mod database_roles;
 
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 #[cfg(feature = "non-fips")]
 use cosmian_kms_crypto::reexport::cosmian_crypto_core::Secret;
-use cosmian_kms_interfaces::{ObjectsStore, PermissionsStore};
+use cosmian_kms_interfaces::{ObjectsStore, PermissionsStore, RoleStore};
 #[cfg(feature = "non-fips")]
 use redis::AsyncCommands;
 use tokio::sync::RwLock;
@@ -32,6 +33,8 @@ pub struct Database {
     objects: RwLock<HashMap<String, Arc<dyn ObjectsStore + Sync + Send>>>,
     /// The permissions store is used to check if a user has the right to perform an operation
     permissions: Arc<dyn PermissionsStore + Sync + Send>,
+    /// The role store manages RBAC role assignments (user → roles)
+    roles: Arc<dyn RoleStore + Sync + Send>,
     /// The Unwrapped cache keeps the unwrapped version of keys in memory.
     /// This cache avoids calls to HSMs for each operation
     unwrapped_cache: UnwrappedCache,
@@ -102,6 +105,7 @@ impl Database {
                 let health = Arc::new(SqliteHealthProbe::new(db.clone()));
                 Ok(Self::new(
                     db.clone(),
+                    db.clone(),
                     db,
                     cache_max_age,
                     MainDbKind::Sqlite,
@@ -112,6 +116,7 @@ impl Database {
                 let db = Arc::new(PgPool::instantiate(url, clear_db_on_start, *max_conns).await?);
                 let health = Arc::new(PgHealthProbe::new(db.clone()));
                 Ok(Self::new(
+                    db.clone(),
                     db.clone(),
                     db,
                     cache_max_age,
@@ -125,6 +130,7 @@ impl Database {
                 );
                 let health = Arc::new(MySqlHealthProbe::new(db.clone()));
                 Ok(Self::new(
+                    db.clone(),
                     db.clone(),
                     db,
                     cache_max_age,
@@ -154,6 +160,7 @@ impl Database {
                 let health = Arc::new(RedisFindexHealthProbe::new(db.clone()));
                 Ok(Self::new(
                     db.clone(),
+                    db.clone(),
                     db,
                     cache_max_age,
                     MainDbKind::RedisFindex,
@@ -180,6 +187,7 @@ impl Database {
     fn new(
         default_objects_database: Arc<dyn ObjectsStore + Sync + Send>,
         permissions_database: Arc<dyn PermissionsStore + Sync + Send>,
+        roles_database: Arc<dyn RoleStore + Sync + Send>,
         cache_max_age: Duration,
         kind: MainDbKind,
         health: Arc<dyn DatabaseHealth + Sync + Send>,
@@ -187,6 +195,7 @@ impl Database {
         Self {
             objects: RwLock::new(HashMap::from([(String::new(), default_objects_database)])),
             permissions: permissions_database,
+            roles: roles_database,
             unwrapped_cache: UnwrappedCache::new(cache_max_age),
             kind,
             health,

--- a/crate/server_database/src/stores/redis/redis_with_findex.rs
+++ b/crate/server_database/src/stores/redis/redis_with_findex.rs
@@ -14,7 +14,7 @@ use cosmian_kms_crypto::{
     reexport::cosmian_crypto_core::{FixedSizeCBytes, Secret, SymmetricKey, kdf256},
 };
 use cosmian_kms_interfaces::{
-    AtomicOperation, InterfaceResult, ObjectWithMetadata, ObjectsStore, PermissionsStore,
+    AtomicOperation, InterfaceResult, ObjectWithMetadata, ObjectsStore, PermissionsStore, RoleStore,
 };
 use cosmian_logger::{debug, trace};
 use cosmian_sse_memories::{ADDRESS_LENGTH, Address, RedisMemory};
@@ -661,6 +661,89 @@ impl PermissionsStore for RedisWithFindex {
             .unwrap_or_default()
             .into_iter()
             .collect())
+    }
+}
+
+/// Redis key prefix for RBAC role assignments.
+const ROLE_ASSIGNMENTS_KEY: &str = "kms:rbac:roles";
+
+#[async_trait(?Send)]
+impl RoleStore for RedisWithFindex {
+    async fn assign_role(&self, user: &str, role: &str) -> InterfaceResult<()> {
+        let key = format!("{ROLE_ASSIGNMENTS_KEY}:{user}");
+        let mut mgr = self.mgr.clone();
+        redis::cmd("SADD")
+            .arg(&key)
+            .arg(role)
+            .query_async::<()>(&mut mgr)
+            .await
+            .map_err(|e| {
+                DbError::DatabaseError(format!(
+                    "failed to assign role '{role}' to user '{user}': {e}"
+                ))
+            })?;
+        Ok(())
+    }
+
+    async fn remove_role(&self, user: &str, role: &str) -> InterfaceResult<()> {
+        let key = format!("{ROLE_ASSIGNMENTS_KEY}:{user}");
+        let mut mgr = self.mgr.clone();
+        redis::cmd("SREM")
+            .arg(&key)
+            .arg(role)
+            .query_async::<()>(&mut mgr)
+            .await
+            .map_err(|e| {
+                DbError::DatabaseError(format!(
+                    "failed to remove role '{role}' from user '{user}': {e}"
+                ))
+            })?;
+        Ok(())
+    }
+
+    async fn list_user_roles(&self, user: &str) -> InterfaceResult<Vec<String>> {
+        let key = format!("{ROLE_ASSIGNMENTS_KEY}:{user}");
+        let mut mgr = self.mgr.clone();
+        let roles: Vec<String> = redis::cmd("SMEMBERS")
+            .arg(&key)
+            .query_async(&mut mgr)
+            .await
+            .map_err(|e| {
+                DbError::DatabaseError(format!("failed to list roles for user '{user}': {e}"))
+            })?;
+        Ok(roles)
+    }
+
+    async fn list_all_role_assignments(&self) -> InterfaceResult<HashMap<String, Vec<String>>> {
+        let mut mgr = self.mgr.clone();
+        let pattern = format!("{ROLE_ASSIGNMENTS_KEY}:*");
+        let keys: Vec<String> = redis::cmd("KEYS")
+            .arg(&pattern)
+            .query_async(&mut mgr)
+            .await
+            .map_err(|e| {
+                DbError::DatabaseError(format!("failed to list role assignment keys: {e}"))
+            })?;
+
+        let prefix_len = ROLE_ASSIGNMENTS_KEY.len() + 1; // +1 for the ':'
+        let mut result: HashMap<String, Vec<String>> = HashMap::new();
+        for key in &keys {
+            if key.len() <= prefix_len {
+                continue;
+            }
+            let user = &key[prefix_len..];
+            let roles: Vec<String> = redis::cmd("SMEMBERS")
+                .arg(key)
+                .query_async(&mut mgr)
+                .await
+                .map_err(|e| {
+                    DbError::DatabaseError(format!("failed to get roles for key '{key}': {e}"))
+                })?;
+            if !roles.is_empty() {
+                result.insert(user.to_owned(), roles);
+            }
+        }
+        Ok(result)
     }
 }
 

--- a/crate/server_database/src/stores/sql/mysql.rs
+++ b/crate/server_database/src/stores/sql/mysql.rs
@@ -11,7 +11,7 @@ use cosmian_kmip::{
 };
 use cosmian_kms_interfaces::{
     AtomicOperation, InterfaceError, InterfaceResult, ObjectWithMetadata, ObjectsStore,
-    PermissionsStore,
+    PermissionsStore, RoleStore,
 };
 use cosmian_logger::{debug, trace};
 #[cfg(feature = "non-fips")]
@@ -249,6 +249,7 @@ impl MySqlPool {
             "create-table-objects",
             "create-table-read_access",
             "create-table-tags",
+            "create-table-role_assignments",
         ] {
             let sql = MYSQL_QUERIES
                 .get(name)
@@ -262,6 +263,7 @@ impl MySqlPool {
                 "clean-table-objects",
                 "clean-table-read_access",
                 "clean-table-tags",
+                "clean-table-role_assignments",
             ] {
                 if let Some(sql) = MYSQL_QUERIES.get(name) {
                     conn.query_drop(sql).await.map_err(DbError::from)?;
@@ -713,6 +715,56 @@ impl PermissionsStore for MySqlPool {
         no_inherited_access: bool,
     ) -> InterfaceResult<HashSet<KmipOperation>> {
         Ok(list_user_access_rights_on_object_(uid, user, no_inherited_access, &self.pool).await?)
+    }
+}
+
+#[async_trait(?Send)]
+impl RoleStore for MySqlPool {
+    async fn assign_role(&self, user: &str, role: &str) -> InterfaceResult<()> {
+        let mut conn = self.pool.get_conn().await.map_err(DbError::from)?;
+        conn.exec_drop(get_mysql_query!("insert-role_assignment"), (user, role))
+            .await
+            .map_err(DbError::from)?;
+        Ok(())
+    }
+
+    async fn remove_role(&self, user: &str, role: &str) -> InterfaceResult<()> {
+        let mut conn = self.pool.get_conn().await.map_err(DbError::from)?;
+        conn.exec_drop(get_mysql_query!("delete-role_assignment"), (user, role))
+            .await
+            .map_err(DbError::from)?;
+        Ok(())
+    }
+
+    async fn list_user_roles(&self, user: &str) -> InterfaceResult<Vec<String>> {
+        let mut conn = self.pool.get_conn().await.map_err(DbError::from)?;
+        let rows: Vec<mysql_async::Row> = conn
+            .exec(get_mysql_query!("select-user-roles"), (user,))
+            .await
+            .map_err(DbError::from)?;
+        let roles = rows
+            .iter()
+            .map(|r| r.get::<String, _>(0).unwrap_or_default())
+            .collect();
+        Ok(roles)
+    }
+
+    async fn list_all_role_assignments(&self) -> InterfaceResult<HashMap<String, Vec<String>>> {
+        let mut conn = self.pool.get_conn().await.map_err(DbError::from)?;
+        let rows: Vec<mysql_async::Row> = conn
+            .exec(
+                get_mysql_query!("select-all-role_assignments"),
+                mysql_async::Params::Empty,
+            )
+            .await
+            .map_err(DbError::from)?;
+        let mut result: HashMap<String, Vec<String>> = HashMap::new();
+        for row in &rows {
+            let user: String = row.get::<String, _>(0).unwrap_or_default();
+            let role: String = row.get::<String, _>(1).unwrap_or_default();
+            result.entry(user).or_default().push(role);
+        }
+        Ok(result)
     }
 }
 

--- a/crate/server_database/src/stores/sql/pgsql.rs
+++ b/crate/server_database/src/stores/sql/pgsql.rs
@@ -7,7 +7,7 @@ use cosmian_kmip::{
 };
 use cosmian_kms_interfaces::{
     AtomicOperation, InterfaceError, InterfaceResult, ObjectWithMetadata, ObjectsStore,
-    PermissionsStore,
+    PermissionsStore, RoleStore,
 };
 use deadpool_postgres::{Config as PgConfig, ManagerConfig, Pool, RecyclingMethod};
 use openssl::ssl::{SslConnector, SslFiletype, SslMethod, SslVerifyMode};
@@ -326,6 +326,7 @@ impl PgPool {
             "create-table-objects",
             "create-table-read_access",
             "create-table-tags",
+            "create-table-role_assignments",
         ] {
             let sql = tmp_loader.get_query(name)?;
             client.batch_execute(sql).await.map_err(DbError::from)?;
@@ -344,6 +345,7 @@ impl PgPool {
                 // Remove dependent rows first to avoid potential constraints if present
                 "clean-table-read_access",
                 "clean-table-tags",
+                "clean-table-role_assignments",
                 "clean-table-objects",
             ] {
                 let sql = tmp_loader.get_query(name)?;
@@ -981,6 +983,72 @@ impl PermissionsStore for PgPool {
                 }
             }
             Ok(perms)
+        })
+    }
+}
+
+#[async_trait(?Send)]
+impl RoleStore for PgPool {
+    async fn assign_role(&self, user: &str, role: &str) -> InterfaceResult<()> {
+        pg_retry!(self.pool, |client| {
+            let stmt = client
+                .prepare(get_pgsql_query!("insert-role_assignment"))
+                .await
+                .map_err(|e| InterfaceError::from(DbError::from(e)))?;
+            client
+                .execute(&stmt, &[&user, &role])
+                .await
+                .map_err(|e| InterfaceError::from(DbError::from(e)))?;
+            Ok(())
+        })
+    }
+
+    async fn remove_role(&self, user: &str, role: &str) -> InterfaceResult<()> {
+        pg_retry!(self.pool, |client| {
+            let stmt = client
+                .prepare(get_pgsql_query!("delete-role_assignment"))
+                .await
+                .map_err(|e| InterfaceError::from(DbError::from(e)))?;
+            client
+                .execute(&stmt, &[&user, &role])
+                .await
+                .map_err(|e| InterfaceError::from(DbError::from(e)))?;
+            Ok(())
+        })
+    }
+
+    async fn list_user_roles(&self, user: &str) -> InterfaceResult<Vec<String>> {
+        pg_retry!(self.pool, |client| {
+            let stmt = client
+                .prepare(get_pgsql_query!("select-user-roles"))
+                .await
+                .map_err(|e| InterfaceError::from(DbError::from(e)))?;
+            let rows = client
+                .query(&stmt, &[&user])
+                .await
+                .map_err(|e| InterfaceError::from(DbError::from(e)))?;
+            let roles: Vec<String> = rows.iter().map(|r| r.get(0)).collect();
+            Ok(roles)
+        })
+    }
+
+    async fn list_all_role_assignments(&self) -> InterfaceResult<HashMap<String, Vec<String>>> {
+        pg_retry!(self.pool, |client| {
+            let stmt = client
+                .prepare(get_pgsql_query!("select-all-role_assignments"))
+                .await
+                .map_err(|e| InterfaceError::from(DbError::from(e)))?;
+            let rows = client
+                .query(&stmt, &[])
+                .await
+                .map_err(|e| InterfaceError::from(DbError::from(e)))?;
+            let mut result: HashMap<String, Vec<String>> = HashMap::new();
+            for row in &rows {
+                let user: String = row.get(0);
+                let role: String = row.get(1);
+                result.entry(user).or_default().push(role);
+            }
+            Ok(result)
         })
     }
 }

--- a/crate/server_database/src/stores/sql/query.sql
+++ b/crate/server_database/src/stores/sql/query.sql
@@ -46,6 +46,13 @@ CREATE TABLE IF NOT EXISTS tags (
         UNIQUE (id, tag)
 );
 
+-- name: create-table-role_assignments
+CREATE TABLE IF NOT EXISTS role_assignments (
+        userid VARCHAR(255),
+        role VARCHAR(128),
+        UNIQUE (userid, role)
+);
+
 -- name: clean-table-objects
 DELETE FROM objects;
 
@@ -54,6 +61,9 @@ DELETE FROM read_access;
 
 -- name: clean-table-tags
 DELETE FROM tags;
+
+-- name: clean-table-role_assignments
+DELETE FROM role_assignments;
 
 -- name: insert-objects
 INSERT INTO objects (id, object, attributes, state, owner) VALUES ($1, $2, $3, $4, $5);
@@ -135,3 +145,15 @@ ON objects.id = matched_tags.id;
 
 -- name: select-uids-from-tags
 SELECT id FROM tags WHERE tag IN (@TAGS) GROUP BY id HAVING COUNT(DISTINCT tag) = @LEN;
+
+-- name: insert-role_assignment
+INSERT INTO role_assignments (userid, role) VALUES ($1, $2) ON CONFLICT(userid, role) DO NOTHING;
+
+-- name: delete-role_assignment
+DELETE FROM role_assignments WHERE userid=$1 AND role=$2;
+
+-- name: select-user-roles
+SELECT role FROM role_assignments WHERE userid=$1;
+
+-- name: select-all-role_assignments
+SELECT userid, role FROM role_assignments ORDER BY userid, role;

--- a/crate/server_database/src/stores/sql/query_mysql.sql
+++ b/crate/server_database/src/stores/sql/query_mysql.sql
@@ -55,6 +55,14 @@ CREATE TABLE IF NOT EXISTS tags
     PRIMARY KEY (id, tag)
 );
 
+-- name: create-table-role_assignments
+CREATE TABLE IF NOT EXISTS role_assignments
+(
+    userid VARCHAR(255) NOT NULL,
+    role   VARCHAR(128) NOT NULL,
+    PRIMARY KEY (userid, role)
+);
+
 -- name: clean-table-objects
 DELETE
 FROM objects;
@@ -66,6 +74,10 @@ FROM read_access;
 -- name: clean-table-tags
 DELETE
 FROM tags;
+
+-- name: clean-table-role_assignments
+DELETE
+FROM role_assignments;
 
 
 -- name: insert-objects
@@ -176,3 +188,15 @@ FROM tags
 WHERE tag IN (@TAGS)
 GROUP BY id
 HAVING COUNT(DISTINCT tag) = ?;
+
+-- name: insert-role_assignment
+INSERT IGNORE INTO role_assignments (userid, role) VALUES (?, ?);
+
+-- name: delete-role_assignment
+DELETE FROM role_assignments WHERE userid=? AND role=?;
+
+-- name: select-user-roles
+SELECT role FROM role_assignments WHERE userid=?;
+
+-- name: select-all-role_assignments
+SELECT userid, role FROM role_assignments ORDER BY userid, role;

--- a/crate/server_database/src/stores/sql/sqlite.rs
+++ b/crate/server_database/src/stores/sql/sqlite.rs
@@ -11,7 +11,7 @@ use cosmian_kmip::{
 };
 use cosmian_kms_interfaces::{
     AtomicOperation, InterfaceError, InterfaceResult, ObjectWithMetadata, ObjectsStore,
-    PermissionsStore,
+    PermissionsStore, RoleStore,
 };
 use rawsql::Loader;
 use rusqlite::{OptionalExtension, Row, params_from_iter};
@@ -76,9 +76,11 @@ impl SqlitePool {
         let create_objects = pool.get_query("create-table-objects")?.to_owned();
         let create_read_access = pool.get_query("create-table-read_access")?.to_owned();
         let create_tags = pool.get_query("create-table-tags")?.to_owned();
+        let create_role_assignments = pool.get_query("create-table-role_assignments")?.to_owned();
         let clean_objects = pool.get_query("clean-table-objects")?.to_owned();
         let clean_read_access = pool.get_query("clean-table-read_access")?.to_owned();
         let clean_tags = pool.get_query("clean-table-tags")?.to_owned();
+        let clean_role_assignments = pool.get_query("clean-table-role_assignments")?.to_owned();
         pool.conn
             .call(
                 move |c: &mut rusqlite::Connection| -> Result<(), rusqlite::Error> {
@@ -87,10 +89,12 @@ impl SqlitePool {
                     tx.execute(&create_objects, [])?;
                     tx.execute(&create_read_access, [])?;
                     tx.execute(&create_tags, [])?;
+                    tx.execute(&create_role_assignments, [])?;
                     if clear_database {
                         tx.execute(&clean_objects, [])?;
                         tx.execute(&clean_read_access, [])?;
                         tx.execute(&clean_tags, [])?;
+                        tx.execute(&clean_role_assignments, [])?;
                     }
                     tx.commit()?;
                     Ok(())
@@ -772,6 +776,88 @@ impl SqlitePool {
             })
             .await
             .map_err(DbError::from)
+    }
+}
+
+#[async_trait(?Send)]
+impl RoleStore for SqlitePool {
+    async fn assign_role(&self, user: &str, role: &str) -> InterfaceResult<()> {
+        let sql = replace_dollars_with_qn(get_sqlite_query!("insert-role_assignment"));
+        let user_s = user.to_owned();
+        let role_s = role.to_owned();
+        self.conn
+            .call(
+                move |c: &mut rusqlite::Connection| -> Result<(), rusqlite::Error> {
+                    c.execute(&sql, params_from_iter([&user_s, &role_s]))?;
+                    Ok(())
+                },
+            )
+            .await
+            .map_err(DbError::from)?;
+        Ok(())
+    }
+
+    async fn remove_role(&self, user: &str, role: &str) -> InterfaceResult<()> {
+        let sql = replace_dollars_with_qn(get_sqlite_query!("delete-role_assignment"));
+        let user_s = user.to_owned();
+        let role_s = role.to_owned();
+        self.conn
+            .call(
+                move |c: &mut rusqlite::Connection| -> Result<(), rusqlite::Error> {
+                    c.execute(&sql, params_from_iter([&user_s, &role_s]))?;
+                    Ok(())
+                },
+            )
+            .await
+            .map_err(DbError::from)?;
+        Ok(())
+    }
+
+    async fn list_user_roles(&self, user: &str) -> InterfaceResult<Vec<String>> {
+        let sql = replace_dollars_with_qn(get_sqlite_query!("select-user-roles"));
+        let user_s = user.to_owned();
+        let roles = self
+            .conn
+            .call(
+                move |c: &mut rusqlite::Connection| -> Result<Vec<String>, rusqlite::Error> {
+                    let mut stmt = c.prepare(&sql)?;
+                    let mut rows = stmt.query(params_from_iter([&user_s]))?;
+                    let mut result = Vec::new();
+                    while let Some(r) = rows.next()? {
+                        let role: String = r.get(0)?;
+                        result.push(role);
+                    }
+                    Ok(result)
+                },
+            )
+            .await
+            .map_err(DbError::from)?;
+        Ok(roles)
+    }
+
+    async fn list_all_role_assignments(&self) -> InterfaceResult<HashMap<String, Vec<String>>> {
+        let sql = get_sqlite_query!("select-all-role_assignments").to_string();
+        let map = self
+            .conn
+            .call(
+                move |c: &mut rusqlite::Connection| -> Result<
+                    HashMap<String, Vec<String>>,
+                    rusqlite::Error,
+                > {
+                    let mut stmt = c.prepare(&sql)?;
+                    let mut rows = stmt.query([])?;
+                    let mut result: HashMap<String, Vec<String>> = HashMap::new();
+                    while let Some(r) = rows.next()? {
+                        let user: String = r.get(0)?;
+                        let role: String = r.get(1)?;
+                        result.entry(user).or_default().push(role);
+                    }
+                    Ok(result)
+                },
+            )
+            .await
+            .map_err(DbError::from)?;
+        Ok(map)
     }
 }
 

--- a/deny.toml
+++ b/deny.toml
@@ -104,6 +104,7 @@ allow = [
   "CC0-1.0",
   "BUSL-1.1",
   "GPL-3.0-or-later", # legacy dependency note
+  "CDLA-Permissive-2.0", # webpki-roots (Mozilla root certificates)
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the

--- a/nix/expected-hashes/cli.vendor.linux.sha256
+++ b/nix/expected-hashes/cli.vendor.linux.sha256
@@ -1,1 +1,1 @@
-sha256-DdyPC95YZiEIsx+NfM/gRRsTfeaj3CYD1M/ZAwxcR9Y=
+sha256-pBAXkaEZQ6TjLREs9UKSFionRrukY2qBAbyDSQaqDug=

--- a/nix/expected-hashes/server.vendor.dynamic.sha256
+++ b/nix/expected-hashes/server.vendor.dynamic.sha256
@@ -1,1 +1,1 @@
-sha256-sSvhpvGU8xqK8F2XktX/dOpr05w/GFR0iyYjD9lrGm8=
+sha256-Q3ZD6DikIfVAdXu7bAuZcD7VH6nvTgozwdPdTxQAOXA=

--- a/nix/expected-hashes/server.vendor.static.sha256
+++ b/nix/expected-hashes/server.vendor.static.sha256
@@ -1,1 +1,1 @@
-sha256-jCJCaae4hb3vkEP/vWGupRfojjcPx16sm666yVpHhhQ=
+sha256-Rac+BfNQXrxeu7GBlk4iLLWXX7CSRagIvzAFx/wJCPM=

--- a/resources/rbac/default_rbac.rego
+++ b/resources/rbac/default_rbac.rego
@@ -1,0 +1,85 @@
+# Cosmian KMS — Default RBAC Policy
+#
+# This policy implements role-based access control aligned with NIST SP 800-162.
+# It defines four default roles: administrator, operator, auditor, and readonly.
+#
+# Input schema (NIST SP 800-162 attributes):
+#   input.subject.user_id       — authenticated user identifier
+#   input.subject.roles         — list of assigned roles
+#   input.subject.is_owner      — true if user owns the target object
+#   input.subject.is_privileged — true if user is in the privileged_users list
+#   input.action.operation      — KMIP operation (lowercase)
+#   input.resource.*            — target object attributes
+#   input.environment.*         — contextual attributes (reserved)
+#
+# Decision: data.cosmian.kms.rbac.allow = true | false
+
+package cosmian.kms.rbac
+
+import rego.v1
+
+default allow := false
+
+# ── Administrator ────────────────────────────────────────────────────────
+# Full access to all operations.
+allow if {
+    some role in input.subject.roles
+    role == "administrator"
+}
+
+# ── Operator ─────────────────────────────────────────────────────────────
+# All key management and cryptographic operations.
+allow if {
+    some role in input.subject.roles
+    role == "operator"
+    input.action.operation in operator_operations
+}
+
+operator_operations := {
+    "create",
+    "certify",
+    "decrypt",
+    "derive_key",
+    "destroy",
+    "encrypt",
+    "export",
+    "get",
+    "get_attributes",
+    "hash",
+    "import",
+    "locate",
+    "mac",
+    "revoke",
+    "rekey",
+    "sign",
+    "signature_verify",
+    "validate",
+}
+
+# ── Auditor ──────────────────────────────────────────────────────────────
+# Read-only access for inspection and compliance auditing.
+allow if {
+    some role in input.subject.roles
+    role == "auditor"
+    input.action.operation in auditor_operations
+}
+
+auditor_operations := {
+    "get",
+    "get_attributes",
+    "locate",
+    "validate",
+}
+
+# ── Read-Only ────────────────────────────────────────────────────────────
+# Minimal access: can only list and inspect metadata.
+allow if {
+    some role in input.subject.roles
+    role == "readonly"
+    input.action.operation in readonly_operations
+}
+
+readonly_operations := {
+    "get_attributes",
+    "locate",
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -6,6 +6,8 @@ import AccessListForm from "./actions/Access/AccessList";
 import AccessObtainedList from "./actions/Access/AccessObtained";
 import AccessRevokeForm from "./actions/Access/AccessRevoke";
 import AttributeDeleteForm from "./actions/Attributes/AttributeDelete";
+import RbacRoleManagement from "./actions/Rbac/RbacRoleManagement";
+import RbacStatus from "./actions/Rbac/RbacStatus";
 import AttributeGetForm from "./actions/Attributes/AttributeGet";
 import AttributeModifyForm from "./actions/Attributes/AttributeModify";
 import AttributeSetForm from "./actions/Attributes/AttributeSet";
@@ -325,6 +327,10 @@ const AppContent: React.FC<AppContentProps> = ({ isDarkMode, setIsDarkMode, wasm
                             <Route path="list" element={<AccessListForm />} />
                             <Route path="owned" element={<ObjectsOwnedList />} />
                             <Route path="obtained" element={<AccessObtainedList />} />
+                        </Route>
+                        <Route path="rbac">
+                            <Route path="roles" element={<RbacRoleManagement />} />
+                            <Route path="status" element={<RbacStatus />} />
                         </Route>
                         <Route path="certificates">
                             <Route path="certs/import" element={<CertificateImportForm />} />

--- a/ui/src/actions/Rbac/RbacRoleManagement.tsx
+++ b/ui/src/actions/Rbac/RbacRoleManagement.tsx
@@ -1,0 +1,182 @@
+import { Button, Card, Form, Input, Select, Space, Table, Tag, Popconfirm } from "antd";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { useAuth } from "../../contexts/AuthContext";
+import { deleteNoTTLVRequest, getNoTTLVRequest, postNoTTLVRequest } from "../../utils/utils";
+
+interface RoleAssignment {
+    user_id: string;
+    role: string;
+}
+
+interface AssignRoleFormData {
+    user_id: string;
+    role: string;
+}
+
+const BUILT_IN_ROLES = [
+    { label: "Administrator", value: "administrator" },
+    { label: "Operator", value: "operator" },
+    { label: "Auditor", value: "auditor" },
+    { label: "Read Only", value: "readonly" },
+];
+
+const RbacRoleManagement: React.FC = () => {
+    const [form] = Form.useForm<AssignRoleFormData>();
+    const [assignments, setAssignments] = useState<RoleAssignment[]>([]);
+    const [isLoading, setIsLoading] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [res, setRes] = useState<string | undefined>(undefined);
+    const { idToken, serverUrl } = useAuth();
+    const responseRef = useRef<HTMLDivElement>(null);
+
+    const fetchAssignments = useCallback(async () => {
+        setIsLoading(true);
+        try {
+            const response: RoleAssignment[] = await getNoTTLVRequest("/rbac/roles", idToken, serverUrl);
+            setAssignments(response);
+            setRes(undefined);
+        } catch (e) {
+            setRes(`Error fetching role assignments: ${e}`);
+            console.error("Error fetching role assignments:", e);
+        } finally {
+            setIsLoading(false);
+        }
+    }, [idToken, serverUrl]);
+
+    useEffect(() => {
+        if (idToken) {
+            fetchAssignments();
+        } else {
+            setAssignments([]);
+        }
+    }, [fetchAssignments, idToken]);
+
+    const onFinish = async (values: AssignRoleFormData) => {
+        setIsSubmitting(true);
+        setRes(undefined);
+        try {
+            await postNoTTLVRequest("/rbac/roles", values, idToken, serverUrl);
+            setRes(`Role '${values.role}' assigned to user '${values.user_id}'`);
+            form.resetFields();
+            await fetchAssignments();
+        } catch (e) {
+            setRes(`Error assigning role: ${e}`);
+            console.error("Error assigning role:", e);
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    const handleRemove = async (userId: string, role: string) => {
+        try {
+            await deleteNoTTLVRequest("/rbac/roles", { user_id: userId, role }, idToken, serverUrl);
+            setRes(`Role '${role}' removed from user '${userId}'`);
+            await fetchAssignments();
+        } catch (e) {
+            setRes(`Error removing role: ${e}`);
+            console.error("Error removing role:", e);
+        }
+    };
+
+    const roleColors: Record<string, string> = {
+        administrator: "red",
+        operator: "blue",
+        auditor: "green",
+        readonly: "default",
+    };
+
+    const columns = [
+        {
+            title: "User",
+            dataIndex: "user_id",
+            key: "user_id",
+            sorter: (a: RoleAssignment, b: RoleAssignment) => a.user_id.localeCompare(b.user_id),
+        },
+        {
+            title: "Role",
+            dataIndex: "role",
+            key: "role",
+            render: (role: string) => <Tag color={roleColors[role] || "default"}>{role}</Tag>,
+            sorter: (a: RoleAssignment, b: RoleAssignment) => a.role.localeCompare(b.role),
+        },
+        {
+            title: "Actions",
+            key: "actions",
+            render: (_value: unknown, record: RoleAssignment) => (
+                <Popconfirm
+                    title={`Remove role '${record.role}' from '${record.user_id}'?`}
+                    onConfirm={() => handleRemove(record.user_id, record.role)}
+                    okText="Yes"
+                    cancelText="No"
+                >
+                    <Button type="link" danger data-testid={`remove-${record.user_id}-${record.role}`}>
+                        Remove
+                    </Button>
+                </Popconfirm>
+            ),
+        },
+    ];
+
+    return (
+        <div className="p-6">
+            <div className="flex justify-between items-center mb-6">
+                <h1 className="text-2xl font-bold">RBAC Role Management</h1>
+                <Button type="primary" onClick={fetchAssignments} loading={isLoading} className="bg-primary">
+                    Refresh
+                </Button>
+            </div>
+
+            <Space direction="vertical" size="large" style={{ display: "flex" }}>
+                <Card title="Assign Role">
+                    <Form form={form} onFinish={onFinish} layout="vertical" initialValues={{ role: "operator" }}>
+                        <Space direction="horizontal" size="middle" wrap>
+                            <Form.Item
+                                name="user_id"
+                                label="User Identifier"
+                                rules={[{ required: true, message: "Please enter a user identifier" }]}
+                            >
+                                <Input
+                                    placeholder="user@example.com"
+                                    style={{ minWidth: 250 }}
+                                    data-testid="rbac-user-id"
+                                />
+                            </Form.Item>
+                            <Form.Item name="role" label="Role" rules={[{ required: true, message: "Please select a role" }]}>
+                                <Select
+                                    options={BUILT_IN_ROLES}
+                                    style={{ minWidth: 180 }}
+                                    data-testid="rbac-role-select"
+                                />
+                            </Form.Item>
+                            <Form.Item label=" ">
+                                <Button type="primary" htmlType="submit" loading={isSubmitting} data-testid="rbac-assign-btn">
+                                    Assign Role
+                                </Button>
+                            </Form.Item>
+                        </Space>
+                    </Form>
+                </Card>
+
+                {res && (
+                    <div ref={responseRef} data-testid="rbac-response">
+                        <Card>{res}</Card>
+                    </div>
+                )}
+
+                <Card title="Current Role Assignments">
+                    <Table
+                        dataSource={assignments}
+                        columns={columns}
+                        rowKey={(record) => `${record.user_id}-${record.role}`}
+                        loading={isLoading}
+                        pagination={false}
+                        data-testid="rbac-assignments-table"
+                        locale={{ emptyText: "No role assignments" }}
+                    />
+                </Card>
+            </Space>
+        </div>
+    );
+};
+
+export default RbacRoleManagement;

--- a/ui/src/actions/Rbac/RbacStatus.tsx
+++ b/ui/src/actions/Rbac/RbacStatus.tsx
@@ -1,0 +1,79 @@
+import { Card, Descriptions, Spin, Tag } from "antd";
+import React, { useCallback, useEffect, useState } from "react";
+import { useAuth } from "../../contexts/AuthContext";
+import { getNoTTLVRequest } from "../../utils/utils";
+
+interface RbacStatusData {
+    enabled: boolean;
+    engine: string;
+}
+
+const RbacStatus: React.FC = () => {
+    const [status, setStatus] = useState<RbacStatusData | undefined>(undefined);
+    const [isLoading, setIsLoading] = useState(false);
+    const [error, setError] = useState<string | undefined>(undefined);
+    const { idToken, serverUrl } = useAuth();
+
+    const fetchStatus = useCallback(async () => {
+        setIsLoading(true);
+        setError(undefined);
+        try {
+            const response: RbacStatusData = await getNoTTLVRequest("/rbac/status", idToken, serverUrl);
+            setStatus(response);
+        } catch (e) {
+            setError(`Error fetching RBAC status: ${e}`);
+            console.error("Error fetching RBAC status:", e);
+        } finally {
+            setIsLoading(false);
+        }
+    }, [idToken, serverUrl]);
+
+    useEffect(() => {
+        if (idToken) {
+            fetchStatus();
+        } else {
+            setStatus(undefined);
+        }
+    }, [fetchStatus, idToken]);
+
+    const engineLabel = (engine: string) => {
+        switch (engine) {
+            case "embedded_regorus":
+                return "Embedded Rego (regorus)";
+            case "external_opa":
+                return "External OPA Server";
+            default:
+                return engine;
+        }
+    };
+
+    return (
+        <div className="p-6">
+            <h1 className="text-2xl font-bold mb-6">RBAC Status</h1>
+            {isLoading && <Spin size="large" />}
+            {error && <Card>{error}</Card>}
+            {status && (
+                <Card data-testid="rbac-status-card">
+                    <Descriptions column={1} bordered>
+                        <Descriptions.Item label="RBAC Enforcement">
+                            {status.enabled ? (
+                                <Tag color="green" data-testid="rbac-enabled-tag">
+                                    ENABLED
+                                </Tag>
+                            ) : (
+                                <Tag color="default" data-testid="rbac-disabled-tag">
+                                    DISABLED
+                                </Tag>
+                            )}
+                        </Descriptions.Item>
+                        <Descriptions.Item label="Policy Engine">
+                            {engineLabel(status.engine)}
+                        </Descriptions.Item>
+                    </Descriptions>
+                </Card>
+            )}
+        </div>
+    );
+};
+
+export default RbacStatus;

--- a/ui/src/menuItems.tsx
+++ b/ui/src/menuItems.tsx
@@ -216,6 +216,15 @@ const baseMenu: MenuItem[] = [
         ],
     },
     {
+        key: "rbac",
+        label: "RBAC",
+        icon: <TeamOutlined />,
+        children: [
+            { key: "rbac/roles", label: "Roles" },
+            { key: "rbac/status", label: "Status" },
+        ],
+    },
+    {
         key: "hyperscalers",
         label: "Hyperscalers",
         icon: <CloudOutlined />,

--- a/ui/src/utils/utils.ts
+++ b/ui/src/utils/utils.ts
@@ -103,6 +103,26 @@ export const getNoTTLVRequest = async (path: string, idToken: string | null, ser
     return await response.json();
 };
 
+export const deleteNoTTLVRequest = async (path: string, request: object, idToken: string | null, serverUrl: string) => {
+    const kmsUrl = serverUrl + path;
+    const response = await fetch(kmsUrl, {
+        method: "DELETE",
+        credentials: "include",
+        headers: {
+            "Content-Type": "application/json",
+            ...(idToken && { Authorization: `Bearer ${idToken}` }),
+        },
+        body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`${response.status}: ${errorText}`);
+    }
+
+    return await response.json();
+};
+
 export const getNoTTLVRequestWithTimeout = async (path: string, idToken: string | null, serverUrl: string, timeoutMs: number) => {
     const kmsUrl = serverUrl + path;
     const controller = new AbortController();


### PR DESCRIPTION
Implement Role-Based Access Control following NIST SP 800-162 using Open Policy Agent Rego policies evaluated via Microsoft's regorus crate.

- New cosmian_kms_rbac crate with embedded Rego + external OPA support
- RoleStore trait with SQLite, PostgreSQL, MySQL, Redis implementations
- Server config: --rbac-policy-path and --opa-url flags
- Default Rego policy with 4 roles: administrator, operator, auditor, readonly
- RBAC works alongside existing ACL (OR logic)
- REST API: POST/DELETE/GET /rbac/roles, GET /rbac/status
- CLI: ckms rbac assign-role, remove-role, list, list-all, status
- Web UI: RBAC role management and status pages