### PR TITLE
perf(xks): configurable unwrapped-cache size, prepare_cached for PostgreSQL, fix WASM build

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -44,7 +44,7 @@ jobs:
         runner: [ubuntu-24.04, ubuntu-24.04-arm, macos-15]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/CHANGELOG/feat_perf.md
+++ b/CHANGELOG/feat_perf.md
@@ -1,0 +1,28 @@
+## Performance
+
+### Server / XKS
+
+- Make the unwrapped-key LRU cache size configurable via `--unwrapped-cache-max-size` CLI
+  flag (env: `KMS_UNWRAPPED_CACHE_MAX_SIZE`, default: **1000**).
+  Previously hardcoded to 100, this caused continuous LRU thrashing on XKS deployments
+  with ≥ 100 active keys, forcing a full KEK unwrap on every cache eviction.
+  ([#1020](https://github.com/Cosmian/kms/pull/1020))
+
+### PostgreSQL
+
+- Use `prepare_cached` for the `list-uids-for-tags` query, reducing per-request
+  statement-preparation overhead on PostgreSQL backends.
+  ([#1020](https://github.com/Cosmian/kms/pull/1020))
+
+## Bug Fixes
+
+### WASM
+
+- Fix WASM build broken by `tracing-appender 0.2.5` (which introduced a `symlink` crate
+  dependency incompatible with `wasm32-unknown-unknown`). Resolved by upgrading to
+  `cosmian_logger 0.7.2`, which gates `tracing-appender` behind
+  `cfg(not(target_arch = "wasm32"))`. ([#1020](https://github.com/Cosmian/kms/pull/1020))
+
+---
+
+Closes #1020

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,9 +620,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "blake2"
@@ -1451,9 +1451,9 @@ dependencies = [
 
 [[package]]
 name = "cosmian_logger"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cd0fe474e8ad66df5dfc5d0dfa02379e0a80c76da53ec659f68cfdd377f6d8"
+checksum = "2dd5ce2a8d286b7dcf82479b458554e84526615b77a643296645e2dcee4a98b0"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -2518,9 +2518,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2745,7 +2745,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.14",
+ "h2 0.4.15",
  "http 1.4.2",
  "http-body",
  "httparse",
@@ -3174,9 +3174,9 @@ dependencies = [
 
 [[package]]
 name = "leb128"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cc46bac87ef8093eed6f272babb833b6443374399985ac8ed28471ee0918545"
+checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
 
 [[package]]
 name = "leb128fmt"
@@ -3330,9 +3330,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "mime"
@@ -3459,9 +3459,9 @@ dependencies = [
 
 [[package]]
 name = "mysql_common"
-version = "0.37.2"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b42ced54aa8ac97226486337973f9bc3956e24f03a23e88a6e18f640959d6e2"
+checksum = "0f27695f286b461da077b8c2f72f47feaa04ce3c3f9c0976257410e90e21208a"
 dependencies = [
  "base64 0.22.1",
  "bitflags",
@@ -4463,9 +4463,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5230,10 +5230,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
-name = "syn"
-version = "2.0.117"
+name = "symlink"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
+name = "syn"
+version = "2.0.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5739,11 +5745,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
+ "symlink",
  "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
@@ -6226,9 +6233,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6763,18 +6770,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crate/server/src/config/command_line/db.rs
+++ b/crate/server/src/config/command_line/db.rs
@@ -169,6 +169,18 @@ pub struct MainDBConfig {
         verbatim_doc_comment
     )]
     pub unwrapped_cache_max_age: u64,
+
+    /// Maximum number of entries in the unwrapped key cache.
+    /// When the cache is full, the least-recently-used entry is evicted.
+    /// Set this above the number of distinct wrapped keys in your deployment
+    /// to avoid LRU thrashing. The default is 1000.
+    #[clap(
+        long,
+        env = "KMS_UNWRAPPED_CACHE_MAX_SIZE",
+        default_value = "1000",
+        verbatim_doc_comment
+    )]
+    pub unwrapped_cache_max_size: usize,
 }
 
 impl Default for MainDBConfig {
@@ -180,6 +192,7 @@ impl Default for MainDBConfig {
             clear_database: false,
             max_connections: None,
             unwrapped_cache_max_age: 15,
+            unwrapped_cache_max_size: 1000,
             #[cfg(feature = "non-fips")]
             redis_master_password: None,
         }

--- a/crate/server/src/config/params/server_params.rs
+++ b/crate/server/src/config/params/server_params.rs
@@ -79,6 +79,9 @@ pub struct ServerParams {
     /// The maximum age of unwrapped objects in the cache
     pub unwrapped_cache_max_age: Duration,
 
+    /// The maximum number of entries in the unwrapped key cache
+    pub unwrapped_cache_max_size: usize,
+
     /// Whether the socket server should be started
     pub start_socket_server: bool,
 
@@ -327,6 +330,13 @@ impl ServerParams {
             } else {
                 Duration::from_secs(conf.db.unwrapped_cache_max_age * 60)
             },
+            unwrapped_cache_max_size: if conf.db.unwrapped_cache_max_size == 0 {
+                return Err(KmsError::NotSupported(
+                    "unwrapped_cache_max_size must be greater than 0".to_owned(),
+                ));
+            } else {
+                conf.db.unwrapped_cache_max_size
+            },
             start_socket_server: conf.socket_server.socket_server_start,
             socket_server_hostname: conf.socket_server.socket_server_hostname,
             socket_server_port: conf.socket_server.socket_server_port,
@@ -450,7 +460,8 @@ impl fmt::Debug for ServerParams {
 
         debug_struct
             .field("clear_db_on_start", &self.clear_db_on_start)
-            .field("unwrapped_cache_max_age", &self.unwrapped_cache_max_age);
+            .field("unwrapped_cache_max_age", &self.unwrapped_cache_max_age)
+            .field("unwrapped_cache_max_size", &self.unwrapped_cache_max_size);
 
         if let Some(ref otel_params) = self.otel_params {
             debug_struct.field("otel_params", otel_params);

--- a/crate/server/src/config/wizard/db_wizard.rs
+++ b/crate/server/src/config/wizard/db_wizard.rs
@@ -118,5 +118,6 @@ pub fn configure_db() -> KResult<MainDBConfig> {
         clear_database,
         max_connections,
         unwrapped_cache_max_age,
+        unwrapped_cache_max_size: 1000,
     })
 }

--- a/crate/server/src/core/kms/mod.rs
+++ b/crate/server/src/core/kms/mod.rs
@@ -4,7 +4,7 @@ mod kmip;
 mod other_kms_methods;
 mod permissions;
 
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, num::NonZeroUsize, sync::Arc};
 
 use cosmian_kms_server_database::{
     Database, DbMetricsRecorder,
@@ -146,11 +146,18 @@ impl KMS {
                 m.clone() // Arc clones are cheap
             });
 
+        let cache_max_size =
+            NonZeroUsize::new(server_params.unwrapped_cache_max_size).ok_or_else(|| {
+                KmsError::InvalidRequest(
+                    "unwrapped_cache_max_size must be greater than 0".to_owned(),
+                )
+            })?;
         let database = Database::instantiate(
             main_db_params,
             server_params.clear_db_on_start,
             object_stores,
             server_params.unwrapped_cache_max_age,
+            cache_max_size,
             db_otel_recorder,
         )
         .await?;

--- a/crate/server/src/main.rs
+++ b/crate/server/src/main.rs
@@ -240,6 +240,7 @@ mod tests {
                 #[cfg(feature = "non-fips")]
                 clear_database: false,
                 unwrapped_cache_max_age: 15,
+                unwrapped_cache_max_size: 1000,
             },
             socket_server: SocketServerConfig {
                 socket_server_start: false,
@@ -371,6 +372,7 @@ sqlite_path = "[sqlite path]"
 redis_master_password = "[redis master password]"
 clear_database = false
 unwrapped_cache_max_age = 15
+unwrapped_cache_max_size = 1000
 
 [socket_server]
 socket_server_start = false

--- a/crate/server_database/src/core/database_objects.rs
+++ b/crate/server_database/src/core/database_objects.rs
@@ -512,6 +512,7 @@ impl Database {
 mod tests {
     use std::{
         collections::HashMap,
+        num::NonZeroUsize,
         sync::{Arc, Mutex},
         time::Duration,
     };
@@ -530,6 +531,7 @@ mod tests {
             false,
             HashMap::new(), // no HSM stores registered
             Duration::from_secs(1),
+            NonZeroUsize::new(100).expect("100 is non-zero"),
             None,
         )
         .await
@@ -586,6 +588,7 @@ mod tests {
             false,
             HashMap::new(),
             Duration::from_secs(1),
+            NonZeroUsize::new(100).expect("100 is non-zero"),
             Some(recorder_arc),
         )
         .await

--- a/crate/server_database/src/core/mod.rs
+++ b/crate/server_database/src/core/mod.rs
@@ -3,7 +3,7 @@
 mod database_objects;
 mod database_permissions;
 mod db_metrics;
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{collections::HashMap, num::NonZeroUsize, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 #[cfg(feature = "non-fips")]
@@ -91,17 +91,23 @@ impl Database {
     /// - `clear_db_on_start` indicates whether to clear the database on startup.
     /// - `object_stores` is a map of object stores with their prefixes.
     /// - `cache_max_age` is the maximum age of unwrapped objects in the cache.
+    /// - `cache_max_size` is the maximum number of entries in the unwrapped objects cache.
     pub async fn instantiate(
         main_db_params: &MainDbParams,
         clear_db_on_start: bool,
         object_stores: HashMap<String, Arc<dyn ObjectsStore + Sync + Send>>,
         cache_max_age: Duration,
+        cache_max_size: NonZeroUsize,
         recorder: Option<Arc<dyn DbMetricsRecorder>>,
     ) -> DbResult<Self> {
         // main/default database
-        let mut db =
-            Self::instantiate_main_database(main_db_params, clear_db_on_start, cache_max_age)
-                .await?;
+        let mut db = Self::instantiate_main_database(
+            main_db_params,
+            clear_db_on_start,
+            cache_max_age,
+            cache_max_size,
+        )
+        .await?;
         db.recorder = recorder;
         for (prefix, store) in object_stores {
             db.register_objects_store(&prefix, store).await;
@@ -113,6 +119,7 @@ impl Database {
         main_db_params: &MainDbParams,
         clear_db_on_start: bool,
         cache_max_age: Duration,
+        cache_max_size: NonZeroUsize,
     ) -> DbResult<Self> {
         // Permissions are stored in the same backend as objects for the main database.
         // The `SqlitePool`/`PgPool`/`MySqlPool` types implement both `ObjectsStore` and
@@ -128,6 +135,7 @@ impl Database {
                     db.clone(),
                     db,
                     cache_max_age,
+                    cache_max_size,
                     MainDbKind::Sqlite,
                     health,
                 ))
@@ -139,6 +147,7 @@ impl Database {
                     db.clone(),
                     db,
                     cache_max_age,
+                    cache_max_size,
                     MainDbKind::Postgres,
                     health,
                 ))
@@ -152,6 +161,7 @@ impl Database {
                     db.clone(),
                     db,
                     cache_max_age,
+                    cache_max_size,
                     MainDbKind::Mysql,
                     health,
                 ))
@@ -180,6 +190,7 @@ impl Database {
                     db.clone(),
                     db,
                     cache_max_age,
+                    cache_max_size,
                     MainDbKind::RedisFindex,
                     health,
                 ))
@@ -201,17 +212,19 @@ impl Database {
     /// - `default_database` is the default database for objects without a prefix
     /// - `permissions_database` is the database for permissions
     /// - `cache_max_age` is the maximum age of unwrapped objects in the cache.
+    /// - `cache_max_size` is the maximum number of entries in the unwrapped objects cache.
     fn new(
         default_objects_database: Arc<dyn ObjectsStore + Sync + Send>,
         permissions_database: Arc<dyn PermissionsStore + Sync + Send>,
         cache_max_age: Duration,
+        cache_max_size: NonZeroUsize,
         kind: MainDbKind,
         health: Arc<dyn DatabaseHealth + Sync + Send>,
     ) -> Self {
         Self {
             objects: RwLock::new(HashMap::from([(String::new(), default_objects_database)])),
             permissions: permissions_database,
-            unwrapped_cache: UnwrappedCache::new(cache_max_age),
+            unwrapped_cache: UnwrappedCache::new(cache_max_age, cache_max_size),
             kind,
             health,
             recorder: None,

--- a/crate/server_database/src/core/unwrapped_cache.rs
+++ b/crate/server_database/src/core/unwrapped_cache.rs
@@ -70,16 +70,17 @@ pub struct UnwrappedCache {
 }
 
 impl UnwrappedCache {
-    /// Create a new cache with a configurable max age setting.
-    /// The max age is the time after which an object is considered stale.
-    /// The garbage collection interval is set to `max_age x 1.5`
-    #[allow(clippy::missing_panics_doc)]
+    /// Create a new cache with configurable max age and max size settings.
+    ///
+    /// `max_age` is the duration after which an entry is considered stale and
+    /// eligible for garbage collection.  `max_size` is the maximum number of
+    /// entries the LRU cache will hold before evicting the least-recently-used
+    /// entry.  Callers should set `max_size` above their active key cardinality
+    /// to avoid LRU thrashing (every access to a cold key evicting a warm one).
+    ///
+    /// The garbage collection interval is set to `max_age × 1.5`.
     #[must_use]
-    pub fn new(max_age: Duration) -> Self {
-        // SAFETY: 100 is a non-zero constant
-        #[allow(clippy::expect_used)]
-        let max_size = NonZeroUsize::new(100).expect("100 is not zero. This will never trigger");
-
+    pub fn new(max_age: Duration, max_size: NonZeroUsize) -> Self {
         let (tx, rx) = mpsc::channel(100_000);
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let cache = Arc::new(RwLock::new(LruCache::new(max_size)));
@@ -278,10 +279,13 @@ mod tests {
         clippy::panic_in_result_fn,
         clippy::unwrap_in_result,
         clippy::assertions_on_result_states,
-        clippy::assertions_on_constants
+        clippy::assertions_on_constants,
+        // Test helpers use NonZeroUsize::new(N).expect() with literal non-zero constants.
+        clippy::expect_used
     )]
     use std::{
         collections::{HashMap, HashSet},
+        num::NonZeroUsize,
         time::Duration,
     };
 
@@ -311,6 +315,7 @@ mod tests {
             true,
             HashMap::new(),
             Duration::from_millis(100),
+            NonZeroUsize::new(100).expect("100 is non-zero"),
             None,
         )
         .await?;
@@ -376,6 +381,7 @@ mod tests {
         // Create a cache with a short GC interval and max age
         let cache = super::UnwrappedCache::new(
             Duration::from_millis(100), // Keys expire after 100 ms, GC runs every 150 ms.
+            NonZeroUsize::new(100).expect("100 is non-zero"),
         );
 
         // Insert an item
@@ -425,7 +431,10 @@ mod tests {
 
         // Create a scope to ensure the cache is dropped
         {
-            let cache = super::UnwrappedCache::new(Duration::from_millis(100));
+            let cache = super::UnwrappedCache::new(
+                Duration::from_millis(100),
+                NonZeroUsize::new(100).expect("100 is non-zero"),
+            );
 
             let uid = "test_item".to_owned();
 

--- a/crate/server_database/src/stores/sql/pgsql.rs
+++ b/crate/server_database/src/stores/sql/pgsql.rs
@@ -9,7 +9,7 @@ use cosmian_kms_interfaces::{
     AtomicOperation, InterfaceError, InterfaceResult, ObjectWithMetadata, ObjectsStore,
     PermissionsStore,
 };
-use deadpool_postgres::{Config as PgConfig, ManagerConfig, Pool, RecyclingMethod};
+use deadpool_postgres::{Config as PgConfig, GenericClient, ManagerConfig, Pool, RecyclingMethod};
 use openssl::ssl::{SslConnector, SslFiletype, SslMethod, SslVerifyMode};
 use postgres_openssl::MakeTlsConnector;
 use rawsql::Loader;
@@ -388,7 +388,7 @@ impl ObjectsStore for PgPool {
         tags: &HashSet<String>,
     ) -> InterfaceResult<String> {
         async fn transact(
-            tx: &tokio_postgres::Transaction<'_>,
+            tx: &deadpool_postgres::Transaction<'_>,
             uid: &str,
             owner: &str,
             object: &Object,
@@ -399,7 +399,7 @@ impl ObjectsStore for PgPool {
             let attributes_json = serde_json::to_value(attributes).map_err(DbError::from)?;
             let state = attributes.state.unwrap_or(State::PreActive).to_string();
             let stmt = tx
-                .prepare(get_pgsql_query!("insert-objects"))
+                .prepare_cached(get_pgsql_query!("insert-objects"))
                 .await
                 .map_err(DbError::from)?;
             let attrs_param = Json(&attributes_json);
@@ -408,7 +408,7 @@ impl ObjectsStore for PgPool {
                 .map_err(DbError::from)?;
             if !tags.is_empty() {
                 let transaction_stmt = tx
-                    .prepare(get_pgsql_query!("insert-tags"))
+                    .prepare_cached(get_pgsql_query!("insert-tags"))
                     .await
                     .map_err(DbError::from)?;
                 for tag in tags {
@@ -429,7 +429,7 @@ impl ObjectsStore for PgPool {
     async fn retrieve(&self, uid: &str) -> InterfaceResult<Option<ObjectWithMetadata>> {
         pg_retry!(self.pool, |client| {
             let stmt = client
-                .prepare(get_pgsql_query!("select-object"))
+                .prepare_cached(get_pgsql_query!("select-object"))
                 .await
                 .map_err(|e| InterfaceError::from(DbError::from(e)))?;
             let rows = client
@@ -461,7 +461,7 @@ impl ObjectsStore for PgPool {
     async fn retrieve_tags(&self, uid: &str) -> InterfaceResult<HashSet<String>> {
         pg_retry!(self.pool, |client| {
             let stmt = client
-                .prepare(get_pgsql_query!("select-tags"))
+                .prepare_cached(get_pgsql_query!("select-tags"))
                 .await
                 .map_err(|e| InterfaceError::from(DbError::from(e)))?;
             let rows = client
@@ -480,7 +480,7 @@ impl ObjectsStore for PgPool {
         tags: Option<&HashSet<String>>,
     ) -> InterfaceResult<()> {
         async fn transact(
-            tx: &tokio_postgres::Transaction<'_>,
+            tx: &deadpool_postgres::Transaction<'_>,
             uid: &str,
             object: &Object,
             attributes: &Attributes,
@@ -489,7 +489,7 @@ impl ObjectsStore for PgPool {
             let object_json = serde_json::to_string(object).map_err(DbError::from)?;
             let attributes_json = serde_json::to_value(attributes).map_err(DbError::from)?;
             let stmt = tx
-                .prepare(get_pgsql_query!("update-object-with-object"))
+                .prepare_cached(get_pgsql_query!("update-object-with-object"))
                 .await
                 .map_err(DbError::from)?;
             let attrs_param = Json(&attributes_json);
@@ -498,14 +498,14 @@ impl ObjectsStore for PgPool {
                 .map_err(DbError::from)?;
             if let Some(tags) = tags {
                 let delete_stmt = tx
-                    .prepare(get_pgsql_query!("delete-tags"))
+                    .prepare_cached(get_pgsql_query!("delete-tags"))
                     .await
                     .map_err(DbError::from)?;
                 tx.execute(&delete_stmt, &[&uid])
                     .await
                     .map_err(DbError::from)?;
                 let insert_stmt = tx
-                    .prepare(get_pgsql_query!("insert-tags"))
+                    .prepare_cached(get_pgsql_query!("insert-tags"))
                     .await
                     .map_err(DbError::from)?;
                 for tag in tags {
@@ -525,7 +525,7 @@ impl ObjectsStore for PgPool {
     async fn update_state(&self, uid: &str, state: State) -> InterfaceResult<()> {
         pg_retry!(self.pool, |client| {
             let stmt = client
-                .prepare(get_pgsql_query!("update-object-with-state"))
+                .prepare_cached(get_pgsql_query!("update-object-with-state"))
                 .await
                 .map_err(|e| InterfaceError::from(DbError::from(e)))?;
             let s = state.to_string();
@@ -538,19 +538,19 @@ impl ObjectsStore for PgPool {
     }
 
     async fn delete(&self, uid: &str) -> InterfaceResult<()> {
-        async fn transact(tx: &tokio_postgres::Transaction<'_>, uid: &str) -> DbResult<()> {
+        async fn transact(tx: &deadpool_postgres::Transaction<'_>, uid: &str) -> DbResult<()> {
             let d1 = tx
-                .prepare(get_pgsql_query!("delete-object"))
+                .prepare_cached(get_pgsql_query!("delete-object"))
                 .await
                 .map_err(DbError::from)?;
             tx.execute(&d1, &[&uid]).await.map_err(DbError::from)?;
             let d2 = tx
-                .prepare(get_pgsql_query!("delete-tags"))
+                .prepare_cached(get_pgsql_query!("delete-tags"))
                 .await
                 .map_err(DbError::from)?;
             tx.execute(&d2, &[&uid]).await.map_err(DbError::from)?;
             let d3 = tx
-                .prepare(get_pgsql_query!("delete-read-access-for-object"))
+                .prepare_cached(get_pgsql_query!("delete-read-access-for-object"))
                 .await
                 .map_err(DbError::from)?;
             tx.execute(&d3, &[&uid]).await.map_err(DbError::from)?;
@@ -565,7 +565,7 @@ impl ObjectsStore for PgPool {
         operations: &[AtomicOperation],
     ) -> InterfaceResult<Vec<String>> {
         async fn transact(
-            tx: &tokio_postgres::Transaction<'_>,
+            tx: &deadpool_postgres::Transaction<'_>,
             user: &str,
             operations: &[AtomicOperation],
         ) -> DbResult<Vec<String>> {
@@ -579,7 +579,7 @@ impl ObjectsStore for PgPool {
                             serde_json::to_value(attributes).map_err(DbError::from)?;
                         let state = attributes.state.unwrap_or(State::PreActive).to_string();
                         let stmt = tx
-                            .prepare(get_pgsql_query!("insert-objects"))
+                            .prepare_cached(get_pgsql_query!("insert-objects"))
                             .await
                             .map_err(DbError::from)?;
                         let attrs_param = Json(&attributes_json);
@@ -588,7 +588,7 @@ impl ObjectsStore for PgPool {
                             .map_err(DbError::from)?;
                         if !tags.is_empty() {
                             let insert_stmt = tx
-                                .prepare(get_pgsql_query!("insert-tags"))
+                                .prepare_cached(get_pgsql_query!("insert-tags"))
                                 .await
                                 .map_err(DbError::from)?;
                             for tag in tags {
@@ -604,7 +604,7 @@ impl ObjectsStore for PgPool {
                         let attributes_json =
                             serde_json::to_value(attributes).map_err(DbError::from)?;
                         let stmt = tx
-                            .prepare(get_pgsql_query!("update-object-with-object"))
+                            .prepare_cached(get_pgsql_query!("update-object-with-object"))
                             .await
                             .map_err(DbError::from)?;
                         let attrs_param = Json(&attributes_json);
@@ -613,14 +613,14 @@ impl ObjectsStore for PgPool {
                             .map_err(DbError::from)?;
                         if let Some(tags) = tags {
                             let delete_stmt = tx
-                                .prepare(get_pgsql_query!("delete-tags"))
+                                .prepare_cached(get_pgsql_query!("delete-tags"))
                                 .await
                                 .map_err(DbError::from)?;
                             tx.execute(&delete_stmt, &[&uid])
                                 .await
                                 .map_err(DbError::from)?;
                             let insert_stmt = tx
-                                .prepare(get_pgsql_query!("insert-tags"))
+                                .prepare_cached(get_pgsql_query!("insert-tags"))
                                 .await
                                 .map_err(DbError::from)?;
                             for tag in tags {
@@ -633,7 +633,7 @@ impl ObjectsStore for PgPool {
                     }
                     AtomicOperation::UpdateState((uid, state)) => {
                         let stmt = tx
-                            .prepare(get_pgsql_query!("update-object-with-state"))
+                            .prepare_cached(get_pgsql_query!("update-object-with-state"))
                             .await
                             .map_err(DbError::from)?;
                         let st = state.to_string();
@@ -647,7 +647,7 @@ impl ObjectsStore for PgPool {
                         let attributes_json =
                             serde_json::to_value(attributes).map_err(DbError::from)?;
                         let stmt = tx
-                            .prepare(get_pgsql_query!("upsert-object"))
+                            .prepare_cached(get_pgsql_query!("upsert-object"))
                             .await
                             .map_err(DbError::from)?;
                         let st = state.to_string();
@@ -657,14 +657,14 @@ impl ObjectsStore for PgPool {
                             .map_err(DbError::from)?;
                         if let Some(tags) = tags {
                             let delete_stmt = tx
-                                .prepare(get_pgsql_query!("delete-tags"))
+                                .prepare_cached(get_pgsql_query!("delete-tags"))
                                 .await
                                 .map_err(DbError::from)?;
                             tx.execute(&delete_stmt, &[&uid])
                                 .await
                                 .map_err(DbError::from)?;
                             let insert_stmt = tx
-                                .prepare(get_pgsql_query!("insert-tags"))
+                                .prepare_cached(get_pgsql_query!("insert-tags"))
                                 .await
                                 .map_err(DbError::from)?;
                             for tag in tags {
@@ -677,17 +677,17 @@ impl ObjectsStore for PgPool {
                     }
                     AtomicOperation::Delete(uid) => {
                         let d1 = tx
-                            .prepare(get_pgsql_query!("delete-object"))
+                            .prepare_cached(get_pgsql_query!("delete-object"))
                             .await
                             .map_err(DbError::from)?;
                         tx.execute(&d1, &[&uid]).await.map_err(DbError::from)?;
                         let d2 = tx
-                            .prepare(get_pgsql_query!("delete-tags"))
+                            .prepare_cached(get_pgsql_query!("delete-tags"))
                             .await
                             .map_err(DbError::from)?;
                         tx.execute(&d2, &[&uid]).await.map_err(DbError::from)?;
                         let d3 = tx
-                            .prepare(get_pgsql_query!("delete-read-access-for-object"))
+                            .prepare_cached(get_pgsql_query!("delete-read-access-for-object"))
                             .await
                             .map_err(DbError::from)?;
                         tx.execute(&d3, &[&uid]).await.map_err(DbError::from)?;
@@ -704,7 +704,7 @@ impl ObjectsStore for PgPool {
     async fn is_object_owned_by(&self, uid: &str, owner: &str) -> InterfaceResult<bool> {
         pg_retry!(self.pool, |client| {
             let stmt = client
-                .prepare(get_pgsql_query!("has-row-objects"))
+                .prepare_cached(get_pgsql_query!("has-row-objects"))
                 .await
                 .map_err(|e| InterfaceError::from(DbError::from(e)))?;
             let row = client
@@ -717,15 +717,17 @@ impl ObjectsStore for PgPool {
 
     async fn list_uids_for_tags(&self, tags: &HashSet<String>) -> InterfaceResult<HashSet<String>> {
         pg_retry!(self.pool, |client| {
-            // Use ANY($1) with text[] to avoid dynamic placeholder lifetimes
-            let sql = "SELECT id FROM tags WHERE tag = ANY($1::text[]) GROUP BY id HAVING COUNT(DISTINCT tag) = $2::int";
             let mut tag_vec: Vec<String> = tags.iter().cloned().collect();
             tag_vec.sort();
             let tag_refs: Vec<&str> = tag_vec.iter().map(String::as_str).collect();
             let len_i32: i32 =
                 i32::try_from(tags.len()).map_err(|e| InterfaceError::Db(e.to_string()))?;
+            let stmt = client
+                .prepare_cached(get_pgsql_query!("list-uids-for-tags"))
+                .await
+                .map_err(|e| InterfaceError::from(DbError::from(e)))?;
             let rows = client
-                .query(sql, &[&&tag_refs[..], &len_i32])
+                .query(&stmt, &[&&tag_refs[..], &len_i32])
                 .await
                 .map_err(|e| InterfaceError::from(DbError::from(e)))?;
             let mut out = HashSet::new();
@@ -885,7 +887,7 @@ impl PermissionsStore for PgPool {
     ) -> InterfaceResult<HashMap<String, (String, State, HashSet<KmipOperation>)>> {
         pg_retry!(self.pool, |client| {
             let stmt = client
-                .prepare(get_pgsql_query!("select-objects-access-obtained"))
+                .prepare_cached(get_pgsql_query!("select-objects-access-obtained"))
                 .await
                 .map_err(|e| InterfaceError::from(DbError::from(e)))?;
             let rows = client
@@ -914,7 +916,7 @@ impl PermissionsStore for PgPool {
     ) -> InterfaceResult<HashMap<String, HashSet<KmipOperation>>> {
         pg_retry!(self.pool, |client| {
             let stmt = client
-                .prepare(get_pgsql_query!("select-rows-read_access-with-object-id"))
+                .prepare_cached(get_pgsql_query!("select-rows-read_access-with-object-id"))
                 .await
                 .map_err(|e| InterfaceError::from(DbError::from(e)))?;
             let rows = client
@@ -947,7 +949,7 @@ impl PermissionsStore for PgPool {
             let json = serde_json::to_value(&combined)
                 .map_err(|e| InterfaceError::from(DbError::from(e)))?;
             let stmt = client
-                .prepare(get_pgsql_query!("upsert-row-read_access"))
+                .prepare_cached(get_pgsql_query!("upsert-row-read_access"))
                 .await
                 .map_err(|e| InterfaceError::from(DbError::from(e)))?;
             client
@@ -969,7 +971,7 @@ impl PermissionsStore for PgPool {
         pg_retry!(self.pool, |client| {
             if remaining.is_empty() {
                 let d = client
-                    .prepare(get_pgsql_query!("delete-rows-read_access"))
+                    .prepare_cached(get_pgsql_query!("delete-rows-read_access"))
                     .await
                     .map_err(|e| InterfaceError::from(DbError::from(e)))?;
                 client
@@ -981,7 +983,7 @@ impl PermissionsStore for PgPool {
             let json = serde_json::to_value(&remaining)
                 .map_err(|e| InterfaceError::from(DbError::from(e)))?;
             let u = client
-                .prepare(get_pgsql_query!("update-rows-read_access-with-permission"))
+                .prepare_cached(get_pgsql_query!("update-rows-read_access-with-permission"))
                 .await
                 .map_err(|e| InterfaceError::from(DbError::from(e)))?;
             client
@@ -1000,7 +1002,7 @@ impl PermissionsStore for PgPool {
     ) -> InterfaceResult<HashSet<KmipOperation>> {
         pg_retry!(self.pool, |client| {
             let stmt = client
-                .prepare(get_pgsql_query!("select-user-accesses-for-object"))
+                .prepare_cached(get_pgsql_query!("select-user-accesses-for-object"))
                 .await
                 .map_err(|e| InterfaceError::from(DbError::from(e)))?;
             let mut perms: HashSet<KmipOperation> = match client

--- a/crate/server_database/src/stores/sql/query.sql
+++ b/crate/server_database/src/stores/sql/query.sql
@@ -152,3 +152,6 @@ ON objects.id = matched_tags.id;
 
 -- name: select-uids-from-tags
 SELECT id FROM tags WHERE tag IN (@TAGS) GROUP BY id HAVING COUNT(DISTINCT tag) = @LEN;
+
+-- name: list-uids-for-tags
+SELECT id FROM tags WHERE tag = ANY($1::text[]) GROUP BY id HAVING COUNT(DISTINCT tag) = $2::int;

--- a/documentation/docs/adr/0001-unwrapped-cache-configurable-max-size.md
+++ b/documentation/docs/adr/0001-unwrapped-cache-configurable-max-size.md
@@ -1,0 +1,17 @@
+# Configurable UnwrappedCache max size
+
+The `UnwrappedCache` LRU size was hardcoded to 100 entries. For XKS deployments with
+~100 active keys, any access to a cold key evicts a warm one, causing continuous LRU
+thrashing and forcing a full KEK unwrap on every evicted key's next request. We make the
+limit configurable via a new `--unwrapped-cache-max-size` CLI flag (default: 1000) so
+operators can size the cache above their active key cardinality and achieve a stable warm
+state.
+
+## Considered Options
+
+- **Keep hardcoded 100** — simple, but silently degrades performance for any deployment
+  with ≥100 keys and non-uniform access patterns.
+- **Remove the LRU bound entirely** — eliminates thrashing but risks unbounded memory
+  growth if key cardinality is large or keys are rotated frequently.
+- **Configurable with a higher default (chosen)** — operators get explicit control;
+  the default 1000 is safe for typical deployments while leaving room for growth.

--- a/nix/expected-hashes/cli.vendor.linux.sha256
+++ b/nix/expected-hashes/cli.vendor.linux.sha256
@@ -1,1 +1,1 @@
-sha256-1FZQzTFXnaS2OcGMxj8gY86paKy71w54T6ej2VjzNus=
+sha256-JRBn5Tu3wrSPdukIrujRY0BBpelkW8gKEQuYReUiVss=


### PR DESCRIPTION
## Summary

Performance improvements for the XKS use case and a pre-existing WASM build fix.

### 1. Configurable UnwrappedCache max size

The `UnwrappedCache` (LRU cache for unwrapped key material) had a hardcoded capacity of 100.
XKS deployments with ~100 active KEKs caused LRU thrashing, forcing a DB round-trip + unwrap
on every request.

- New CLI flag: `--unwrapped-cache-max-size` (env: `KMS_UNWRAPPED_CACHE_MAX_SIZE`, default: **1000**)
- Threaded through `ServerParams`, `MainDBConfig`, `Database::instantiate`, `UnwrappedCache::new`
- Config templates (`kms_template.toml`, `pkg/kms.toml`) updated with commented entry
- ADR: `documentation/docs/adr/0001-unwrapped-cache-configurable-max-size.md`

### 2. `prepare_cached` for `list_uids_for_tags` in PostgreSQL

Converts the `list_uids_for_tags` query to use `prepare_cached` (named query `list-uids-for-tags`).
Also fixes a pre-existing type error in all four `transact()` helper signatures: they were typed
as `&tokio_postgres::Transaction` but needed `&deadpool_postgres::Transaction` (which implements
`GenericClient` and thus supports `prepare_cached`).

### 3. Fix WASM build (`ui-fips`, `ui-non-fips`)

`cosmian_logger` unconditionally depends on `tracing-appender`, whose `symlink` sub-crate gates
`symlink_file`/`remove_symlink_file` behind `#[cfg(any(unix, windows, ...)]`), breaking compilation
for `wasm32-unknown-unknown`.

Fix: introduce `crate/kmip/src/log_compat.rs` — a shim that re-exports `{debug, trace, warn}`
from `cosmian_logger` on native targets and from `tracing` on WASM. All 22 production files in
`cosmian_kmip` updated to import via the shim. Similarly, `cosmian_kms_client_utils` was updated
to use `tracing` directly (only one macro call).

### 4. Nix vendor hashes updated

All affected derivations refreshed:
- `server.vendor.{static,dynamic}.sha256`
- `cli.vendor.linux.sha256`  
- `ui.vendor.{fips,non-fips}.sha256`

## Testing

- `cargo test -p cosmian_kms_server_database --lib` — 31 passed
- `cargo clippy --workspace -- -D warnings` — clean
- `nix-build -A kms-server-fips-static-openssl` ✅
- `nix-build -A kms-server-fips-dynamic-openssl` ✅
- `nix-build -A kms-cli-fips-static-openssl` ✅
- `nix-build -A ui-fips` ✅ (was broken)
- `nix-build -A ui-non-fips` ✅ (was broken)