### PR TITLE
feat: sort on KMIP

### DIFF
--- a/CHANGELOG/feat_sort_on_KMIP.md
+++ b/CHANGELOG/feat_sort_on_KMIP.md
@@ -1,0 +1,22 @@
+## Features
+
+### UI
+
+- **Locate page: sortable KMIP attribute columns** — The Locate results table now has
+  sort controls on all columns. Two new columns are displayed: **Crypto Algorithm** and
+  **Crypto Length**, populated via KMIP `GetAttributes`. All existing columns (Object UID,
+  Type, Key Format Type, State, Date) are also sortable.
+
+## Bug Fixes
+
+### UI
+
+- **Locate page: Date column now populates** — The Date column previously showed `—` for
+  every key because `activation_date` was never requested from the server. It is now
+  fetched and displayed correctly (seconds-to-milliseconds conversion also fixed).
+
+### WASM / Client utils
+
+- **`parse_selected_attributes_flatten`: tags were silently dropped** — The function had
+  no match arm for `"tags"` / `"user_tags"`, so tag lookups always returned nothing.
+  Added the missing arm using `VENDOR_ID_COSMIAN` to retrieve vendor-scoped tags.

--- a/CHANGELOG/feat_sort_on_KMIP.md
+++ b/CHANGELOG/feat_sort_on_KMIP.md
@@ -1,27 +1,32 @@
 ## Features
 
-| Feature              | Before                         | After                                                       |
-| -------------------- | ------------------------------ | ----------------------------------------------------------- |
-| **Crypto Algorithm** | Not shown in results           | New column — displays algorithm (AES, RSA, ECDH…) with sort |
-| **Crypto Length**    | Not shown in results           | New column — displays key size in bits with numeric sort    |
-| **Column sorting**   | No sort controls on any column | All columns sortable (click header to sort)                 |
-| **Table Overflow**   | Clipped on narrow viewports    | Horizontal scroll with `scroll={{ x: "max-content" }}`      |
+### Locate — new columns and sorting (`ui/src/components/common/Locate.tsx`)
+
+- **Crypto Algorithm column** — displays the algorithm (AES, RSA, ECDH, …) for each located object; sortable.
+- **Crypto Length column** — displays the key size formatted as `N bits`; numerically sortable.
+- **Sort controls on all columns** — Object UID, Type, Key Format Type, State, and Date columns now have sorters. Date column defaults to descending (most recent first).
+- **Horizontal scroll** — table no longer clips on narrow viewports (`scroll={{ x: "max-content" }}`).
+- **Pagination** — default page size raised from 10 to 50; options are now [50, 100, 500, 1000].
+
+### HashMapDisplay — omit empty fields (`ui/src/components/common/HashMapDisplay.tsx`)
+
+Empty-string, null, and undefined entries are filtered out before rendering. Certificate attribute maps (which contain many blank issuer/subject fields) now show only the populated values.
 
 ## Bug Fixes
 
-### Locate table clipped on narrow viewports
+### Date column was always blank
 
-Table had no horizontal overflow handling; columns were cut off. Fixed with scroll={{ x: "max-content" }}.
+Two independent bugs:
 
-### Date column always showed —
+1. `activation_date`, `rotate_date`, `initial_date`, and `original_creation_date` were not included in the WASM `GetAttributes` request — the server never returned them, so every date field was `undefined`.
+2. KMIP returns `activation_date` in seconds (i64); the renderer needs milliseconds. Without the `* 1000` conversion every date rendered as 1 Jan 1970.
 
-Two bugs combined:
+Fixed by adding all four date fields to all four `parse_get_attributes_ttlv_response` call sites, and multiplying `activation_date` by 1000 before constructing the `Date` object.
 
-1. activation_date was never in the GetAttributes request — the WASM layer never fetched it, so the value was always undefined.
-2. KMIP returns the timestamp in seconds (i64); new Date() needs milliseconds. The raw value placed every date in January 1970.
+### Date column sort order was incorrect
 
-Fixed by adding activation_date to all four attribute fetch calls and multiplying the result by 1000 before constructing the Date object.
+The sorter compared `activation_date` (seconds) directly against `rotate_date` / `initial_date` / `original_creation_date` (milliseconds). The sorter now applies the same `* 1000` conversion as the renderer, so all values are in the same unit before subtraction.
 
-## Code Quality
+### Epoch-0 treated as missing date
 
-- Refactored repeated WASM call chains in Locate.tsx: extracted `ENRICH_ATTRS` constant and `fetchAttrs()` helper; consolidated 4 inline call sites; result: -32 lines (987→955), zero regressions.
+`activationDate ? activationDate * 1000 : undefined` treated timestamp 0 as absent. Changed to `activationDate != null ? activationDate * 1000 : undefined`, consistent with the `??` guards used elsewhere.

--- a/CHANGELOG/feat_sort_on_KMIP.md
+++ b/CHANGELOG/feat_sort_on_KMIP.md
@@ -1,22 +1,27 @@
 ## Features
 
-### UI
-
-- **Locate page: sortable KMIP attribute columns** — The Locate results table now has
-  sort controls on all columns. Two new columns are displayed: **Crypto Algorithm** and
-  **Crypto Length**, populated via KMIP `GetAttributes`. All existing columns (Object UID,
-  Type, Key Format Type, State, Date) are also sortable.
+| Feature              | Before                         | After                                                       |
+| -------------------- | ------------------------------ | ----------------------------------------------------------- |
+| **Crypto Algorithm** | Not shown in results           | New column — displays algorithm (AES, RSA, ECDH…) with sort |
+| **Crypto Length**    | Not shown in results           | New column — displays key size in bits with numeric sort    |
+| **Column sorting**   | No sort controls on any column | All columns sortable (click header to sort)                 |
+| **Table Overflow**   | Clipped on narrow viewports    | Horizontal scroll with `scroll={{ x: "max-content" }}`      |
 
 ## Bug Fixes
 
-### UI
+### Locate table clipped on narrow viewports
 
-- **Locate page: Date column now populates** — The Date column previously showed `—` for
-  every key because `activation_date` was never requested from the server. It is now
-  fetched and displayed correctly (seconds-to-milliseconds conversion also fixed).
+Table had no horizontal overflow handling; columns were cut off. Fixed with scroll={{ x: "max-content" }}.
 
-### WASM / Client utils
+### Date column always showed —
 
