### PR TITLE
feat: display OpenSSL CPU hardware-acceleration feature flags at startup

### DIFF
--- a/CHANGELOG/feat_openssl_cpu_features.md
+++ b/CHANGELOG/feat_openssl_cpu_features.md
@@ -1,0 +1,3 @@
+## Features
+
+- Log OpenSSL CPU hardware-acceleration feature flags (AES-NI, PCLMULQDQ, AVX, AVX2, SHA, VAES, RDRAND, etc.) at server startup for compliance and audit purposes. Decoded for x86_64, AArch64, and PowerPC; raw string logged for other architectures.

--- a/CHANGELOG/feat_openssl_cpu_features.md
+++ b/CHANGELOG/feat_openssl_cpu_features.md
@@ -1,3 +1,9 @@
 ## Features
 
 - Log OpenSSL CPU hardware-acceleration feature flags (AES-NI, PCLMULQDQ, AVX, AVX2, SHA, VAES, RDRAND, etc.) at server startup for compliance and audit purposes. Decoded for x86_64, AArch64, and PowerPC; raw string logged for other architectures.
+
+## Refactor
+
+- Add `OpenSSL_version_num()` liveness check and `// SAFETY:` justification to `cpu_features_info()` unsafe block ([#963](https://github.com/Cosmian/kms/pull/963))
+- Replace raw `openssl_sys::OpenSSL_version_num()` calls in `init_openssl_providers*` with safe `openssl::version::number()` wrapper, eliminating unnecessary unsafe blocks
+- Extract `OPENSSL_3_0_VERSION_NUMBER` named constant to replace hardcoded `0x3000_0000` magic number

--- a/crate/server/src/main.rs
+++ b/crate/server/src/main.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use cosmian_kms_server::{
     config::{ClapConfig, OpenTelemetryConfig, ServerParams, wizard::run_configure_wizard},
     core::KMS,
-    openssl_providers::safe_openssl_version_info,
+    openssl_providers::{cpu_features_info, safe_openssl_version_info},
     result::{KResult, KResultHelper},
 };
 use cosmian_logger::{TelemetryConfig, TracingConfig, info, tracing_init};
@@ -122,6 +122,7 @@ async fn run() -> KResult<()> {
         env!("CARGO_PKG_VERSION")
     );
     info!("OpenSSL version: {ossl_version}, in {ossl_dir}, number: {ossl_number:x}");
+    info!("{}", cpu_features_info());
 
     // For an explanation of OpenSSL providers,
     //  https://docs.openssl.org/3.1/man7/crypto/#openssl-providers

--- a/crate/server/src/openssl_providers.rs
+++ b/crate/server/src/openssl_providers.rs
@@ -220,8 +220,7 @@ fn decode_ia32cap(hex: &str) -> String {
 /// The value is a 32-bit bitmask (`OPENSSL_armcap_P`) populated by the kernel
 /// auxiliary vector (AT_HWCAP / AT_HWCAP2) during `OPENSSL_cpuid_setup`.
 fn decode_armcap(hex: &str) -> String {
-    let cap =
-        u32::from_str_radix(hex.trim_start_matches("0x"), 16).unwrap_or(0);
+    let cap = u32::from_str_radix(hex.trim_start_matches("0x"), 16).unwrap_or(0);
 
     #[rustfmt::skip]
     const FLAGS: &[(u32, &str)] = &[
@@ -259,8 +258,7 @@ fn decode_armcap(hex: &str) -> String {
 /// The value is a 32-bit bitmask (`OPENSSL_ppccap_P`) populated during
 /// `OPENSSL_cpuid_setup` from the Linux auxiliary vector.
 fn decode_ppccap(hex: &str) -> String {
-    let cap =
-        u32::from_str_radix(hex.trim_start_matches("0x"), 16).unwrap_or(0);
+    let cap = u32::from_str_radix(hex.trim_start_matches("0x"), 16).unwrap_or(0);
 
     #[rustfmt::skip]
     const FLAGS: &[(u32, &str)] = &[

--- a/crate/server/src/openssl_providers.rs
+++ b/crate/server/src/openssl_providers.rs
@@ -1,4 +1,4 @@
-use std::ffi::CStr;
+use std::ffi::{CStr, c_int};
 
 use cosmian_logger::info;
 
@@ -60,6 +60,229 @@ pub fn safe_openssl_version_info() -> (String, String, u64) {
     };
 
     (version, dir, num)
+}
+
+/// Retrieve human-readable OpenSSL CPU hardware-acceleration feature flags detected
+/// at runtime.
+///
+/// `OpenSSL_version(OPENSSL_CPU_INFO)` (constant `9`, not yet exposed by `openssl-sys`)
+/// returns the raw capability bitmask string that OpenSSL assembled during its own
+/// `OPENSSL_cpuid_setup` call.  This function decodes that bitmask for the known
+/// architectures and falls back to the raw string for unknown ones.
+///
+/// Supported architectures:
+/// - **x86_64**: five packed `u64` words (`OPENSSL_ia32cap_P[0..10]`) covering
+///   CPUID leaves 1, 7.0, 7.1, and 24.  Each bit is mapped to a well-known flag name.
+/// - **AArch64**: a single `u32` word (`OPENSSL_armcap_P`) with ARMv7/v8 extension flags.
+/// - **PowerPC**: a single `u32` word (`OPENSSL_ppccap_P`) with AltiVec / VSX flags.
+/// - **s390x, RISC-V, other**: the raw OpenSSL string is returned verbatim.
+///
+/// # Returns
+///
+/// A `String` such as:
+/// ```text
+/// OpenSSL CPU features (x86_64): AES-NI, PCLMULQDQ, AVX, AVX2, SHA, RDRAND
+/// ```
+#[allow(unsafe_code)]
+#[must_use]
+pub fn cpu_features_info() -> String {
+    // OPENSSL_CPU_INFO = 9; this constant is not yet exposed by openssl-sys.
+    const OPENSSL_CPU_INFO_QUERY: c_int = 9;
+
+    let raw = unsafe {
+        let ptr = openssl_sys::OpenSSL_version(OPENSSL_CPU_INFO_QUERY);
+        if ptr.is_null() {
+            return "OpenSSL CPU features: <unavailable>".to_owned();
+        }
+        match CStr::from_ptr(ptr).to_str() {
+            Ok(s) => s.to_owned(),
+            Err(_) => return "OpenSSL CPU features: <invalid utf-8>".to_owned(),
+        }
+    };
+
+    // Strip optional " env:..." suffix that OpenSSL may append when the
+    // OPENSSL_ia32cap / OPENSSL_armcap env vars override capabilities.
+    // Also strip the leading "CPUINFO: " prefix that OpenSSL_version(9) includes.
+    let raw = raw
+        .split_once(" env:")
+        .map_or(raw.as_str(), |(head, _)| head)
+        .trim_start_matches("CPUINFO: ")
+        .trim()
+        .to_owned();
+
+    if let Some(hex) = raw.strip_prefix("OPENSSL_ia32cap=") {
+        return format!("OpenSSL CPU features (x86_64): {}", decode_ia32cap(hex));
+    }
+    if let Some(hex) = raw.strip_prefix("OPENSSL_armcap=") {
+        return format!("OpenSSL CPU features (aarch64): {}", decode_armcap(hex));
+    }
+    if let Some(hex) = raw.strip_prefix("OPENSSL_ppccap=") {
+        return format!("OpenSSL CPU features (powerpc): {}", decode_ppccap(hex));
+    }
+
+    // s390x, RISC-V, or any future architecture: log the raw string verbatim.
+    format!("OpenSSL CPU features: {raw}")
+}
+
+/// Decode the x86_64 `OPENSSL_ia32cap` five-word hex string into named flags.
+///
+/// Format: `0xW0:0xW1:0xW2:0xW3:0xW4` — five packed `u64` where each word packs
+/// two 32-bit CPUID output registers (low = first register, high = second register):
+///
+/// | Word | Low 32 bits     | High 32 bits    |
+/// |------|-----------------|-----------------|
+/// | 0    | CPUID.1.EDX     | CPUID.1.ECX     |
+/// | 1    | CPUID.7.0.EBX   | CPUID.7.0.ECX   |
+/// | 2    | CPUID.7.0.EDX   | CPUID.7.1.EAX   |
+/// | 3    | CPUID.7.1.EDX   | CPUID.7.1.EBX   |
+/// | 4    | CPUID.7.1.ECX   | CPUID.24.0.EBX  |
+fn decode_ia32cap(hex: &str) -> String {
+    let words: Vec<u64> = hex
+        .split(':')
+        .map(|s| u64::from_str_radix(s.trim_start_matches("0x"), 16).unwrap_or(0))
+        .collect();
+
+    if words.len() < 5 {
+        return format!("<parse error: {hex}>");
+    }
+
+    // (word_index, bit_position_within_word, display_name)
+    // Bits 0-31 map to the low u32 register; bits 32-63 to the high u32 register.
+    #[rustfmt::skip]
+    const FLAGS: &[(usize, u32, &str)] = &[
+        // Word 0 — CPUID leaf 1, EDX (bits 0-31) + ECX (bits 32-63)
+        (0, 23, "MMX"),
+        (0, 25, "SSE"),
+        (0, 26, "SSE2"),
+        (0, 32, "SSE3"),
+        (0, 33, "PCLMULQDQ"),
+        (0, 41, "SSSE3"),
+        (0, 44, "FMA"),
+        (0, 51, "SSE4.1"),
+        (0, 52, "SSE4.2"),
+        (0, 54, "MOVBE"),
+        (0, 55, "POPCNT"),
+        (0, 57, "AES-NI"),
+        (0, 58, "XSAVE"),
+        (0, 60, "AVX"),
+        (0, 62, "RDRAND"),
+        // Word 1 — CPUID leaf 7 subleaf 0, EBX (bits 0-31) + ECX (bits 32-63)
+        (1,  3, "BMI1"),
+        (1,  5, "AVX2"),
+        (1,  8, "BMI2"),
+        (1, 16, "AVX512F"),
+        (1, 17, "AVX512DQ"),
+        (1, 18, "RDSEED"),
+        (1, 19, "ADX"),
+        (1, 21, "AVX512IFMA"),
+        (1, 28, "AVX512CD"),
+        (1, 29, "SHA"),
+        (1, 30, "AVX512BW"),
+        (1, 31, "AVX512VL"),
+        (1, 33, "AVX512VBMI"),
+        (1, 38, "AVX512VBMI2"),
+        (1, 40, "GFNI"),
+        (1, 41, "VAES"),
+        (1, 42, "VPCLMULQDQ"),
+        (1, 43, "AVX512VNNI"),
+        (1, 44, "AVX512BITALG"),
+        (1, 46, "AVX512VPOPCNTDQ"),
+        // Word 2 — CPUID.7.0.EDX (bits 0-31) + CPUID.7.1.EAX (bits 32-63)
+        (2,  2, "AVX512-4VNNIW"),
+        (2,  3, "AVX512-4FMAPS"),
+        (2,  8, "AVX512VP2INTERSECT"),
+        (2, 36, "AVX-VNNI"),
+        (2, 37, "AVX512-BF16"),
+        // Word 3 — CPUID.7.1.EDX (bits 0-31) + CPUID.7.1.EBX (bits 32-63)
+        (3, 32, "SHA512"),
+        (3, 33, "SM3"),
+        (3, 34, "SM4"),
+        // Word 4 — CPUID.7.1.ECX (bits 0-31) + CPUID.24.0.EBX (bits 32-63, AVX10)
+        (4,  4, "AVX-NE-CONVERT"),
+        (4,  5, "AVX-VNNI-INT8"),
+    ];
+
+    let enabled: Vec<&str> = FLAGS
+        .iter()
+        .filter(|&&(w, bit, _)| (words[w] >> bit) & 1 == 1)
+        .map(|&(_, _, name)| name)
+        .collect();
+
+    if enabled.is_empty() {
+        "<none>".to_owned()
+    } else {
+        enabled.join(", ")
+    }
+}
+
+/// Decode the AArch64 `OPENSSL_armcap` single-word hex string into named flags.
+///
+/// The value is a 32-bit bitmask (`OPENSSL_armcap_P`) populated by the kernel
+/// auxiliary vector (AT_HWCAP / AT_HWCAP2) during `OPENSSL_cpuid_setup`.
+fn decode_armcap(hex: &str) -> String {
+    let cap =
+        u32::from_str_radix(hex.trim_start_matches("0x"), 16).unwrap_or(0);
+
+    #[rustfmt::skip]
+    const FLAGS: &[(u32, &str)] = &[
+        (1 <<  0, "NEON"),
+        (1 <<  2, "ARMV8_AES"),
+        (1 <<  3, "ARMV8_SHA1"),
+        (1 <<  4, "ARMV8_SHA256"),
+        (1 <<  5, "ARMV8_PMULL"),
+        (1 <<  6, "ARMV8_SHA512"),
+        (1 <<  8, "ARMV8_RNG"),
+        (1 <<  9, "ARMV8_SM3"),
+        (1 << 10, "ARMV8_SM4"),
+        (1 << 11, "ARMV8_SHA3"),
+        (1 << 12, "ARMV8_UNROLL8_EOR3"),
+        (1 << 13, "ARMV8_SVE"),
+        (1 << 14, "ARMV8_SVE2"),
+        (1 << 16, "ARMV8_UNROLL12_EOR3"),
+    ];
+
+    let enabled: Vec<&str> = FLAGS
+        .iter()
+        .filter(|&&(mask, _)| cap & mask != 0)
+        .map(|&(_, name)| name)
+        .collect();
+
+    if enabled.is_empty() {
+        "<none>".to_owned()
+    } else {
+        enabled.join(", ")
+    }
+}
+
+/// Decode the PowerPC `OPENSSL_ppccap` single-word hex string into named flags.
+///
+/// The value is a 32-bit bitmask (`OPENSSL_ppccap_P`) populated during
+/// `OPENSSL_cpuid_setup` from the Linux auxiliary vector.
+fn decode_ppccap(hex: &str) -> String {
+    let cap =
+        u32::from_str_radix(hex.trim_start_matches("0x"), 16).unwrap_or(0);
+
+    #[rustfmt::skip]
+    const FLAGS: &[(u32, &str)] = &[
+        (1 << 0, "PPC_FPU64"),
+        (1 << 1, "PPC_ALTIVEC"),
+        (1 << 2, "PPC_CRYPTO207"),
+        (1 << 3, "PPC_FPU"),
+        (1 << 4, "PPC_MADD300"),
+        (1 << 5, "PPC_MFTB"),
+    ];
+
+    let enabled: Vec<&str> = FLAGS
+        .iter()
+        .filter(|&&(mask, _)| cap & mask != 0)
+        .map(|&(_, name)| name)
+        .collect();
+
+    if enabled.is_empty() {
+        "<none>".to_owned()
+    } else {
+        enabled.join(", ")
+    }
 }
 
 /// Initialize OpenSSL providers for test environments.

--- a/crate/server/src/openssl_providers.rs
+++ b/crate/server/src/openssl_providers.rs
@@ -2,6 +2,11 @@ use std::ffi::{CStr, c_int};
 
 use cosmian_logger::info;
 
+/// Minimum `OpenSSL_version_num()` value that indicates OpenSSL 3.x.
+/// Encoding: `MNNFFPPS` where M=major, NN=minor, etc.
+#[cfg(feature = "non-fips")]
+const OPENSSL_3_0_VERSION_NUMBER: u64 = 0x3000_0000;
+
 /// Safely retrieve OpenSSL version information without risking a segmentation
 /// fault.  In some edge-case environments (missing OpenSSL shared library,
 /// incomplete installation, restricted container, …) the underlying
@@ -71,10 +76,10 @@ pub fn safe_openssl_version_info() -> (String, String, u64) {
 /// architectures and falls back to the raw string for unknown ones.
 ///
 /// Supported architectures:
-/// - **x86_64**: five packed `u64` words (`OPENSSL_ia32cap_P[0..10]`) covering
+/// - **`x86_64`**: five packed `u64` words (`OPENSSL_ia32cap_P[0..10]`) covering
 ///   CPUID leaves 1, 7.0, 7.1, and 24.  Each bit is mapped to a well-known flag name.
-/// - **AArch64**: a single `u32` word (`OPENSSL_armcap_P`) with ARMv7/v8 extension flags.
-/// - **PowerPC**: a single `u32` word (`OPENSSL_ppccap_P`) with AltiVec / VSX flags.
+/// - **`AArch64`**: a single `u32` word (`OPENSSL_armcap_P`) with ARMv7/v8 extension flags.
+/// - **`PowerPC`**: a single `u32` word (`OPENSSL_ppccap_P`) with `AltiVec` / VSX flags.
 /// - **s390x, RISC-V, other**: the raw OpenSSL string is returned verbatim.
 ///
 /// # Returns
@@ -89,6 +94,18 @@ pub fn cpu_features_info() -> String {
     // OPENSSL_CPU_INFO = 9; this constant is not yet exposed by openssl-sys.
     const OPENSSL_CPU_INFO_QUERY: c_int = 9;
 
+    // Liveness check: if OpenSSL is not initialised at all, bail out early
+    // rather than risking a crash from `OpenSSL_version`.  This mirrors the
+    // guard in `safe_openssl_version_info()`.
+    if openssl::version::number() == 0 {
+        return "OpenSSL CPU features: <unavailable>".to_owned();
+    }
+
+    // SAFETY: `OpenSSL_version` returns a `*const c_char` pointing to a static
+    // string owned by the library.  We verified above that OpenSSL is alive
+    // (version_num != 0), and we check for NULL before dereferencing via
+    // `CStr::from_ptr`.  The returned pointer remains valid for the lifetime of
+    // the process.
     let raw = unsafe {
         let ptr = openssl_sys::OpenSSL_version(OPENSSL_CPU_INFO_QUERY);
         if ptr.is_null() {
@@ -124,7 +141,7 @@ pub fn cpu_features_info() -> String {
     format!("OpenSSL CPU features: {raw}")
 }
 
-/// Decode the x86_64 `OPENSSL_ia32cap` five-word hex string into named flags.
+/// Decode the `x86_64` `OPENSSL_ia32cap` five-word hex string into named flags.
 ///
 /// Format: `0xW0:0xW1:0xW2:0xW3:0xW4` — five packed `u64` where each word packs
 /// two 32-bit CPUID output registers (low = first register, high = second register):
@@ -137,15 +154,6 @@ pub fn cpu_features_info() -> String {
 /// | 3    | CPUID.7.1.EDX   | CPUID.7.1.EBX   |
 /// | 4    | CPUID.7.1.ECX   | CPUID.24.0.EBX  |
 fn decode_ia32cap(hex: &str) -> String {
-    let words: Vec<u64> = hex
-        .split(':')
-        .map(|s| u64::from_str_radix(s.trim_start_matches("0x"), 16).unwrap_or(0))
-        .collect();
-
-    if words.len() < 5 {
-        return format!("<parse error: {hex}>");
-    }
-
     // (word_index, bit_position_within_word, display_name)
     // Bits 0-31 map to the low u32 register; bits 32-63 to the high u32 register.
     #[rustfmt::skip]
@@ -202,9 +210,18 @@ fn decode_ia32cap(hex: &str) -> String {
         (4,  5, "AVX-VNNI-INT8"),
     ];
 
+    let words: Vec<u64> = hex
+        .split(':')
+        .map(|s| u64::from_str_radix(s.trim_start_matches("0x"), 16).unwrap_or(0))
+        .collect();
+
+    if words.len() < 5 {
+        return format!("<parse error: {hex}>");
+    }
+
     let enabled: Vec<&str> = FLAGS
         .iter()
-        .filter(|&&(w, bit, _)| (words[w] >> bit) & 1 == 1)
+        .filter(|&&(w, bit, _)| words.get(w).is_some_and(|word| (word >> bit) & 1 == 1))
         .map(|&(_, _, name)| name)
         .collect();
 
@@ -215,13 +232,11 @@ fn decode_ia32cap(hex: &str) -> String {
     }
 }
 
-/// Decode the AArch64 `OPENSSL_armcap` single-word hex string into named flags.
+/// Decode the `AArch64` `OPENSSL_armcap` single-word hex string into named flags.
 ///
 /// The value is a 32-bit bitmask (`OPENSSL_armcap_P`) populated by the kernel
-/// auxiliary vector (AT_HWCAP / AT_HWCAP2) during `OPENSSL_cpuid_setup`.
+/// auxiliary vector (`AT_HWCAP` / `AT_HWCAP2`) during `OPENSSL_cpuid_setup`.
 fn decode_armcap(hex: &str) -> String {
-    let cap = u32::from_str_radix(hex.trim_start_matches("0x"), 16).unwrap_or(0);
-
     #[rustfmt::skip]
     const FLAGS: &[(u32, &str)] = &[
         (1 <<  0, "NEON"),
@@ -239,6 +254,8 @@ fn decode_armcap(hex: &str) -> String {
         (1 << 14, "ARMV8_SVE2"),
         (1 << 16, "ARMV8_UNROLL12_EOR3"),
     ];
+
+    let cap = u32::from_str_radix(hex.trim_start_matches("0x"), 16).unwrap_or(0);
 
     let enabled: Vec<&str> = FLAGS
         .iter()
@@ -258,8 +275,6 @@ fn decode_armcap(hex: &str) -> String {
 /// The value is a 32-bit bitmask (`OPENSSL_ppccap_P`) populated during
 /// `OPENSSL_cpuid_setup` from the Linux auxiliary vector.
 fn decode_ppccap(hex: &str) -> String {
-    let cap = u32::from_str_radix(hex.trim_start_matches("0x"), 16).unwrap_or(0);
-
     #[rustfmt::skip]
     const FLAGS: &[(u32, &str)] = &[
         (1 << 0, "PPC_FPU64"),
@@ -269,6 +284,8 @@ fn decode_ppccap(hex: &str) -> String {
         (1 << 4, "PPC_MADD300"),
         (1 << 5, "PPC_MFTB"),
     ];
+
+    let cap = u32::from_str_radix(hex.trim_start_matches("0x"), 16).unwrap_or(0);
 
     let enabled: Vec<&str> = FLAGS
         .iter()
@@ -292,7 +309,7 @@ fn decode_ppccap(hex: &str) -> String {
 /// Note: The default provider is already active via openssl.cnf configuration.
 /// This function only adds the legacy provider on top of it.
 #[cfg(feature = "non-fips")]
-#[allow(unsafe_code, clippy::missing_panics_doc, clippy::expect_used)]
+#[allow(clippy::missing_panics_doc, clippy::expect_used)]
 pub fn init_openssl_providers_for_tests() {
     use std::sync::OnceLock;
 
@@ -302,9 +319,8 @@ pub fn init_openssl_providers_for_tests() {
     static PROVIDER: OnceLock<Provider> = OnceLock::new();
 
     PROVIDER.get_or_init(|| {
-        #[allow(clippy::useless_conversion)]
-        let ossl_number = u64::from(unsafe { openssl_sys::OpenSSL_version_num() });
-        if ossl_number >= 0x3000_0000 {
+        let ossl_number = u64::try_from(openssl::version::number()).unwrap_or(0);
+        if ossl_number >= OPENSSL_3_0_VERSION_NUMBER {
             // OpenSSL 3.x: load the legacy provider for old PKCS#12 formats
             Provider::try_load(None, "legacy", true).expect("Failed to load legacy provider")
         } else {
@@ -335,7 +351,6 @@ pub const fn init_openssl_providers_for_tests() {
 /// # Errors
 ///
 /// Returns an error if the provider fails to load.
-#[allow(unsafe_code)]
 pub fn init_openssl_providers() -> Result<(), openssl::error::ErrorStack> {
     use std::sync::OnceLock;
 
@@ -357,9 +372,8 @@ pub fn init_openssl_providers() -> Result<(), openssl::error::ErrorStack> {
         static PROVIDER: OnceLock<Provider> = OnceLock::new();
 
         if PROVIDER.get().is_none() {
-            #[allow(clippy::useless_conversion)]
-            let ossl_number = u64::from(unsafe { openssl_sys::OpenSSL_version_num() });
-            let provider = if ossl_number >= 0x3000_0000 {
+            let ossl_number = u64::try_from(openssl::version::number()).unwrap_or(0);
+            let provider = if ossl_number >= OPENSSL_3_0_VERSION_NUMBER {
                 // OpenSSL 3.x: load the legacy provider for old PKCS#12 formats
                 info!("Load legacy provider");
                 Provider::try_load(None, "legacy", true)?


### PR DESCRIPTION
## Summary

Log human-readable OpenSSL CPU hardware-acceleration feature flags at KMS startup for compliance and audit purposes.

## Changes

- **`crate/server/src/openssl_providers.rs`**: Add `cpu_features_info() -> String` that calls `OpenSSL_version(OPENSSL_CPU_INFO=9)` (raw `c_int`; `openssl-sys` does not expose this constant), strips the `CPUINFO: ` prefix and decodes the bitmask per architecture:
  - **x86_64**: 5×u64 ia32cap words (CPUID leaves 1, 7.0, 7.1, 24) → named flags (AES-NI, PCLMULQDQ, AVX, AVX2, SHA, VAES, RDRAND, etc.)
  - **AArch64**: 1×u32 armcap word → ARMV8_AES, ARMV8_SHA256, ARMV8_SHA512, ARMV8_SVE, ARMV8_SVE2, etc.
  - **PowerPC**: 1×u32 ppccap word → PPC_ALTIVEC, PPC_CRYPTO207, etc.
  - **s390x / RISC-V / unknown**: raw OpenSSL string logged verbatim

## Example output

```
INFO OpenSSL CPU features (x86_64): MMX, SSE, SSE2, SSE3, PCLMULQDQ, SSSE3, FMA, SSE4.1, SSE4.2, MOVBE, POPCNT, AES-NI, XSAVE, AVX, RDRAND, BMI1, AVX2, BMI2, RDSEED, ADX, SHA, GFNI, VAES, VPCLMULQDQ, AVX-VNNI
```

## Notes

- No new Rust dependencies introduced.
- Both FIPS and non-FIPS builds compile clean.
- Visible under `--info` flag (lightweight probe mode) since it runs before provider loading.