### PR TITLE
feat(cng): grant by default key usages for PrivateKey/PublicKey

### DIFF
--- a/crate/clients/cng/src/backend.rs
+++ b/crate/clients/cng/src/backend.rs
@@ -553,39 +553,57 @@ pub fn encrypt_data(
 
 /// Create an RSA key pair in the KMS with the given bit length and name tag,
 /// and return `(private_uuid, public_uuid)`.
+///
+/// The private key is created with `Sign | Decrypt | UnwrapKey` usage mask and
+/// the public key with `Verify | Encrypt | WrapKey`, allowing the key pair to
+/// be used for all standard RSA operations.
 pub fn create_rsa_key_pair(
     client: &KmsClient,
     vendor_id: &str,
     key_name: &str,
     bit_length: u32,
-    use_for_sign: bool,
 ) -> KspResult<(String, String)> {
     debug!("CNG KSP: create_rsa_key_pair name={key_name} bits={bit_length}");
 
     let tag = cng_key_tag(key_name);
-    let usage = if use_for_sign {
-        CryptographicUsageMask::Sign | CryptographicUsageMask::Verify
-    } else {
-        CryptographicUsageMask::Decrypt | CryptographicUsageMask::Encrypt
-    };
 
     RUNTIME.block_on(async {
-        let attrs = Attributes {
+        let activation_date = Some(time_normalize().map_err(|e| KspError::Backend(e.to_string()))?);
+
+        let mut common_attrs = Attributes {
             cryptographic_algorithm: Some(CryptographicAlgorithm::RSA),
             cryptographic_length: Some(i32::try_from(bit_length).unwrap_or(2048)),
-            cryptographic_usage_mask: Some(usage),
-            // Set activation_date to the past so the key is created in Active state
-            // (without it the server creates keys in PreActive state, which cannot be used).
-            activation_date: Some(time_normalize().map_err(|e| KspError::Backend(e.to_string()))?),
+            activation_date,
             ..Default::default()
         };
-        let mut attrs = attrs;
-        attrs
+        common_attrs
             .set_tags(vendor_id, [CNG_KSP_TAG, tag.as_str()])
             .map_err(|e| KspError::Backend(e.to_string()))?;
 
+        let private_key_attributes = Attributes {
+            cryptographic_usage_mask: Some(
+                CryptographicUsageMask::Sign
+                    | CryptographicUsageMask::Decrypt
+                    | CryptographicUsageMask::UnwrapKey,
+            ),
+            activation_date,
+            ..Default::default()
+        };
+
+        let public_key_attributes = Attributes {
+            cryptographic_usage_mask: Some(
+                CryptographicUsageMask::Verify
+                    | CryptographicUsageMask::Encrypt
+                    | CryptographicUsageMask::WrapKey,
+            ),
+            activation_date,
+            ..Default::default()
+        };
+
         let op = CreateKeyPair {
-            common_attributes: Some(attrs),
+            common_attributes: Some(common_attrs),
+            private_key_attributes: Some(private_key_attributes),
+            public_key_attributes: Some(public_key_attributes),
             ..Default::default()
         };
         let resp = client
@@ -600,6 +618,10 @@ pub fn create_rsa_key_pair(
 }
 
 /// Create an EC key pair in the KMS with the given curve and name tag.
+///
+/// The private key is created with `Sign | DeriveKey | KeyAgreement` usage mask
+/// and the public key with `Verify | DeriveKey | KeyAgreement`, supporting both
+/// ECDSA signing and ECDH key agreement.
 pub fn create_ec_key_pair(
     client: &KmsClient,
     vendor_id: &str,
@@ -611,27 +633,45 @@ pub fn create_ec_key_pair(
     let tag = cng_key_tag(key_name);
 
     RUNTIME.block_on(async {
-        let attrs = Attributes {
+        let activation_date = Some(time_normalize().map_err(|e| KspError::Backend(e.to_string()))?);
+
+        let mut common_attrs = Attributes {
             cryptographic_algorithm: Some(CryptographicAlgorithm::EC),
             cryptographic_domain_parameters: Some(CryptographicDomainParameters {
                 recommended_curve: Some(curve),
                 ..Default::default()
             }),
-            cryptographic_usage_mask: Some(
-                CryptographicUsageMask::Sign | CryptographicUsageMask::Verify,
-            ),
-            // Set activation_date to the past so the key is created in Active state
-            // (without it the server creates keys in PreActive state, which cannot be used).
-            activation_date: Some(time_normalize().map_err(|e| KspError::Backend(e.to_string()))?),
+            activation_date,
             ..Default::default()
         };
-        let mut attrs = attrs;
-        attrs
+        common_attrs
             .set_tags(vendor_id, [CNG_KSP_TAG, tag.as_str()])
             .map_err(|e| KspError::Backend(e.to_string()))?;
 
+        let private_key_attributes = Attributes {
+            cryptographic_usage_mask: Some(
+                CryptographicUsageMask::Sign
+                    | CryptographicUsageMask::DeriveKey
+                    | CryptographicUsageMask::KeyAgreement,
+            ),
+            activation_date,
+            ..Default::default()
+        };
+
+        let public_key_attributes = Attributes {
+            cryptographic_usage_mask: Some(
+                CryptographicUsageMask::Verify
+                    | CryptographicUsageMask::DeriveKey
+                    | CryptographicUsageMask::KeyAgreement,
+            ),
+            activation_date,
+            ..Default::default()
+        };
+
         let op = CreateKeyPair {
-            common_attributes: Some(attrs),
+            common_attributes: Some(common_attrs),
+            private_key_attributes: Some(private_key_attributes),
+            public_key_attributes: Some(public_key_attributes),
             ..Default::default()
         };
         let resp = client

--- a/crate/clients/cng/src/key.rs
+++ b/crate/clients/cng/src/key.rs
@@ -311,16 +311,12 @@ impl CngKeyCtx {
         } else {
             // Generate a new key pair in the KMS
             match &pending.algorithm {
-                KeyAlgorithm::Rsa { bits } => {
-                    let use_sign = pending.usage.contains(KeyUsage::SIGN);
-                    backend::create_rsa_key_pair(
-                        &self.client,
-                        &self.vendor_id,
-                        &pending.key_name,
-                        *bits,
-                        use_sign,
-                    )?
-                }
+                KeyAlgorithm::Rsa { bits } => backend::create_rsa_key_pair(
+                    &self.client,
+                    &self.vendor_id,
+                    &pending.key_name,
+                    *bits,
+                )?,
                 KeyAlgorithm::Ec { curve } => {
                     use ckms::reexport::cosmian_kms_cli_actions::reexport::cosmian_kmip::kmip_2_1::kmip_types::RecommendedCurve;
                     let kms_curve = match curve {

--- a/crate/clients/cng/src/tests.rs
+++ b/crate/clients/cng/src/tests.rs
@@ -48,7 +48,7 @@ fn cleanup_key_pair(client: &KmsClient, priv_id: &str, pub_id: &str) {
 fn test_create_rsa_key_pair() {
     let client = test_client();
     let (priv_id, pub_id) =
-        backend::create_rsa_key_pair(&client, TEST_VENDOR_ID, "test-rsa-2048", 2048, true)
+        backend::create_rsa_key_pair(&client, TEST_VENDOR_ID, "test-rsa-2048", 2048)
             .expect("create_rsa_key_pair failed");
     assert!(!priv_id.is_empty(), "private key UUID must not be empty");
     assert!(!pub_id.is_empty(), "public key UUID must not be empty");
@@ -66,7 +66,7 @@ fn test_sign_with_rsa_key() {
 
     let client = test_client();
     let (priv_id, pub_id) =
-        backend::create_rsa_key_pair(&client, TEST_VENDOR_ID, "test-rsa-sign", 2048, true)
+        backend::create_rsa_key_pair(&client, TEST_VENDOR_ID, "test-rsa-sign", 2048)
             .expect("create_rsa_key_pair failed");
 
     // SHA-256 of "hello"
@@ -119,7 +119,7 @@ fn test_create_ec_key_pair() {
 fn test_locate_key_by_name() {
     let client = test_client();
     let (priv_id, pub_id) =
-        backend::create_rsa_key_pair(&client, TEST_VENDOR_ID, "test-locate", 2048, true)
+        backend::create_rsa_key_pair(&client, TEST_VENDOR_ID, "test-locate", 2048)
             .expect("create_rsa_key_pair failed");
 
     let found_id = backend::locate_key_by_name(&client, TEST_VENDOR_ID, "test-locate")
@@ -139,10 +139,10 @@ fn test_list_cng_keys() {
 
     // Create two keys
     let (priv1, pub1) =
-        backend::create_rsa_key_pair(&client, TEST_VENDOR_ID, "list-test-key-1", 2048, true)
+        backend::create_rsa_key_pair(&client, TEST_VENDOR_ID, "list-test-key-1", 2048)
             .expect("create key 1 failed");
     let (priv2, pub2) =
-        backend::create_rsa_key_pair(&client, TEST_VENDOR_ID, "list-test-key-2", 2048, false)
+        backend::create_rsa_key_pair(&client, TEST_VENDOR_ID, "list-test-key-2", 2048)
             .expect("create key 2 failed");
 
     let keys = backend::list_cng_keys(&client, TEST_VENDOR_ID).expect("list_cng_keys failed");
@@ -168,7 +168,7 @@ fn test_list_cng_keys() {
 fn test_export_public_key_spki() {
     let client = test_client();
     let (priv_id, pub_id) =
-        backend::create_rsa_key_pair(&client, TEST_VENDOR_ID, "test-export-pub", 2048, true)
+        backend::create_rsa_key_pair(&client, TEST_VENDOR_ID, "test-export-pub", 2048)
             .expect("create_rsa_key_pair failed");
 
     let spki =
@@ -249,7 +249,7 @@ fn test_sign_rsa_pss() {
 
     let client = test_client();
     let (priv_id, pub_id) =
-        backend::create_rsa_key_pair(&client, TEST_VENDOR_ID, "test-rsa-pss", 2048, true)
+        backend::create_rsa_key_pair(&client, TEST_VENDOR_ID, "test-rsa-pss", 2048)
             .expect("create_rsa_key_pair failed");
 
     let hash: [u8; 32] = [0x42; 32];
@@ -279,7 +279,7 @@ fn test_verify_rsa_pkcs1v15() {
 
     let client = test_client();
     let (priv_id, pub_id) =
-        backend::create_rsa_key_pair(&client, TEST_VENDOR_ID, "test-verify-rsa", 2048, true)
+        backend::create_rsa_key_pair(&client, TEST_VENDOR_ID, "test-verify-rsa", 2048)
             .expect("create_rsa_key_pair failed");
 
     let hash: [u8; 32] = [0x55; 32];
@@ -379,7 +379,7 @@ fn test_rsa_encrypt_decrypt_oaep() {
 
     let client = test_client();
     let (priv_id, pub_id) =
-        backend::create_rsa_key_pair(&client, TEST_VENDOR_ID, "test-enc-oaep", 2048, false)
+        backend::create_rsa_key_pair(&client, TEST_VENDOR_ID, "test-enc-oaep", 2048)
             .expect("create_rsa_key_pair failed");
 
     let plaintext = b"CNG KSP OAEP round-trip test";


### PR DESCRIPTION
Relax strict key usage of CNG keys. A PrivateKey is allowed by default to Sign or Decrypt