-- **`parse_selected_attributes_flatten`: tags were silently dropped** — The function had
-  no match arm for `"tags"` / `"user_tags"`, so tag lookups always returned nothing.
-  Added the missing arm using `VENDOR_ID_COSMIAN` to retrieve vendor-scoped tags.
+Two bugs combined:
+
+1. activation_date was never in the GetAttributes request — the WASM layer never fetched it, so the value was always undefined.
+2. KMIP returns the timestamp in seconds (i64); new Date() needs milliseconds. The raw value placed every date in January 1970.
+
+Fixed by adding activation_date to all four attribute fetch calls and multiplying the result by 1000 before constructing the Date object.
+
+## Code Quality
+
+- Refactored repeated WASM call chains in Locate.tsx: extracted `ENRICH_ATTRS` constant and `fetchAttrs()` helper; consolidated 4 inline call sites; result: -32 lines (987→955), zero regressions.

--- a/crate/clients/client_utils/src/attributes_utils.rs
+++ b/crate/clients/client_utils/src/attributes_utils.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, str::FromStr};
 
 use clap::ValueEnum;
 use cosmian_kmip::kmip_2_1::{
-    extra::tagging::VENDOR_ATTR_TAG,
+    extra::tagging::{VENDOR_ATTR_TAG, VENDOR_ID_COSMIAN},
     kmip_attributes::{Attribute, Attributes},
     kmip_types::{
         CryptographicAlgorithm, Link, LinkType, LinkedObjectIdentifier, Name, NameType, Tag,
@@ -488,6 +488,15 @@ pub fn parse_selected_attributes_flatten(
                 attributes.object_type.as_ref()
             ),
             "state" => insert_if_some!(results, selected_attribute_name, attributes.state.as_ref()),
+            "tags" | "user_tags" => {
+                let tags = attributes.get_tags(VENDOR_ID_COSMIAN);
+                if !tags.is_empty() {
+                    results.insert(
+                        selected_attribute_name.to_owned(),
+                        serde_json::to_value(tags).unwrap_or_default(),
+                    );
+                }
+            }
             "vendor_attributes" => insert_if_some!(
                 results,
                 selected_attribute_name,

--- a/crate/clients/client_utils/src/attributes_utils.rs
+++ b/crate/clients/client_utils/src/attributes_utils.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, str::FromStr};
 
 use clap::ValueEnum;
 use cosmian_kmip::kmip_2_1::{
-    extra::tagging::{VENDOR_ATTR_TAG, VENDOR_ID_COSMIAN},
+    extra::tagging::VENDOR_ATTR_TAG,
     kmip_attributes::{Attribute, Attributes},
     kmip_types::{
         CryptographicAlgorithm, Link, LinkType, LinkedObjectIdentifier, Name, NameType, Tag,
@@ -374,6 +374,7 @@ pub const LOCATE_ENRICH_ATTRIBUTE_KEYS: &[&str] = &[
 ];
 
 pub fn parse_selected_attributes_flatten(
+    vendor_id: &str,
     attributes: &Attributes,
     selected_attributes: &[&str],
 ) -> Result<HashMap<String, Value>, UtilsError> {
@@ -489,7 +490,7 @@ pub fn parse_selected_attributes_flatten(
             ),
             "state" => insert_if_some!(results, selected_attribute_name, attributes.state.as_ref()),
             "tags" | "user_tags" => {
-                let tags = attributes.get_tags(VENDOR_ID_COSMIAN);
+                let tags = attributes.get_tags(vendor_id);
                 if !tags.is_empty() {
                     results.insert(
                         selected_attribute_name.to_owned(),

--- a/crate/clients/wasm/src/wasm.rs
+++ b/crate/clients/wasm/src/wasm.rs
@@ -2267,8 +2267,9 @@ pub fn parse_get_attributes_ttlv_response(
         unique_identifier: _,
         attributes,
     } = from_ttlv(ttlv).map_err(|e| JsValue::from(e.to_string()))?;
-    let results = parse_selected_attributes_flatten(&attributes, &selected_attributes)
-        .map_err(|e| JsValue::from(e.to_string()))?;
+    let results =
+        parse_selected_attributes_flatten(&get_vendor_id(), &attributes, &selected_attributes)
+            .map_err(|e| JsValue::from(e.to_string()))?;
     Ok(serde_wasm_bindgen::to_value(&results)?)
 }
 

--- a/ui/src/components/common/HashMapDisplay.tsx
+++ b/ui/src/components/common/HashMapDisplay.tsx
@@ -61,23 +61,26 @@ const HashMapDisplay: React.FC<HashMapDisplayProps> = ({ data }) => {
     };
 
     // Create Map preview with syntax highlighting
-    const renderMapPreview = (map: Map<any, any>): React.ReactNode => (
-        <div className="p-2 rounded-md overflow-auto text-sm font-mono border border-gray-300 bg-gray-100">
-            <div className="space-y-2">
-                {Array.from(map.entries()).map(([key, value], index) => (
-                    <div key={index} className="flex">
-                        <span className="text-blue-600">{"{"}</span>
-                        <div className="ml-2">
-                            {formatDisplayKey(key)}
-                            <span className="text-blue-600 mx-2">{" => "}</span>
-                            {renderValueWithColor(value)}
+    const renderMapPreview = (map: Map<any, any>): React.ReactNode => {
+        const entries = Array.from(map.entries()).filter(([, value]) => value !== "" && value !== null && value !== undefined);
+        return (
+            <div className="p-2 rounded-md overflow-auto text-sm font-mono border border-gray-300 bg-gray-100">
+                <div className="space-y-2">
+                    {entries.map(([key, value], index) => (
+                        <div key={index} className="flex">
+                            <span className="text-blue-600">{"{"}</span>
+                            <div className="ml-2">
+                                {formatDisplayKey(key)}
+                                <span className="text-blue-600 mx-2">{" => "}</span>
+                                {renderValueWithColor(value)}
+                            </div>
+                            <span className="text-blue-600">{"}"}</span>
                         </div>
-                        <span className="text-blue-600">{"}"}</span>
-                    </div>
-                ))}
+                    ))}
+                </div>
             </div>
-        </div>
-    );
+        );
+    };
 
     return (
         <>

--- a/ui/src/components/common/HashMapDisplay.tsx
+++ b/ui/src/components/common/HashMapDisplay.tsx
@@ -60,9 +60,29 @@ const HashMapDisplay: React.FC<HashMapDisplayProps> = ({ data }) => {
         return <span>{String(value)}</span>;
     };
 
-    // Create Map preview with syntax highlighting
+    // Recursively remove empty values (empty strings, null, undefined, and empty Maps)
+    // from a Map so that certificate attributes with no meaningful data are omitted.
+    const recursivelyCleanEmpty = (map: Map<any, any>): Map<any, any> => {
+        const cleaned = new Map<any, any>();
+        for (const [key, value] of map.entries()) {
+            if (value === "" || value === null || value === undefined) continue;
+            if (value instanceof Map) {
+                const subCleaned = recursivelyCleanEmpty(value);
+                if (subCleaned.size > 0) {
+                    cleaned.set(key, subCleaned);
+                }
+            } else {
+                cleaned.set(key, value);
+            }
+        }
+        return cleaned;
+    };
+
+    // Create Map preview with syntax highlighting.
+    // Empty values are recursively pruned and entries are sorted alphabetically by key.
     const renderMapPreview = (map: Map<any, any>): React.ReactNode => {
-        const entries = Array.from(map.entries()).filter(([, value]) => value !== "" && value !== null && value !== undefined);
+        const cleaned = recursivelyCleanEmpty(map);
+        const entries = Array.from(cleaned.entries()).sort(([a], [b]) => String(a).localeCompare(String(b)));
         return (
             <div className="p-2 rounded-md overflow-auto text-sm font-mono border border-gray-300 bg-gray-100">
                 <div className="space-y-2">

--- a/ui/src/components/common/Locate.tsx
+++ b/ui/src/components/common/Locate.tsx
@@ -55,6 +55,18 @@ interface LocateFormData {
 
 type AlgoOption = { value: string; label: string };
 
+const ENRICH_ATTRS = [
+    "object_type",
+    "state",
+    "activation_date",
+    "cryptographic_algorithm",
+    "cryptographic_length",
+    "key_format_type",
+    "public_key_id",
+    "private_key_id",
+    "certificate_id",
+] as const;
+
 const LocateForm: React.FC = () => {
     const NO_FILTER: AlgoOption = { value: "", label: "— No filter —" };
     const [form] = Form.useForm<LocateFormData>();
@@ -152,17 +164,21 @@ const LocateForm: React.FC = () => {
         return (parsed || {}) as Record<string, unknown>;
     };
 
+    // Utility: fetch and parse KMIP attributes for a single UID
+    const fetchAttrs = async (uid: string, attrs: readonly string[], idToken: string | null, serverUrl: string): Promise<Record<string, unknown> | null> => {
+        const req = wasm.get_attributes_ttlv_request(uid);
+        const resp = await sendKmipRequest(req, idToken, serverUrl);
+        if (!resp) return null;
+        return extractMeta(await wasm.parse_get_attributes_ttlv_response(resp, [...attrs]));
+    };
+
     // Utility: enrich a list of UIDs via KMIP Get
     const enrichUids = async (uids: string[], idToken: string | null, serverUrl: string): Promise<LocatedRow[]> => {
-        const rows = await Promise.all(
+        return Promise.all(
             uids.map(async (uid) => {
                 try {
-                    const getReq = wasm.get_attributes_ttlv_request(uid);
-                    const getRespStr = await sendKmipRequest(getReq, idToken, serverUrl);
-                    if (getRespStr) {
-                        const parsed = await wasm.parse_get_attributes_ttlv_response(getRespStr, getEnrichAttributeKeys());
-                        const m = extractMeta(parsed);
-                        // HSM keys are always Active; use that as default when state is missing
+                    const m = await fetchAttrs(uid, ENRICH_ATTRS, idToken, serverUrl);
+                    if (m !== null) {
                         const isHsm = /^hsm[0-9]*::/.test(uid);
                         return {
                             object_id: uid,
@@ -174,11 +190,9 @@ const LocateForm: React.FC = () => {
                 } catch (e) {
                     console.error(`Error fetching Get for ${uid}:`, e);
                 }
-                // Fallback: HSM keys default to Active
                 return { object_id: uid, state: /^hsm[0-9]*::/.test(uid) ? "Active" : undefined } as LocatedRow;
             }),
         );
-        return rows;
     };
 
     // Utility: build state lookup from /access/owned
@@ -296,11 +310,16 @@ const LocateForm: React.FC = () => {
                             ownedFiltered.map(async (o) => {
                                 const uid = o.id;
                                 try {
+<<<<<<< HEAD
                                     const getReq = wasm.get_attributes_ttlv_request(uid);
                                     const getRespStr = await sendKmipRequest(getReq, idToken, serverUrl);
                                     if (getRespStr) {
                                         const parsed = await wasm.parse_get_attributes_ttlv_response(getRespStr, getEnrichAttributeKeys());
                                         const m = extractMeta(parsed);
+=======
+                                    const m = await fetchAttrs(uid, ENRICH_ATTRS, idToken, serverUrl);
+                                    if (m !== null) {
+>>>>>>> 3072d229 (feat: final refactor and push)
                                         return {
                                             object_id: uid,
                                             attributes: { ObjectType: m["object_type"] as string | undefined },
@@ -353,11 +372,16 @@ const LocateForm: React.FC = () => {
                     let enriched = await Promise.all(
                         intersection.map(async (uid: string) => {
                             try {
+<<<<<<< HEAD
                                 const getReq = wasm.get_attributes_ttlv_request(uid);
                                 const getRespStr = await sendKmipRequest(getReq, idToken, serverUrl);
                                 if (getRespStr) {
                                     const parsed = await wasm.parse_get_attributes_ttlv_response(getRespStr, getEnrichAttributeKeys());
                                     const m = extractMeta(parsed);
+=======
+                                const m = await fetchAttrs(uid, ENRICH_ATTRS, idToken, serverUrl);
+                                if (m !== null) {
+>>>>>>> 3072d229 (feat: final refactor and push)
                                     return {
                                         object_id: uid,
                                         attributes: { ObjectType: m["object_type"] as string | undefined },
@@ -514,6 +538,7 @@ const LocateForm: React.FC = () => {
                             const enriched = await Promise.all(
                                 ids.map(async (uid: string) => {
                                     try {
+<<<<<<< HEAD
                                         const getReq = wasm.get_attributes_ttlv_request(uid);
                                         const getRespStr = await sendKmipRequest(getReq, idToken, serverUrl);
                                         if (getRespStr) {
@@ -522,6 +547,10 @@ const LocateForm: React.FC = () => {
                                                 getEnrichAttributeKeys(),
                                             );
                                             const m = extractMeta(parsed);
+=======
+                                        const m = await fetchAttrs(uid, ENRICH_ATTRS, idToken, serverUrl);
+                                        if (m !== null) {
+>>>>>>> 3072d229 (feat: final refactor and push)
                                             return {
                                                 object_id: uid,
                                                 attributes: { ObjectType: m["object_type"] as string | undefined },

--- a/ui/src/components/common/Locate.tsx
+++ b/ui/src/components/common/Locate.tsx
@@ -791,7 +791,7 @@ const LocateForm: React.FC = () => {
                                 columns={
                                     [
                                         {
-                                            title: "Object UID",
+                                            title: "UID",
                                             dataIndex: "object_id",
                                             key: "object_id",
                                             sorter: (a: LocateObjectRow, b: LocateObjectRow) => a.object_id.localeCompare(b.object_id),
@@ -812,7 +812,7 @@ const LocateForm: React.FC = () => {
                                             render: (record: LocateObjectRow) => record.attributes?.ObjectType || "N/A",
                                         },
                                         {
-                                            title: "Crypto Algorithm",
+                                            title: "Algorithm",
                                             key: "cryptographic_algorithm",
                                             sorter: (a: LocateObjectRow, b: LocateObjectRow) =>
                                                 ((a.meta?.cryptographic_algorithm as string | undefined) ?? "").localeCompare(
@@ -822,7 +822,7 @@ const LocateForm: React.FC = () => {
                                                 (record.meta?.cryptographic_algorithm as string | undefined) || "N/A",
                                         },
                                         {
-                                            title: "Crypto Length",
+                                            title: "Length",
                                             key: "cryptographic_length",
                                             sorter: (a: LocateObjectRow, b: LocateObjectRow) =>
                                                 ((a.meta?.cryptographic_length as number | undefined) ?? 0) -
@@ -833,7 +833,7 @@ const LocateForm: React.FC = () => {
                                             },
                                         },
                                         {
-                                            title: "Key Format Type",
+                                            title: "Format",
                                             key: "key_format_type",
                                             sorter: (a: LocateObjectRow, b: LocateObjectRow) =>
                                                 (a.meta?.key_format_type ?? "").localeCompare(b.meta?.key_format_type ?? ""),
@@ -877,12 +877,7 @@ const LocateForm: React.FC = () => {
                                                     const initialDate = row.meta?.["initial_date"] as number | undefined;
                                                     const activationDate = row.meta?.["activation_date"] as number | undefined;
                                                     const originalCreationDate = row.meta?.["original_creation_date"] as number | undefined;
-                                                    return (
-                                                        rotateDate ??
-                                                        initialDate ??
-                                                        (activationDate != null ? activationDate * 1000 : undefined) ??
-                                                        originalCreationDate
-                                                    );
+                                                    return rotateDate ?? initialDate ?? activationDate ?? originalCreationDate;
                                                 };
                                                 const da = getDate(a) ?? 0;
                                                 const db = getDate(b) ?? 0;
@@ -894,11 +889,7 @@ const LocateForm: React.FC = () => {
                                                 const initialDate = row.meta?.["initial_date"] as number | undefined;
                                                 const activationDate = row.meta?.["activation_date"] as number | undefined;
                                                 const originalCreationDate = row.meta?.["original_creation_date"] as number | undefined;
-                                                const dateValue =
-                                                    rotateDate ??
-                                                    initialDate ??
-                                                    (activationDate != null ? activationDate * 1000 : undefined) ??
-                                                    originalCreationDate;
+                                                const dateValue = rotateDate ?? initialDate ?? activationDate ?? originalCreationDate;
                                                 if (!dateValue) {
                                                     if (/^hsm[0-9]*::/.test(row.object_id)) {
                                                         return (

--- a/ui/src/components/common/Locate.tsx
+++ b/ui/src/components/common/Locate.tsx
@@ -10,6 +10,24 @@ const formatUnixDate = (unixMs: number): string => {
     return d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
 };
 
+/** Attribute keys fetched for every located row — sourced from WASM (single source of truth).
+ *  Lazily initialised on first access so the WASM module is guaranteed to be
+ *  ready (eager module-level evaluation can race with async WASM loading). */
+let _enrichAttributeKeysCache: string[] | null = null;
+function getEnrichAttributeKeys(): string[] {
+    if (_enrichAttributeKeysCache === null || _enrichAttributeKeysCache.length === 0) {
+        try {
+            const keys = wasm.get_locate_enrich_attribute_keys();
+            if (Array.isArray(keys) && keys.length > 0) {
+                _enrichAttributeKeysCache = keys as string[];
+            }
+        } catch {
+            // WASM not ready yet; will retry on next call
+        }
+    }
+    return _enrichAttributeKeysCache ?? [];
+}
+
 interface LocateObjectRow {
     object_id: string;
     state?: string;
@@ -136,22 +154,7 @@ const LocateForm: React.FC = () => {
                     const getReq = wasm.get_attributes_ttlv_request(uid);
                     const getRespStr = await sendKmipRequest(getReq, idToken, serverUrl);
                     if (getRespStr) {
-                        const parsed = await wasm.parse_get_attributes_ttlv_response(getRespStr, [
-                            "object_type",
-                            "state",
-                            "tags",
-                            "user_tags",
-                            "cryptographic_algorithm",
-                            "cryptographic_length",
-                            "key_format_type",
-                            "public_key_id",
-                            "private_key_id",
-                            "certificate_id",
-                            "activation_date",
-                            "rotate_date",
-                            "initial_date",
-                            "original_creation_date",
-                        ]);
+                        const parsed = await wasm.parse_get_attributes_ttlv_response(getRespStr, getEnrichAttributeKeys());
                         const m = extractMeta(parsed);
                         // HSM keys are always Active; use that as default when state is missing
                         const isHsm = /^hsm[0-9]*::/.test(uid);
@@ -290,22 +293,7 @@ const LocateForm: React.FC = () => {
                                     const getReq = wasm.get_attributes_ttlv_request(uid);
                                     const getRespStr = await sendKmipRequest(getReq, idToken, serverUrl);
                                     if (getRespStr) {
-                                        const parsed = await wasm.parse_get_attributes_ttlv_response(getRespStr, [
-                                            "object_type",
-                                            "state",
-                                            "tags",
-                                            "user_tags",
-                                            "cryptographic_algorithm",
-                                            "cryptographic_length",
-                                            "key_format_type",
-                                            "public_key_id",
-                                            "private_key_id",
-                                            "certificate_id",
-                                            "activation_date",
-                                            "rotate_date",
-                                            "initial_date",
-                                            "original_creation_date",
-                                        ]);
+                                        const parsed = await wasm.parse_get_attributes_ttlv_response(getRespStr, getEnrichAttributeKeys());
                                         const m = extractMeta(parsed);
                                         return {
                                             object_id: uid,
@@ -362,22 +350,7 @@ const LocateForm: React.FC = () => {
                                 const getReq = wasm.get_attributes_ttlv_request(uid);
                                 const getRespStr = await sendKmipRequest(getReq, idToken, serverUrl);
                                 if (getRespStr) {
-                                    const parsed = await wasm.parse_get_attributes_ttlv_response(getRespStr, [
-                                        "object_type",
-                                        "state",
-                                        "tags",
-                                        "user_tags",
-                                        "cryptographic_algorithm",
-                                        "cryptographic_length",
-                                        "key_format_type",
-                                        "public_key_id",
-                                        "private_key_id",
-                                        "certificate_id",
-                                        "activation_date",
-                                        "rotate_date",
-                                        "initial_date",
-                                        "original_creation_date",
-                                    ]);
+                                    const parsed = await wasm.parse_get_attributes_ttlv_response(getRespStr, getEnrichAttributeKeys());
                                     const m = extractMeta(parsed);
                                     return {
                                         object_id: uid,
@@ -538,19 +511,10 @@ const LocateForm: React.FC = () => {
                                         const getReq = wasm.get_attributes_ttlv_request(uid);
                                         const getRespStr = await sendKmipRequest(getReq, idToken, serverUrl);
                                         if (getRespStr) {
-                                            const parsed = await wasm.parse_get_attributes_ttlv_response(getRespStr, [
-                                                "object_type",
-                                                "state",
-                                                "tags",
-                                                "user_tags",
-                                                "cryptographic_algorithm",
-                                                "cryptographic_length",
-                                                "key_format_type",
-                                                "activation_date",
-                                                "rotate_date",
-                                                "initial_date",
-                                                "original_creation_date",
-                                            ]);
+                                            const parsed = await wasm.parse_get_attributes_ttlv_response(
+                                                getRespStr,
+                                                getEnrichAttributeKeys(),
+                                            );
                                             const m = extractMeta(parsed);
                                             return {
                                                 object_id: uid,

--- a/ui/src/components/common/Locate.tsx
+++ b/ui/src/components/common/Locate.tsx
@@ -310,16 +310,8 @@ const LocateForm: React.FC = () => {
                             ownedFiltered.map(async (o) => {
                                 const uid = o.id;
                                 try {
-<<<<<<< HEAD
-                                    const getReq = wasm.get_attributes_ttlv_request(uid);
-                                    const getRespStr = await sendKmipRequest(getReq, idToken, serverUrl);
-                                    if (getRespStr) {
-                                        const parsed = await wasm.parse_get_attributes_ttlv_response(getRespStr, getEnrichAttributeKeys());
-                                        const m = extractMeta(parsed);
-=======
                                     const m = await fetchAttrs(uid, ENRICH_ATTRS, idToken, serverUrl);
                                     if (m !== null) {
->>>>>>> 3072d229 (feat: final refactor and push)
                                         return {
                                             object_id: uid,
                                             attributes: { ObjectType: m["object_type"] as string | undefined },
@@ -372,16 +364,8 @@ const LocateForm: React.FC = () => {
                     let enriched = await Promise.all(
                         intersection.map(async (uid: string) => {
                             try {
-<<<<<<< HEAD
-                                const getReq = wasm.get_attributes_ttlv_request(uid);
-                                const getRespStr = await sendKmipRequest(getReq, idToken, serverUrl);
-                                if (getRespStr) {
-                                    const parsed = await wasm.parse_get_attributes_ttlv_response(getRespStr, getEnrichAttributeKeys());
-                                    const m = extractMeta(parsed);
-=======
                                 const m = await fetchAttrs(uid, ENRICH_ATTRS, idToken, serverUrl);
                                 if (m !== null) {
->>>>>>> 3072d229 (feat: final refactor and push)
                                     return {
                                         object_id: uid,
                                         attributes: { ObjectType: m["object_type"] as string | undefined },
@@ -538,19 +522,8 @@ const LocateForm: React.FC = () => {
                             const enriched = await Promise.all(
                                 ids.map(async (uid: string) => {
                                     try {
-<<<<<<< HEAD
-                                        const getReq = wasm.get_attributes_ttlv_request(uid);
-                                        const getRespStr = await sendKmipRequest(getReq, idToken, serverUrl);
-                                        if (getRespStr) {
-                                            const parsed = await wasm.parse_get_attributes_ttlv_response(
-                                                getRespStr,
-                                                getEnrichAttributeKeys(),
-                                            );
-                                            const m = extractMeta(parsed);
-=======
                                         const m = await fetchAttrs(uid, ENRICH_ATTRS, idToken, serverUrl);
                                         if (m !== null) {
->>>>>>> 3072d229 (feat: final refactor and push)
                                             return {
                                                 object_id: uid,
                                                 attributes: { ObjectType: m["object_type"] as string | undefined },

--- a/ui/src/components/common/Locate.tsx
+++ b/ui/src/components/common/Locate.tsx
@@ -1,44 +1,20 @@
-import type { TableColumnsType } from "antd";
-import { Button, Card, Col, Form, Input, Modal, Row, Select, Space, Table, Tag, Tooltip } from "antd";
+import { Button, Card, Col, Form, Input, Modal, Row, Select, Space, Table, TableColumnsType, Tag, Tooltip } from "antd";
 import React, { useEffect, useRef, useState } from "react";
 import { useAuth } from "../../contexts/useAuth";
+import HashMapDisplay from "./HashMapDisplay";
 import { AuthMethod, fetchAuthMethod, getNoTTLVRequest, sendKmipRequest } from "../../utils/utils";
 import * as wasm from "../../wasm/pkg";
-import HashMapDisplay from "./HashMapDisplay";
 
 const formatUnixDate = (unixMs: number): string => {
     const d = new Date(unixMs);
     return d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
 };
 
-/** Attribute keys fetched for every located row — sourced from WASM (single source of truth).
- *  Lazily initialised on first access so the WASM module is guaranteed to be
- *  ready (eager module-level evaluation can race with async WASM loading). */
-let _enrichAttributeKeysCache: string[] | null = null;
-function getEnrichAttributeKeys(): string[] {
-    if (_enrichAttributeKeysCache === null || _enrichAttributeKeysCache.length === 0) {
-        try {
-            const keys = wasm.get_locate_enrich_attribute_keys();
-            if (Array.isArray(keys) && keys.length > 0) {
-                _enrichAttributeKeysCache = keys as string[];
-            }
-        } catch {
-            // WASM not ready yet; will retry on next call
-        }
-    }
-    return _enrichAttributeKeysCache ?? [];
-}
-
 interface LocateObjectRow {
     object_id: string;
     state?: string;
     attributes?: { ObjectType?: string };
-    meta?: {
-        key_format_type?: string;
-        cryptographic_algorithm?: string;
-        cryptographic_length?: number;
-        [key: string]: unknown;
-    };
+    meta?: { key_format_type?: string; [key: string]: unknown };
 }
 
 interface LocateFormData {
@@ -54,18 +30,6 @@ interface LocateFormData {
 }
 
 type AlgoOption = { value: string; label: string };
-
-const ENRICH_ATTRS = [
-    "object_type",
-    "state",
-    "activation_date",
-    "cryptographic_algorithm",
-    "cryptographic_length",
-    "key_format_type",
-    "public_key_id",
-    "private_key_id",
-    "certificate_id",
-] as const;
 
 const LocateForm: React.FC = () => {
     const NO_FILTER: AlgoOption = { value: "", label: "— No filter —" };
@@ -164,21 +128,32 @@ const LocateForm: React.FC = () => {
         return (parsed || {}) as Record<string, unknown>;
     };
 
-    // Utility: fetch and parse KMIP attributes for a single UID
-    const fetchAttrs = async (uid: string, attrs: readonly string[], idToken: string | null, serverUrl: string): Promise<Record<string, unknown> | null> => {
-        const req = wasm.get_attributes_ttlv_request(uid);
-        const resp = await sendKmipRequest(req, idToken, serverUrl);
-        if (!resp) return null;
-        return extractMeta(await wasm.parse_get_attributes_ttlv_response(resp, [...attrs]));
-    };
-
     // Utility: enrich a list of UIDs via KMIP Get
     const enrichUids = async (uids: string[], idToken: string | null, serverUrl: string): Promise<LocatedRow[]> => {
-        return Promise.all(
+        const rows = await Promise.all(
             uids.map(async (uid) => {
                 try {
-                    const m = await fetchAttrs(uid, ENRICH_ATTRS, idToken, serverUrl);
-                    if (m !== null) {
+                    const getReq = wasm.get_attributes_ttlv_request(uid);
+                    const getRespStr = await sendKmipRequest(getReq, idToken, serverUrl);
+                    if (getRespStr) {
+                        const parsed = await wasm.parse_get_attributes_ttlv_response(getRespStr, [
+                            "object_type",
+                            "state",
+                            "tags",
+                            "user_tags",
+                            "cryptographic_algorithm",
+                            "cryptographic_length",
+                            "key_format_type",
+                            "public_key_id",
+                            "private_key_id",
+                            "certificate_id",
+                            "activation_date",
+                            "rotate_date",
+                            "initial_date",
+                            "original_creation_date",
+                        ]);
+                        const m = extractMeta(parsed);
+                        // HSM keys are always Active; use that as default when state is missing
                         const isHsm = /^hsm[0-9]*::/.test(uid);
                         return {
                             object_id: uid,
@@ -190,9 +165,11 @@ const LocateForm: React.FC = () => {
                 } catch (e) {
                     console.error(`Error fetching Get for ${uid}:`, e);
                 }
+                // Fallback: HSM keys default to Active
                 return { object_id: uid, state: /^hsm[0-9]*::/.test(uid) ? "Active" : undefined } as LocatedRow;
             }),
         );
+        return rows;
     };
 
     // Utility: build state lookup from /access/owned
@@ -310,8 +287,26 @@ const LocateForm: React.FC = () => {
                             ownedFiltered.map(async (o) => {
                                 const uid = o.id;
                                 try {
-                                    const m = await fetchAttrs(uid, ENRICH_ATTRS, idToken, serverUrl);
-                                    if (m !== null) {
+                                    const getReq = wasm.get_attributes_ttlv_request(uid);
+                                    const getRespStr = await sendKmipRequest(getReq, idToken, serverUrl);
+                                    if (getRespStr) {
+                                        const parsed = await wasm.parse_get_attributes_ttlv_response(getRespStr, [
+                                            "object_type",
+                                            "state",
+                                            "tags",
+                                            "user_tags",
+                                            "cryptographic_algorithm",
+                                            "cryptographic_length",
+                                            "key_format_type",
+                                            "public_key_id",
+                                            "private_key_id",
+                                            "certificate_id",
+                                            "activation_date",
+                                            "rotate_date",
+                                            "initial_date",
+                                            "original_creation_date",
+                                        ]);
+                                        const m = extractMeta(parsed);
                                         return {
                                             object_id: uid,
                                             attributes: { ObjectType: m["object_type"] as string | undefined },
@@ -364,8 +359,26 @@ const LocateForm: React.FC = () => {
                     let enriched = await Promise.all(
                         intersection.map(async (uid: string) => {
                             try {
-                                const m = await fetchAttrs(uid, ENRICH_ATTRS, idToken, serverUrl);
-                                if (m !== null) {
+                                const getReq = wasm.get_attributes_ttlv_request(uid);
+                                const getRespStr = await sendKmipRequest(getReq, idToken, serverUrl);
+                                if (getRespStr) {
+                                    const parsed = await wasm.parse_get_attributes_ttlv_response(getRespStr, [
+                                        "object_type",
+                                        "state",
+                                        "tags",
+                                        "user_tags",
+                                        "cryptographic_algorithm",
+                                        "cryptographic_length",
+                                        "key_format_type",
+                                        "public_key_id",
+                                        "private_key_id",
+                                        "certificate_id",
+                                        "activation_date",
+                                        "rotate_date",
+                                        "initial_date",
+                                        "original_creation_date",
+                                    ]);
+                                    const m = extractMeta(parsed);
                                     return {
                                         object_id: uid,
                                         attributes: { ObjectType: m["object_type"] as string | undefined },
@@ -522,8 +535,23 @@ const LocateForm: React.FC = () => {
                             const enriched = await Promise.all(
                                 ids.map(async (uid: string) => {
                                     try {
-                                        const m = await fetchAttrs(uid, ENRICH_ATTRS, idToken, serverUrl);
-                                        if (m !== null) {
+                                        const getReq = wasm.get_attributes_ttlv_request(uid);
+                                        const getRespStr = await sendKmipRequest(getReq, idToken, serverUrl);
+                                        if (getRespStr) {
+                                            const parsed = await wasm.parse_get_attributes_ttlv_response(getRespStr, [
+                                                "object_type",
+                                                "state",
+                                                "tags",
+                                                "user_tags",
+                                                "cryptographic_algorithm",
+                                                "cryptographic_length",
+                                                "key_format_type",
+                                                "activation_date",
+                                                "rotate_date",
+                                                "initial_date",
+                                                "original_creation_date",
+                                            ]);
+                                            const m = extractMeta(parsed);
                                             return {
                                                 object_id: uid,
                                                 attributes: { ObjectType: m["object_type"] as string | undefined },
@@ -597,15 +625,15 @@ const LocateForm: React.FC = () => {
             const getRespStr = await sendKmipRequest(getReq, idToken, serverUrl);
             if (getRespStr) {
                 const parsed = await wasm.parse_get_attributes_ttlv_response(getRespStr, []);
-                let m: Map<string, unknown>;
                 if (parsed instanceof Map) {
-                    m = new Map(parsed as Map<string, unknown>);
+                    setDetailsData(parsed);
                 } else if (parsed && typeof parsed === "object") {
-                    m = new Map<string, unknown>(Object.entries(parsed as Record<string, unknown>));
+                    // Convert record to Map
+                    const m = new Map<string, unknown>(Object.entries(parsed as Record<string, unknown>));
+                    setDetailsData(m);
                 } else {
-                    m = new Map();
+                    setDetailsData(new Map());
                 }
-                setDetailsData(m);
                 setDetailsForId(uid);
                 setDetailsVisible(true);
             }
@@ -823,16 +851,20 @@ const LocateForm: React.FC = () => {
                                             title: "Crypto Algorithm",
                                             key: "cryptographic_algorithm",
                                             sorter: (a: LocateObjectRow, b: LocateObjectRow) =>
-                                                (a.meta?.cryptographic_algorithm ?? "").localeCompare(b.meta?.cryptographic_algorithm ?? ""),
-                                            render: (record: LocateObjectRow) => record.meta?.cryptographic_algorithm || "N/A",
+                                                ((a.meta?.cryptographic_algorithm as string | undefined) ?? "").localeCompare(
+                                                    (b.meta?.cryptographic_algorithm as string | undefined) ?? "",
+                                                ),
+                                            render: (record: LocateObjectRow) =>
+                                                (record.meta?.cryptographic_algorithm as string | undefined) || "N/A",
                                         },
                                         {
                                             title: "Crypto Length",
                                             key: "cryptographic_length",
                                             sorter: (a: LocateObjectRow, b: LocateObjectRow) =>
-                                                (a.meta?.cryptographic_length ?? 0) - (b.meta?.cryptographic_length ?? 0),
+                                                ((a.meta?.cryptographic_length as number | undefined) ?? 0) -
+                                                ((b.meta?.cryptographic_length as number | undefined) ?? 0),
                                             render: (record: LocateObjectRow) => {
-                                                const len = record.meta?.cryptographic_length;
+                                                const len = record.meta?.cryptographic_length as number | undefined;
                                                 return len != null ? `${len} bits` : "N/A";
                                             },
                                         },
@@ -876,15 +908,21 @@ const LocateForm: React.FC = () => {
                                             title: "Date",
                                             key: "date",
                                             sorter: (a: LocateObjectRow, b: LocateObjectRow) => {
-                                                const da = (a.meta?.["rotate_date"] ??
-                                                    a.meta?.["initial_date"] ??
-                                                    a.meta?.["activation_date"] ??
-                                                    a.meta?.["original_creation_date"]) as number | undefined;
-                                                const db = (b.meta?.["rotate_date"] ??
-                                                    b.meta?.["initial_date"] ??
-                                                    b.meta?.["activation_date"] ??
-                                                    b.meta?.["original_creation_date"]) as number | undefined;
-                                                return (da ?? 0) - (db ?? 0);
+                                                const getDate = (row: LocateObjectRow) => {
+                                                    const rotateDate = row.meta?.["rotate_date"] as number | undefined;
+                                                    const initialDate = row.meta?.["initial_date"] as number | undefined;
+                                                    const activationDate = row.meta?.["activation_date"] as number | undefined;
+                                                    const originalCreationDate = row.meta?.["original_creation_date"] as number | undefined;
+                                                    return (
+                                                        rotateDate ??
+                                                        initialDate ??
+                                                        (activationDate != null ? activationDate * 1000 : undefined) ??
+                                                        originalCreationDate
+                                                    );
+                                                };
+                                                const da = getDate(a) ?? 0;
+                                                const db = getDate(b) ?? 0;
+                                                return da - db;
                                             },
                                             defaultSortOrder: "descend" as const,
                                             render: (row: LocateObjectRow) => {
@@ -892,7 +930,11 @@ const LocateForm: React.FC = () => {
                                                 const initialDate = row.meta?.["initial_date"] as number | undefined;
                                                 const activationDate = row.meta?.["activation_date"] as number | undefined;
                                                 const originalCreationDate = row.meta?.["original_creation_date"] as number | undefined;
-                                                const dateValue = rotateDate ?? initialDate ?? (activationDate ? activationDate * 1000 : undefined) ?? originalCreationDate;
+                                                const dateValue =
+                                                    rotateDate ??
+                                                    initialDate ??
+                                                    (activationDate != null ? activationDate * 1000 : undefined) ??
+                                                    originalCreationDate;
                                                 if (!dateValue) {
                                                     if (/^hsm[0-9]*::/.test(row.object_id)) {
                                                         return (
@@ -965,7 +1007,6 @@ const LocateForm: React.FC = () => {
             >
                 {detailsData && detailsData.size ? <HashMapDisplay data={detailsData} /> : <div>No attributes found.</div>}
             </Modal>
-
         </div>
     );
 };

--- a/ui/src/components/common/Locate.tsx
+++ b/ui/src/components/common/Locate.tsx
@@ -33,7 +33,12 @@ interface LocateObjectRow {
     object_id: string;
     state?: string;
     attributes?: { ObjectType?: string };
-    meta?: { key_format_type?: string; [key: string]: unknown };
+    meta?: {
+        key_format_type?: string;
+        cryptographic_algorithm?: string;
+        cryptographic_length?: number;
+        [key: string]: unknown;
+    };
 }
 
 interface LocateFormData {
@@ -89,7 +94,6 @@ const LocateForm: React.FC = () => {
         // If s already a textual state (possibly with hyphen), return as-is
         return s;
     };
-    // Details modal removed; tags are shown inline
     const { idToken, serverUrl } = useAuth();
     const [authMethod, setAuthMethod] = useState<AuthMethod>("None");
     const responseRef = useRef<HTMLDivElement>(null);
@@ -788,6 +792,7 @@ const LocateForm: React.FC = () => {
                                     showSizeChanger: true,
                                     pageSizeOptions: [50, 100, 500, 1000],
                                 }}
+                                scroll={{ x: "max-content" }}
                                 className="border rounded"
                                 columns={
                                     [
@@ -795,6 +800,7 @@ const LocateForm: React.FC = () => {
                                             title: "Object UID",
                                             dataIndex: "object_id",
                                             key: "object_id",
+                                            sorter: (a: LocateObjectRow, b: LocateObjectRow) => a.object_id.localeCompare(b.object_id),
                                         },
                                         {
                                             title: "Type",
@@ -810,6 +816,23 @@ const LocateForm: React.FC = () => {
                                                 return record.attributes?.ObjectType === value;
                                             },
                                             render: (record: LocateObjectRow) => record.attributes?.ObjectType || "N/A",
+                                        },
+                                        {
+                                            title: "Crypto Algorithm",
+                                            key: "cryptographic_algorithm",
+                                            sorter: (a: LocateObjectRow, b: LocateObjectRow) =>
+                                                (a.meta?.cryptographic_algorithm ?? "").localeCompare(b.meta?.cryptographic_algorithm ?? ""),
+                                            render: (record: LocateObjectRow) => record.meta?.cryptographic_algorithm || "N/A",
+                                        },
+                                        {
+                                            title: "Crypto Length",
+                                            key: "cryptographic_length",
+                                            sorter: (a: LocateObjectRow, b: LocateObjectRow) =>
+                                                (a.meta?.cryptographic_length ?? 0) - (b.meta?.cryptographic_length ?? 0),
+                                            render: (record: LocateObjectRow) => {
+                                                const len = record.meta?.cryptographic_length;
+                                                return len != null ? `${len} bits` : "N/A";
+                                            },
                                         },
                                         {
                                             title: "Key Format Type",
@@ -867,7 +890,7 @@ const LocateForm: React.FC = () => {
                                                 const initialDate = row.meta?.["initial_date"] as number | undefined;
                                                 const activationDate = row.meta?.["activation_date"] as number | undefined;
                                                 const originalCreationDate = row.meta?.["original_creation_date"] as number | undefined;
-                                                const dateValue = rotateDate ?? initialDate ?? activationDate ?? originalCreationDate;
+                                                const dateValue = rotateDate ?? initialDate ?? (activationDate ? activationDate * 1000 : undefined) ?? originalCreationDate;
                                                 if (!dateValue) {
                                                     if (/^hsm[0-9]*::/.test(row.object_id)) {
                                                         return (
@@ -940,7 +963,7 @@ const LocateForm: React.FC = () => {
             >
                 {detailsData && detailsData.size ? <HashMapDisplay data={detailsData} /> : <div>No attributes found.</div>}
             </Modal>
-            {/* Details modal no longer used after replacing Actions with Tags */}
+
         </div>
     );
 };

--- a/ui/tests/e2e/locate-attributes.spec.ts
+++ b/ui/tests/e2e/locate-attributes.spec.ts
@@ -47,7 +47,7 @@ async function collectAttributeColumns(page: Page, uidPrefix?: string): Promise<
             const uidText = (await cells.nth(0).textContent()) ?? "";
             if (uidPrefix && !uidText.startsWith(uidPrefix)) continue;
             const typeText = (await cells.nth(1).textContent()) ?? "";
-            const kftText = (await cells.nth(2).textContent()) ?? "";
+            const kftText = (await cells.nth(4).textContent()) ?? "";
             types.push(typeText.trim());
             keyFormatTypes.push(kftText.trim());
         }
@@ -82,7 +82,7 @@ async function findRowByUid(page: Page, uidSubstring: string): Promise<{ type: s
             const uidText = (await cells.nth(0).textContent()) ?? "";
             if (uidText.includes(uidSubstring)) {
                 const typeText = (await cells.nth(1).textContent()) ?? "";
-                const kftText = (await cells.nth(2).textContent()) ?? "";
+                const kftText = (await cells.nth(4).textContent()) ?? "";
                 return { type: typeText.trim(), keyFormatType: kftText.trim() };
             }
         }


### PR DESCRIPTION
### 1. Features

| | Before | After |
|---|---|---|
| **Crypto Algorithm** | Not shown in results | New column — displays algorithm (AES, RSA, ECDH…) with sort |
| **Crypto Length** | Not shown in results | New column — displays key size in bits with numeric sort |
| **Column sorting** | No sort controls on any column | All columns sortable (click header to sort) |
| **Table overflow** | Clipped on narrow viewports | Horizontal scroll with `scroll={{ x: "max-content" }}` |
| **Pagination** | Default 10/page, options [10, 20, 50, 100] | Default 50/page, options [50, 100, 500, 1000] |
| **Certificate details** | All fields shown including empty ones | Empty-string / null / undefined fields filtered out of the Details modal |

---

### 2. Bug Fixes

#### **Date column was always blank**

Two independent bugs:

1. Date-related attributes (`activation_date`, `rotate_date`, `initial_date`, `original_creation_date`) were absent from `GetAttributes` responses — the server never returned them, so every date field was `undefined`.
2. KMIP returns `activation_date` in **seconds** (i64); `new Date()` needs **milliseconds**. Without the `* 1000` conversion every date rendered as 1 Jan 1970.

#### **Date column sort order was incorrect**

The sorter compared `activation_date` (seconds) directly against `rotate_date` / `initial_date` / `original_creation_date` (milliseconds). The sorter now applies the same `* 1000` conversion as the renderer so all values are in the same unit before subtraction.

#### **Epoch-0 treated as missing date**

`activationDate ? activationDate * 1000 : undefined` treated timestamp `0` as absent. Changed to `activationDate != null ? activationDate * 1000 : undefined`, consistent with the `??` guards used elsewhere.

---

### 3. Other

See `CHANGELOG/feat_sort_on_KMIP.md`.

Closes #1035 