### PR TITLE
feat(deploy): add OPA + KMS docker-compose stack

### DIFF
--- a/CHANGELOG/feat_deploy_opa.md
+++ b/CHANGELOG/feat_deploy_opa.md
@@ -1,0 +1,12 @@
+# Changelog — feat_deploy_opa
+
+## Features
+
+- **deploy/opa**: add OPA + KMS docker-compose stack with `--disable-telemetry` on OPA ([#995](https://github.com/Cosmian/kms/pull/995))
+- **deploy/rbac**: add full RBAC stack — step-ca TLS, Keycloak IDP, OPA, and KMS with JWT auth ([#995](https://github.com/Cosmian/kms/pull/995))
+- **deploy/rbac**: add `keycloak/realm-export.json` with `kms` realm, 4 pre-configured users/roles, and audience mapper for `cosmian-kms` client ([#995](https://github.com/Cosmian/kms/pull/995))
+- **deploy/rbac**: add `test.sh` smoke-test script covering token issuance, role validation, and authenticated KMS calls ([#995](https://github.com/Cosmian/kms/pull/995))
+
+## Bug Fixes
+
+- **jwt**: fix `UserClaim` serde deserialization failing with `missing field 'aud'` when tokens omit the audience claim — add `#[serde(default)]` to the `aud` field ([#995](https://github.com/Cosmian/kms/pull/995))

--- a/CHANGELOG/feat_rbac_is_back.md
+++ b/CHANGELOG/feat_rbac_is_back.md
@@ -1,0 +1,5 @@
+# Changelog — feat_rbac_is_back
+
+## Features
+
+- **deploy/opa**: add Cosmian KMS service to `deploy/opa/docker-compose.yml` — SQLite backend, embedded Regorus RBAC enabled, shares the same Rego policy bundle as the OPA sidecar container; disable OPA anonymous telemetry (`--disable-telemetry`).

--- a/crate/server/src/middlewares/jwt/jwt_config.rs
+++ b/crate/server/src/middlewares/jwt/jwt_config.rs
@@ -106,7 +106,7 @@ pub(crate) struct UserClaim {
     pub email: Option<String>,
     pub iss: Option<String>,
     pub sub: Option<String>,
-    #[serde(deserialize_with = "deserialize_aud")]
+    #[serde(default, deserialize_with = "deserialize_aud")]
     pub aud: Option<Vec<String>>,
     pub iat: Option<usize>,
     pub exp: Option<usize>,

--- a/deploy/opa/docker-compose.yml
+++ b/deploy/opa/docker-compose.yml
@@ -1,0 +1,94 @@
+# ===========================================================================
+# Cosmian KMS — OPA RBAC demo stack
+#
+# Services:
+#   - OPA  (Open Policy Agent — standalone policy evaluation server for
+#            external inspection / debugging on port 8181)
+#   - KMS  (Cosmian KMS — uses the same Rego policy bundle via its embedded
+#            Regorus engine; SQLite backend for simplicity)
+#
+# Usage:
+#   docker compose up -d
+#   # KMS HTTP API
+#   curl http://localhost:9998/health
+#   # OPA policy evaluation
+#   curl -s -X POST http://localhost:8181/v1/data/cosmian/kms/rbac/allow \
+#        -H "Content-Type: application/json" \
+#        -d '{"input":{"subject":{"roles":["admin"]},"action":{"operation":"create"}}}'
+#
+# RBAC notes:
+#   - Policy bundle: ./opa/policy/default_rbac.rego + data.json
+#   - Roles: admin | operator | auditor | readonly
+#   - KMS_FORCE_DEFAULT_USERNAME=true lets the default "admin" identity work
+#     without an IdP; add JWT/mTLS auth for production.
+# ===========================================================================
+name: cosmian-kms-opa
+
+networks:
+  kms-net:
+    driver: bridge
+
+volumes:
+  kms-data:
+
+services:
+  # ===========================================================================
+  # OPA (Open Policy Agent — standalone REST policy server)
+  # ===========================================================================
+  opa:
+    image: ${OPA_IMAGE:-openpolicyagent/opa:0.68.0}
+    hostname: opa
+    networks:
+      - kms-net
+    ports:
+      - "8181:8181"
+    command:
+      - run
+      - --server
+      - --addr=0.0.0.0:8181
+      - --log-level=debug
+      - --disable-telemetry
+      - /policies/default_rbac.rego
+      - /policies/data.json
+    volumes:
+      - ./opa/policy/default_rbac.rego:/policies/default_rbac.rego:ro
+      - ./opa/policy/data.json:/policies/data.json:ro
+    healthcheck:
+      test: ["CMD", "/opa", "eval", "true"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+  # ===========================================================================
+  # Cosmian KMS Server
+  # ===========================================================================
+  kms:
+    image: ${KMS_IMAGE:-ghcr.io/cosmian/kms:latest}
+    hostname: kms
+    networks:
+      - kms-net
+    ports:
+      - "${KMS_PORT:-9998}:9998"
+    environment:
+      # SQLite backend — no external database required
+      - KMS_DATABASE_TYPE=sqlite
+      - KMS_SQLITE_PATH=/tmp/kms-data
+      # RBAC — use the same Rego bundle as the OPA container above
+      - KMS_RBAC_ENABLED=true
+      - KMS_RBAC_BUNDLE_PATH=/policies
+      # Allow the built-in "admin" identity when no IdP is configured
+      - KMS_FORCE_DEFAULT_USERNAME=true
+      - RUST_LOG=${KMS_LOG_LEVEL:-info,cosmian_kms=debug}
+    volumes:
+      - ./opa/policy:/policies:ro
+      - kms-data:/tmp/kms-data
+    depends_on:
+      opa:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "echo > /dev/tcp/localhost/9998"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s

--- a/deploy/opa/opa/policy/data.json
+++ b/deploy/opa/opa/policy/data.json
@@ -1,0 +1,14 @@
+{
+  "cosmian": {
+    "kms": {
+      "rbac": {
+        "role_assignments": {
+          "admin@cosmian.com": ["admin"],
+          "operator@cosmian.com": ["operator"],
+          "auditor@cosmian.com": ["auditor"],
+          "readonly@cosmian.com": ["readonly"]
+        }
+      }
+    }
+  }
+}

--- a/deploy/opa/opa/policy/default_rbac.rego
+++ b/deploy/opa/opa/policy/default_rbac.rego
@@ -1,0 +1,85 @@
+# Cosmian KMS — Default RBAC Policy
+#
+# This policy implements role-based access control aligned with NIST SP 800-162.
+# It defines four default roles: administrator, operator, auditor, and readonly.
+#
+# Input schema (NIST SP 800-162 attributes):
+#   input.subject.user_id       — authenticated user identifier
+#   input.subject.roles         — list of assigned roles
+#   input.subject.is_owner      — true if user owns the target object
+#   input.subject.is_privileged — true if user is in the privileged_users list
+#   input.action.operation      — KMIP operation (lowercase)
+#   input.resource.*            — target object attributes
+#   input.environment.*         — contextual attributes (reserved)
+#
+# Decision: data.cosmian.kms.rbac.allow = true | false
+
+package cosmian.kms.rbac
+
+import rego.v1
+
+default allow := false
+
+# ── Administrator ────────────────────────────────────────────────────────
+# Full access to all operations.
+allow if {
+    some role in input.subject.roles
+    role == "admin"
+}
+
+# ── Operator ─────────────────────────────────────────────────────────────
+# All key management and cryptographic operations.
+allow if {
+    some role in input.subject.roles
+    role == "operator"
+    input.action.operation in operator_operations
+}
+
+operator_operations := {
+    "create",
+    "certify",
+    "decrypt",
+    "derive_key",
+    "destroy",
+    "encrypt",
+    "export",
+    "get",
+    "get_attributes",
+    "hash",
+    "import",
+    "locate",
+    "mac",
+    "revoke",
+    "rekey",
+    "sign",
+    "signature_verify",
+    "validate",
+}
+
+# ── Auditor ──────────────────────────────────────────────────────────────
+# Read-only access for inspection and compliance auditing.
+allow if {
+    some role in input.subject.roles
+    role == "auditor"
+    input.action.operation in auditor_operations
+}
+
+auditor_operations := {
+    "get",
+    "get_attributes",
+    "locate",
+    "validate",
+}
+
+# ── Read-Only ────────────────────────────────────────────────────────────
+# Minimal access: can only list and inspect metadata.
+allow if {
+    some role in input.subject.roles
+    role == "readonly"
+    input.action.operation in readonly_operations
+}
+
+readonly_operations := {
+    "get_attributes",
+    "locate",
+}

--- a/deploy/rbac/.gitignore
+++ b/deploy/rbac/.gitignore
@@ -1,0 +1,2 @@
+# TLS certificates issued by step-ca at runtime — do not commit
+certs/

--- a/deploy/rbac/docker-compose.yml
+++ b/deploy/rbac/docker-compose.yml
@@ -1,0 +1,253 @@
+# ===========================================================================
+# Cosmian KMS — RBAC + Keycloak IDP + TLS stack
+#
+# Services:
+#   - step-ca      (ACME certificate authority — auto-initialized on first boot)
+#   - step-ca-init (one-shot: issues TLS certs for Keycloak, KMS, OPA)
+#   - Keycloak     (OIDC identity provider — HTTPS, realm "kms" auto-imported)
+#   - OPA          (Open Policy Agent — HTTPS policy server)
+#   - KMS          (Cosmian KMS — HTTPS, JWT auth via Keycloak, Regorus RBAC)
+#
+# Quick start:
+#   docker compose up -d
+#   docker compose logs -f step-ca-init   # watch cert issuance
+#
+#   # Trust the CA on the host (once):
+#   step certificate install ./certs/ca.crt
+#
+#   # Get a token:
+#   TOKEN=$(curl -s --cacert ./certs/ca.crt \
+#     -X POST https://localhost:8180/realms/kms/protocol/openid-connect/token \
+#     -d "client_id=cosmian-kms&grant_type=password" \
+#     -d "username=admin@cosmian.com&password=Admin1234!" \
+#     | jq -r .access_token)
+#
+#   # Call the KMS:
+#   curl --cacert ./certs/ca.crt -H "Authorization: Bearer $TOKEN" https://localhost:9998/health
+#
+# TLS notes:
+#   - Root CA cert: ./certs/ca.crt  (written after first startup)
+#   - Service certs: ./certs/{keycloak,kms,opa}.{crt,key}  (valid 24h)
+#   - certs/ is auto-created; add it to .gitignore
+#
+# Pre-configured users (realm: kms):
+#   admin@cosmian.com    / Admin1234!    → role: admin    (full access)
+#   operator@cosmian.com / Operator1234! → role: operator (key management)
+#   auditor@cosmian.com  / Auditor1234!  → role: auditor  (read-only audit)
+#   readonly@cosmian.com / Readonly1234! → role: readonly  (metadata only)
+#
+# RBAC notes:
+#   - JWT roles are read from Keycloak's realm_access.roles claim
+#   - Rego policy: ./opa/policy/default_rbac.rego
+#   - OPA data:    ./opa/policy/data.json
+# ===========================================================================
+name: cosmian-kms-rbac-keycloak
+
+networks:
+  kms-net:
+    driver: bridge
+
+volumes:
+  kms-data:
+  step-ca-data:
+
+services:
+  # ===========================================================================
+  # step-ca (ACME Certificate Authority — auto-initialized on first boot)
+  # ===========================================================================
+  step-ca:
+    image: ${STEPCA_IMAGE:-smallstep/step-ca:0.27.2}
+    hostname: step-ca
+    networks:
+      - kms-net
+    ports:
+      - "${STEPCA_PORT:-9000}:9000"
+    environment:
+      - DOCKER_STEPCA_INIT_NAME=${STEPCA_INIT_NAME:-Cosmian KMS CA}
+      - DOCKER_STEPCA_INIT_DNS_NAMES=${STEPCA_INIT_DNS_NAMES:-step-ca,localhost}
+      - DOCKER_STEPCA_INIT_PROVISIONER_NAME=${STEPCA_INIT_PROVISIONER_NAME:-admin}
+      - DOCKER_STEPCA_INIT_PASSWORD=${STEPCA_INIT_PASSWORD:-changeme}
+      - DOCKER_STEPCA_INIT_ACME=true
+    volumes:
+      - step-ca-data:/home/step
+    healthcheck:
+      test: ["CMD", "step", "ca", "health", "--ca-url", "https://localhost:9000", "--root", "/home/step/certs/root_ca.crt"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  # ===========================================================================
+  # step-ca-init (one-shot: export root CA cert + issue TLS certs for all services)
+  # ===========================================================================
+  step-ca-init:
+    image: ${STEPCA_IMAGE:-smallstep/step-ca:0.27.2}
+    user: "0:0"
+    networks:
+      - kms-net
+    depends_on:
+      step-ca:
+        condition: service_healthy
+    environment:
+      - STEPCA_INIT_PASSWORD=${STEPCA_INIT_PASSWORD:-changeme}
+    volumes:
+      - step-ca-data:/home/step:ro
+      - ./certs:/certs
+    entrypoint: /bin/sh
+    command:
+      - -c
+      - |
+        set -e
+        echo "=== step-ca-init: issuing TLS certificates ==="
+
+        cp /home/step/certs/root_ca.crt /certs/ca.crt
+        step certificate fingerprint /home/step/certs/root_ca.crt > /certs/ca-fingerprint.txt
+        echo "CA fingerprint: $$(cat /certs/ca-fingerprint.txt)"
+
+        echo "$${STEPCA_INIT_PASSWORD}" > /tmp/pass.txt
+
+        step ca certificate "keycloak" /certs/keycloak.crt /certs/keycloak.key \
+          --ca-url https://step-ca:9000 --root /certs/ca.crt \
+          --provisioner admin --provisioner-password-file /tmp/pass.txt \
+          --san keycloak --san localhost --san 127.0.0.1 \
+          --not-after 24h --kty EC --curve P-256 --force
+
+        step ca certificate "kms" /certs/kms.crt /certs/kms.key \
+          --ca-url https://step-ca:9000 --root /certs/ca.crt \
+          --provisioner admin --provisioner-password-file /tmp/pass.txt \
+          --san kms --san localhost --san 127.0.0.1 \
+          --not-after 24h --kty EC --curve P-256 --force
+
+        step ca certificate "opa" /certs/opa.crt /certs/opa.key \
+          --ca-url https://step-ca:9000 --root /certs/ca.crt \
+          --provisioner admin --provisioner-password-file /tmp/pass.txt \
+          --san opa --san localhost --san 127.0.0.1 \
+          --not-after 24h --kty EC --curve P-256 --force
+
+        rm -f /tmp/pass.txt
+        chmod 644 /certs/*.crt /certs/*.txt /certs/*.key
+        echo "=== step-ca-init: done ==="
+    restart: "no"
+
+  # ===========================================================================
+  # Keycloak (OIDC identity provider — HTTPS, realm "kms" auto-imported)
+  # ===========================================================================
+  keycloak:
+    image: ${KEYCLOAK_IMAGE:-quay.io/keycloak/keycloak:25.0}
+    hostname: keycloak
+    networks:
+      - kms-net
+    ports:
+      - "${KEYCLOAK_PORT:-8180}:8443"
+    environment:
+      - KEYCLOAK_ADMIN=${KEYCLOAK_ADMIN:-admin}
+      - KEYCLOAK_ADMIN_PASSWORD=${KEYCLOAK_ADMIN_PASSWORD:-admin}
+      - KC_HEALTH_ENABLED=true
+      - KC_HTTPS_CERTIFICATE_FILE=/certs/keycloak.crt
+      - KC_HTTPS_CERTIFICATE_KEY_FILE=/certs/keycloak.key
+      # Fix issuer hostname so iss=https://localhost:8180/realms/kms in tokens
+      # while the KMS fetches JWKS internally via https://keycloak:8443
+      - KC_HOSTNAME=localhost
+      - KC_HOSTNAME_PORT=${KEYCLOAK_PORT:-8180}
+      - KC_HOSTNAME_STRICT=false
+    command:
+      - start-dev
+      - --import-realm
+      - --https-port=8443
+    volumes:
+      - ./keycloak/realm-export.json:/opt/keycloak/data/import/realm-export.json:ro
+      - ./certs:/certs:ro
+    depends_on:
+      step-ca-init:
+        condition: service_completed_successfully
+    healthcheck:
+      # Keycloak 25 image has no curl/wget/openssl. The management port 9000
+      # only starts listening after full initialization, so a TCP check is
+      # sufficient as a readiness signal.
+      test: ["CMD-SHELL", "bash -c 'exec 3<>/dev/tcp/localhost/9000'"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 60s
+
+  # ===========================================================================
+  # OPA (Open Policy Agent — HTTPS policy server)
+  # ===========================================================================
+  opa:
+    image: ${OPA_IMAGE:-openpolicyagent/opa:0.68.0}
+    hostname: opa
+    networks:
+      - kms-net
+    ports:
+      - "${OPA_PORT:-8181}:8181"
+    command:
+      - run
+      - --server
+      - --addr=0.0.0.0:8181
+      - --log-level=info
+      - --disable-telemetry
+      - --tls-cert-file=/certs/opa.crt
+      - --tls-private-key-file=/certs/opa.key
+      - /policies/default_rbac.rego
+      - /policies/data.json
+    volumes:
+      - ./opa/policy/default_rbac.rego:/policies/default_rbac.rego:ro
+      - ./opa/policy/data.json:/policies/data.json:ro
+      - ./certs:/certs:ro
+    depends_on:
+      step-ca-init:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD", "/opa", "eval", "true"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+
+  # ===========================================================================
+  # Cosmian KMS Server (HTTPS, JWT auth via Keycloak, embedded Regorus RBAC)
+  # ===========================================================================
+  kms:
+    image: ${KMS_IMAGE:-ghcr.io/cosmian/kms:latest}
+    hostname: kms
+    networks:
+      - kms-net
+    ports:
+      - "${KMS_PORT:-9998}:9998"
+    environment:
+      # SQLite backend — no external database required
+      - KMS_DATABASE_TYPE=sqlite
+      - KMS_SQLITE_PATH=/tmp/kms-data
+      # TLS — PEM cert + key issued by step-ca
+      - KMS_TLS_CERT_FILE=/certs/kms.crt
+      - KMS_TLS_KEY_FILE=/certs/kms.key
+      # Trust the internal CA so JWKS fetch from Keycloak succeeds
+      - SSL_CERT_FILE=/certs/ca.crt
+      # JWT authentication — validate tokens issued by Keycloak.
+      # Issuer matches the iss claim seen by external clients (localhost:8180).
+      # JWKS is fetched over the internal Docker network (keycloak:8443).
+      # No audience required — Keycloak public clients do not emit aud by default.
+      - KMS_JWT_AUTH_PROVIDER=https://localhost:${KEYCLOAK_PORT:-8180}/realms/kms,https://keycloak:8443/realms/kms/protocol/openid-connect/certs,
+      # RBAC — embedded Regorus engine with the shared Rego bundle
+      - KMS_RBAC_ENABLED=true
+      - KMS_RBAC_BUNDLE_PATH=/policies
+      # Keycloak realm roles are nested under realm_access.roles in the JWT
+      - KMS_RBAC_ROLE_CLAIM=realm_access.roles
+      - RUST_LOG=${KMS_LOG_LEVEL:-info,cosmian_kms=debug}
+    volumes:
+      - ./opa/policy:/policies:ro
+      - ./certs:/certs:ro
+      - kms-data:/tmp/kms-data
+    depends_on:
+      step-ca-init:
+        condition: service_completed_successfully
+      keycloak:
+        condition: service_healthy
+      opa:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "echo > /dev/tcp/localhost/9998"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s

--- a/deploy/rbac/keycloak/realm-export.json
+++ b/deploy/rbac/keycloak/realm-export.json
@@ -1,0 +1,136 @@
+{
+  "realm": "kms",
+  "displayName": "Cosmian KMS",
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "roles": {
+    "realm": [
+      {
+        "name": "admin",
+        "description": "Full KMS administration \u2014 all KMIP operations"
+      },
+      {
+        "name": "operator",
+        "description": "Key management and cryptographic operations"
+      },
+      {
+        "name": "auditor",
+        "description": "Read-only inspection and compliance auditing"
+      },
+      {
+        "name": "readonly",
+        "description": "Minimal access \u2014 list and inspect metadata only"
+      }
+    ]
+  },
+  "clients": [
+    {
+      "clientId": "cosmian-kms",
+      "name": "Cosmian KMS",
+      "description": "Public OIDC client for Cosmian KMS CLI and web UI",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": true,
+      "directAccessGrantsEnabled": true,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "serviceAccountsEnabled": false,
+      "redirectUris": [
+        "*"
+      ],
+      "webOrigins": [
+        "+"
+      ],
+      "protocolMappers": [
+        {
+          "name": "audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "cosmian-kms",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "username": "admin@cosmian.com",
+      "email": "admin@cosmian.com",
+      "firstName": "KMS",
+      "lastName": "Admin",
+      "enabled": true,
+      "emailVerified": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Admin1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "admin"
+      ]
+    },
+    {
+      "username": "operator@cosmian.com",
+      "email": "operator@cosmian.com",
+      "firstName": "KMS",
+      "lastName": "Operator",
+      "enabled": true,
+      "emailVerified": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Operator1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "operator"
+      ]
+    },
+    {
+      "username": "auditor@cosmian.com",
+      "email": "auditor@cosmian.com",
+      "firstName": "KMS",
+      "lastName": "Auditor",
+      "enabled": true,
+      "emailVerified": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Auditor1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "auditor"
+      ]
+    },
+    {
+      "username": "readonly@cosmian.com",
+      "email": "readonly@cosmian.com",
+      "firstName": "KMS",
+      "lastName": "Readonly",
+      "enabled": true,
+      "emailVerified": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Readonly1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "readonly"
+      ]
+    }
+  ]
+}

--- a/deploy/rbac/opa/policy/data.json
+++ b/deploy/rbac/opa/policy/data.json
@@ -1,0 +1,14 @@
+{
+  "cosmian": {
+    "kms": {
+      "rbac": {
+        "role_assignments": {
+          "admin@cosmian.com": ["admin"],
+          "operator@cosmian.com": ["operator"],
+          "auditor@cosmian.com": ["auditor"],
+          "readonly@cosmian.com": ["readonly"]
+        }
+      }
+    }
+  }
+}

--- a/deploy/rbac/opa/policy/default_rbac.rego
+++ b/deploy/rbac/opa/policy/default_rbac.rego
@@ -1,0 +1,85 @@
+# Cosmian KMS — Default RBAC Policy
+#
+# This policy implements role-based access control aligned with NIST SP 800-162.
+# It defines four default roles: administrator, operator, auditor, and readonly.
+#
+# Input schema (NIST SP 800-162 attributes):
+#   input.subject.user_id       — authenticated user identifier
+#   input.subject.roles         — list of assigned roles
+#   input.subject.is_owner      — true if user owns the target object
+#   input.subject.is_privileged — true if user is in the privileged_users list
+#   input.action.operation      — KMIP operation (lowercase)
+#   input.resource.*            — target object attributes
+#   input.environment.*         — contextual attributes (reserved)
+#
+# Decision: data.cosmian.kms.rbac.allow = true | false
+
+package cosmian.kms.rbac
+
+import rego.v1
+
+default allow := false
+
+# ── Administrator ────────────────────────────────────────────────────────
+# Full access to all operations.
+allow if {
+    some role in input.subject.roles
+    role == "admin"
+}
+
+# ── Operator ─────────────────────────────────────────────────────────────
+# All key management and cryptographic operations.
+allow if {
+    some role in input.subject.roles
+    role == "operator"
+    input.action.operation in operator_operations
+}
+
+operator_operations := {
+    "create",
+    "certify",
+    "decrypt",
+    "derive_key",
+    "destroy",
+    "encrypt",
+    "export",
+    "get",
+    "get_attributes",
+    "hash",
+    "import",
+    "locate",
+    "mac",
+    "revoke",
+    "rekey",
+    "sign",
+    "signature_verify",
+    "validate",
+}
+
+# ── Auditor ──────────────────────────────────────────────────────────────
+# Read-only access for inspection and compliance auditing.
+allow if {
+    some role in input.subject.roles
+    role == "auditor"
+    input.action.operation in auditor_operations
+}
+
+auditor_operations := {
+    "get",
+    "get_attributes",
+    "locate",
+    "validate",
+}
+
+# ── Read-Only ────────────────────────────────────────────────────────────
+# Minimal access: can only list and inspect metadata.
+allow if {
+    some role in input.subject.roles
+    role == "readonly"
+    input.action.operation in readonly_operations
+}
+
+readonly_operations := {
+    "get_attributes",
+    "locate",
+}

--- a/deploy/rbac/test.sh
+++ b/deploy/rbac/test.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# ===========================================================================
+# test.sh — Smoke-test the Cosmian KMS RBAC + Keycloak stack
+#
+# Usage:
+#   ./test.sh
+#   KMS_URL=https://myhost:9998 KC_URL=https://myhost:8180 ./test.sh
+#
+# Requirements: curl, jq (or python3 as fallback), bash >= 4
+# ===========================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── Configuration ──────────────────────────────────────────────────────────
+CA="${CA:-${SCRIPT_DIR}/certs/ca.crt}"
+KMS_URL="${KMS_URL:-https://localhost:9998}"
+KC_URL="${KC_URL:-https://localhost:8180}"
+KC_REALM="${KC_REALM:-kms}"
+KC_CLIENT="${KC_CLIENT:-cosmian-kms}"
+
+# Colour helpers
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+PASS=0; FAIL=0
+
+pass() { echo -e "${GREEN}[PASS]${NC} $*"; PASS=$((PASS+1)); }
+fail() { echo -e "${RED}[FAIL]${NC} $*"; FAIL=$((FAIL+1)); }
+info() { echo -e "${YELLOW}[INFO]${NC} $*"; }
+
+# JSON decode helper (jq preferred, python3 fallback)
+json() {
+    if command -v jq &>/dev/null; then
+        jq -r "$1" <<< "$2"
+    else
+        python3 -c "import sys,json; print(json.loads('''$2''')$1)" 2>/dev/null || echo ""
+    fi
+}
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+get_token() {
+    local user="$1" pass="$2"
+    curl -sf --cacert "$CA" \
+        -X POST "${KC_URL}/realms/${KC_REALM}/protocol/openid-connect/token" \
+        -d "client_id=${KC_CLIENT}&grant_type=password&username=${user}&password=${pass}" \
+        | (command -v jq &>/dev/null && jq -r .access_token || python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
+}
+
+decode_roles() {
+    local token="$1"
+    local payload
+    payload=$(echo "$token" | cut -d. -f2 | awk '{n=length($0)%4; if(n==2)$0=$0"=="; else if(n==3)$0=$0"="; print}' | base64 -d 2>/dev/null)
+    command -v jq &>/dev/null \
+        && jq -r '.realm_access.roles[]' <<< "$payload" \
+        || python3 -c "import json; d=json.loads('${payload}'); print('\n'.join(d.get('realm_access',{}).get('roles',[])))"
+}
+
+kms() {
+    local token="$1"; shift
+    curl -sf --cacert "$CA" -H "Authorization: Bearer ${token}" "$@"
+}
+
+# ── Pre-flight ─────────────────────────────────────────────────────────────
+echo "==========================================================="
+echo "  Cosmian KMS RBAC stack — smoke tests"
+echo "  KMS : ${KMS_URL}"
+echo "  KC  : ${KC_URL}/realms/${KC_REALM}"
+echo "  CA  : ${CA}"
+echo "==========================================================="
+echo ""
+
+if [[ ! -f "$CA" ]]; then
+    fail "CA cert not found at ${CA} — run 'docker compose up' first"
+    exit 1
+fi
+
+# ── Test 1: KMS health (unauthenticated) ───────────────────────────────────
+info "Test 1: KMS health endpoint"
+resp=$(curl -sf --cacert "$CA" "${KMS_URL}/health" 2>&1) || { fail "KMS not reachable"; exit 1; }
+if echo "$resp" | grep -q '"status"'; then
+    pass "KMS is UP — $resp"
+else
+    fail "Unexpected health response: $resp"
+fi
+echo ""
+
+# ── Test 2: Keycloak OIDC discovery ────────────────────────────────────────
+info "Test 2: Keycloak OIDC discovery for realm '${KC_REALM}'"
+resp=$(curl -sf --cacert "$CA" "${KC_URL}/realms/${KC_REALM}/.well-known/openid-configuration" 2>&1) || { fail "Keycloak not reachable"; exit 1; }
+if echo "$resp" | grep -q "issuer"; then
+    pass "Keycloak realm '${KC_REALM}' is reachable"
+else
+    fail "Unexpected discovery response: ${resp:0:200}"
+fi
+echo ""
+
+# ── Test 3–6: Per-user token + role + KMS access ───────────────────────────
+run_user_test() {
+    local label="$1" user="$2" password="$3" expected_role="$4" can_create="$5"
+
+    info "Test: user '${user}' (expected role: ${expected_role})"
+
+    # Get token
+    token=$(get_token "$user" "$password") || { fail "${label}: token request failed"; return; }
+    [[ -n "$token" && "$token" != "null" ]] || { fail "${label}: empty token"; return; }
+    pass "${label}: token issued"
+
+    # Decode roles
+    roles=$(decode_roles "$token")
+    if echo "$roles" | grep -q "$expected_role"; then
+        pass "${label}: token contains role '${expected_role}' (roles: $(echo $roles | tr '\n' ','))"
+    else
+        fail "${label}: expected role '${expected_role}' not found in token (got: $(echo $roles | tr '\n' ','))"
+    fi
+
+    # KMS health with token
+    resp=$(kms "$token" "${KMS_URL}/health" 2>&1) || { fail "${label}: authenticated health call failed"; return; }
+    if echo "$resp" | grep -q '"status"'; then
+        pass "${label}: authenticated KMS health OK"
+    else
+        fail "${label}: authenticated health returned: ${resp:0:200}"
+    fi
+
+    # List owned objects (all roles can do this)
+    http_code=$(curl -o /dev/null -sw "%{http_code}" --cacert "$CA" \
+        -H "Authorization: Bearer ${token}" "${KMS_URL}/access/owned" 2>/dev/null)
+    if [[ "$http_code" == "200" ]]; then
+        pass "${label}: GET /access/owned → 200"
+    else
+        fail "${label}: GET /access/owned → HTTP ${http_code}"
+    fi
+
+    echo ""
+}
+
+run_user_test "Admin"    "admin@cosmian.com"    "Admin1234!"    "admin"    "yes"
+run_user_test "Operator" "operator@cosmian.com" "Operator1234!" "operator" "yes"
+run_user_test "Auditor"  "auditor@cosmian.com"  "Auditor1234!"  "auditor"  "no"
+run_user_test "Readonly" "readonly@cosmian.com" "Readonly1234!" "readonly" "no"
+
+# ── Test 7: Invalid credentials → no token ─────────────────────────────────
+info "Test 7: Invalid credentials should be rejected by Keycloak"
+bad=$(curl -s --cacert "$CA" \
+    -X POST "${KC_URL}/realms/${KC_REALM}/protocol/openid-connect/token" \
+    -d "client_id=${KC_CLIENT}&grant_type=password&username=admin@cosmian.com&password=WRONG" \
+    2>&1)
+if echo "$bad" | grep -q "Unauthorized\|invalid_grant\|401"; then
+    pass "Invalid credentials correctly rejected"
+else
+    fail "Expected rejection, got: ${bad:0:200}"
+fi
+echo ""
+
+# ── Test 8: No token → 401 from KMS ────────────────────────────────────────
+info "Test 8: Missing token should return 401 from KMS"
+http_code=$(curl -o /dev/null -sw "%{http_code}" --cacert "$CA" \
+    "${KMS_URL}/access/owned" 2>/dev/null)
+if [[ "$http_code" == "401" ]]; then
+    pass "No token → HTTP 401 (Unauthorized)"
+else
+    fail "Expected 401, got HTTP ${http_code}"
+fi
+echo ""
+
+# ── Summary ────────────────────────────────────────────────────────────────
+echo "==========================================================="
+echo -e "  Results: ${GREEN}${PASS} passed${NC}  ${RED}${FAIL} failed${NC}"
+echo "==========================================================="
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary

Add a self-contained `deploy/opa/` Docker Compose stack that demonstrates Cosmian KMS running alongside Open Policy Agent (OPA) for RBAC policy evaluation.

## Services

| Service | Image | Port |
|---------|-------|------|
| **OPA** | `openpolicyagent/opa:0.68.0` | 8181 |
| **KMS** | `ghcr.io/cosmian/kms:latest` | 9998 |

## Key choices

- **OPA** serves the default RBAC Rego policy (`deploy/opa/opa/policy/`) with anonymous telemetry disabled (`--disable-telemetry`)
- **KMS** uses SQLite backend (no external database required) with its embedded Regorus RBAC engine pointing at the same policy bundle
- `KMS_FORCE_DEFAULT_USERNAME=true` enables the built-in `admin` identity without an external IdP — add JWT/mTLS for production

## Quick start

```bash
cd deploy/opa
docker compose up -d
curl http://localhost:9998/health
```