### PR TITLE
docs(monitoring): add download section and publish monitoring job

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -304,6 +304,49 @@ jobs:
               cosmian@package.cosmian.com:"${remote_dir}/"
           done
 
+  publish-monitoring:
+    name: Publish monitoring stack archive
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
+      || startsWith(github.ref, 'refs/tags/')
+      || github.event_name == 'workflow_dispatch'
+    runs-on: [self-hosted, not-sgx]
+    container:
+      image: cosmian/docker_doc_ci
+      volumes:
+        - /home/cosmian/.ssh/id_rsa:/root/.ssh/id_rsa
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+
+      - name: Create monitoring archive
+        run: |
+          zip -r cosmian-kms-monitoring.zip monitoring/
+
+      - name: Push to package.cosmian.com
+        shell: bash
+        run: |
+          set -ex
+          if [[ "${GITHUB_REF}" =~ 'refs/tags/' ]]; then
+            BRANCH="${GITHUB_REF_NAME}"
+          else
+            BRANCH="last_build/${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+          fi
+          REMOTE_DIR="/mnt/package/kms/${BRANCH}/monitoring"
+          ssh -o 'StrictHostKeyChecking no' -i /root/.ssh/id_rsa cosmian@package.cosmian.com mkdir -p "${REMOTE_DIR}"
+          scp -o 'StrictHostKeyChecking no' -i /root/.ssh/id_rsa \
+            cosmian-kms-monitoring.zip \
+            cosmian@package.cosmian.com:"${REMOTE_DIR}/"
+
+      - name: Publish GitHub Release asset
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v3
+        with:
+          files: cosmian-kms-monitoring.zip
+
   cargo-publish:
     uses: ./.github/workflows/cargo-publish.yml
     with:

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -304,17 +304,13 @@ jobs:
               cosmian@package.cosmian.com:"${remote_dir}/"
           done
 
-  publish-monitoring:
-    name: Publish monitoring stack archive
+  build-monitoring-archive:
+    name: Build monitoring stack archive
     if: |
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
       || startsWith(github.ref, 'refs/tags/')
       || github.event_name == 'workflow_dispatch'
-    runs-on: [self-hosted, not-sgx]
-    container:
-      image: cosmian/docker_doc_ci
-      volumes:
-        - /home/cosmian/.ssh/id_rsa:/root/.ssh/id_rsa
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
@@ -323,8 +319,34 @@ jobs:
           submodules: false
 
       - name: Create monitoring archive
-        run: |
-          zip -r cosmian-kms-monitoring.zip monitoring/
+        run: zip -r cosmian-kms-monitoring.zip monitoring/
+
+      - name: Upload monitoring archive artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: cosmian-kms-monitoring
+          path: cosmian-kms-monitoring.zip
+          retention-days: 1
+          if-no-files-found: error
+
+  publish-monitoring:
+    name: Publish monitoring stack archive
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
+      || startsWith(github.ref, 'refs/tags/')
+      || github.event_name == 'workflow_dispatch'
+    needs: build-monitoring-archive
+    runs-on: [self-hosted, not-sgx]
+    container:
+      image: cosmian/docker_doc_ci
+      volumes:
+        - /home/cosmian/.ssh/id_rsa:/root/.ssh/id_rsa
+
+    steps:
+      - name: Download monitoring archive artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: cosmian-kms-monitoring
 
       - name: Push to package.cosmian.com
         shell: bash

--- a/documentation/docs/configuration/monitoring-setup.md
+++ b/documentation/docs/configuration/monitoring-setup.md
@@ -7,11 +7,34 @@
 
 ## Table of contents
 
-1. [Prerequisites](#prerequisites)
-2. [Local mode — KMS included](#local-mode--kms-included)
-3. [External mode — existing KMS](#external-mode--existing-kms)
-4. [Explore Grafana](#explore-grafana)
-5. [Troubleshooting](#troubleshooting)
+1. [Download](#download)
+2. [Prerequisites](#prerequisites)
+3. [Local mode — KMS included](#local-mode--kms-included)
+4. [External mode — existing KMS](#external-mode--existing-kms)
+5. [Explore Grafana](#explore-grafana)
+6. [Troubleshooting](#troubleshooting)
+
+---
+
+## Download
+
+The monitoring stack is distributed as a standalone archive containing the Docker Compose file,
+configuration templates, and helper scripts.
+
+Download the archive from the [KMS GitHub Releases page](https://github.com/Cosmian/kms/releases/latest)
+(`cosmian-kms-monitoring.zip`), or use `wget` with the version you are deploying:
+
+```bash
+wget https://package.cosmian.com/kms/<version>/monitoring/cosmian-kms-monitoring.zip
+unzip cosmian-kms-monitoring.zip
+cd monitoring/
+```
+
+Replace `<version>` with the KMS version you are deploying (e.g. `5.22.0`).
+The list of available versions is at <https://package.cosmian.com/kms/>.
+
+Alternatively, clone the [KMS repository](https://github.com/Cosmian/kms) and navigate to the
+`monitoring/` directory.
 
 ---
 
@@ -75,6 +98,13 @@ The following ports must be free on the host before starting the stack:
 
 In this mode, the full stack starts together: KMS, OTel Collector, VictoriaMetrics, and Grafana.
 Use this mode for local development or to evaluate the stack end-to-end.
+
+All files referenced below (`docker-compose.yml`, `.env`, `generate-demo-cert.sh`) are located in the
+`monitoring/` directory of the KMS repository. Navigate there first:
+
+```bash
+cd monitoring/
+```
 
 ### 1. Configure `.env`
 
@@ -177,6 +207,13 @@ Expected response: `{"status":"Server available"}`
 
 Use this mode when you already have a running KMS instance and only want to attach
 the observability stack to it.
+
+All files referenced below are located in the `monitoring/` directory of the KMS repository.
+Navigate there first:
+
+```bash
+cd monitoring/
+```
 
 ### 1. Configure `.env`
 


### PR DESCRIPTION
## What

- Adds a `## Download` section to the monitoring setup guide with a versioned download link (using a `<version>` placeholder) and a pointer to the GitHub Releases page
- Clarifies that all commands (`docker compose`, `.env`, scripts) must be run from the `monitoring/` directory — previously never mentioned
- Adds a `publish-monitoring` job in `packaging.yml` that zips the `monitoring/` folder and publishes `cosmian-kms-monitoring.zip` to `package.cosmian.com` (and as a GitHub Release asset on tags)

## Why

Users had no way to download the monitoring stack without cloning the full repo, and the setup guide never told them where the files were located.