### PR TITLE
feat: automate key rotation using scheduler

### DIFF
--- a/.github/skills/adr/SKILL.md
+++ b/.github/skills/adr/SKILL.md
@@ -9,9 +9,9 @@ Create an ADR document for the Cosmian KMS repository.
 
 ## ADR Storage
 
-Save ADRs at: `documentation/docs/adr/adr-NNNN-[title-slug].md`
+Save ADRs at: `documentation/docs/adr/adr-YYYY-MM-DD-[title-slug].md`
 
-Where `NNNN` is the next sequential 4-digit number. Check existing files to determine the next number:
+Where `YYYY-MM-DD` is the current date. Check existing files to determine the next number:
 
 ```bash
 ls documentation/docs/adr/ 2>/dev/null | sort | tail -5

--- a/CHANGELOG/feat_automate_key_rotation.md
+++ b/CHANGELOG/feat_automate_key_rotation.md
@@ -1,0 +1,35 @@
+# CHANGELOG — feat/automate_key_rotation
+
+## Features
+
+### Server / Auto-rotation scheduler
+
+- Implement `run_auto_rotation()` in `crate/server/src/core/operations/auto_rotate.rs`:
+  queries `find_due_for_rotation(now)` via the database backend, routes symmetric keys
+  to `ReKey` and private keys to `ReKeyKeyPair`, and skips HSM-resident keys (UID prefix
+  `hsm::`) since the KMS cannot generate new key material inside an HSM ([#970](https://github.com/Cosmian/kms/pull/970))
+- Implement `dispatch_renewal_warnings()`: queries keys due within the next 30 days and
+  emits `info!` log entries at the [30, 7, 1]-day warning thresholds as a skeleton for the
+  forthcoming SMTP notification layer (PR #971) ([#970](https://github.com/Cosmian/kms/pull/970))
+- Add `days_until_next_rotation(attrs, now)` pure function: computes whole days until the
+  next rotation deadline using `rotate_date + interval` (if the key has already been rotated
+  at least once) or `initial_date + rotate_offset + interval` (first rotation) ([#970](https://github.com/Cosmian/kms/pull/970))
+
+### Metrics
+
+- Add `kms.key.auto_rotation` `OTel` counter to `OtelMetrics` — incremented on every
+  auto-rotation attempt with labels `uid`, `algorithm`, and `outcome` (`"success"` /
+  `"failure"`) ([#970](https://github.com/Cosmian/kms/pull/970))
+
+## Testing
+
+- Add 7 unit tests for `days_until_next_rotation()` covering: overdue key (>1 day),
+  same-day key, future key, `rotate_date` precedence, `rotate_offset` shift, missing
+  interval, and zero interval ([#970](https://github.com/Cosmian/kms/pull/970))
+- Add 2 integration tests in `auto_rotate.rs`:
+  - `test_auto_rotation_rotates_due_symmetric_key`: creates an AES-256 key past its
+    rotation deadline in the in-process SQLite database, calls `run_auto_rotation()`,
+    and asserts the original key transitions to `Deactivated` with a
+    `ReplacementObjectLink` to the successor key ([#970](https://github.com/Cosmian/kms/pull/970))
+  - `test_auto_rotation_skips_hsm_keys`: verifies that a key with an `hsm::` UID prefix
+    remains `Active` after `run_auto_rotation()` ([#970](https://github.com/Cosmian/kms/pull/970))

--- a/crate/clients/clap/src/actions/certificates/mod.rs
+++ b/crate/clients/clap/src/actions/certificates/mod.rs
@@ -7,7 +7,10 @@ use self::{
     export_certificate::ExportCertificateAction, import_certificate::ImportCertificateAction,
     revoke_certificate::RevokeCertificateAction, validate_certificate::ValidateCertificatesAction,
 };
-use crate::{actions::shared::ActivateKeyAction, error::result::KmsCliResult};
+use crate::{
+    actions::shared::{ActivateKeyAction, SetRotationPolicyAction},
+    error::result::KmsCliResult,
+};
 
 pub(crate) mod certify;
 pub(crate) mod decrypt_certificate;
@@ -29,6 +32,8 @@ pub enum CertificatesCommands {
     Import(ImportCertificateAction),
     Revoke(RevokeCertificateAction),
     Destroy(DestroyCertificateAction),
+    /// Set the automatic rotation policy on a certificate (interval, offset, keyset name).
+    SetRotationPolicy(SetRotationPolicyAction),
     Validate(ValidateCertificatesAction),
 }
 
@@ -70,6 +75,7 @@ impl CertificatesCommands {
                 action.run(kms_rest_client).await?;
                 Ok(())
             }
+            Self::SetRotationPolicy(action) => action.run(kms_rest_client).await,
             Self::Validate(action) => {
                 action.run(kms_rest_client).await?;
                 Ok(())

--- a/crate/server/src/core/operations/attributes/set.rs
+++ b/crate/server/src/core/operations/attributes/set.rs
@@ -95,15 +95,15 @@ pub(crate) async fn set_attribute(
     .await?;
     trace!("Set Attribute: Retrieved target object");
 
-    // For SQL keys (non-HSM): rotate_name must equal the key's UID.
+    // For SQL objects (non-HSM): rotate_name must equal the object's UID.
     // This enforces the gen-0 UID = keyset name invariant for deterministic @N addressing.
     if has_prefix(owm.id()).is_none() {
         if let Attribute::RotateName(name) = &request.new_attribute {
-            let key_uid = owm.id();
-            if name.as_str() != key_uid {
+            let object_uid = owm.id();
+            if name.as_str() != object_uid {
                 return Err(KmsError::InvalidRequest(format!(
-                    "SetAttribute: rotate_name ('{name}') must equal the key's UID \
-                     ('{key_uid}') — create the key with the keyset name as its ID"
+                    "SetAttribute: rotate_name ('{name}') must equal the object's UID \
+                     ('{object_uid}') — create the object with the keyset name as its ID"
                 )));
             }
         }
@@ -151,6 +151,11 @@ pub(crate) async fn set_attribute(
 
     // Capture before the macro runs (which may partially move request.new_attribute).
     let is_setting_rotate_name_on_sql = matches!(&request.new_attribute, Attribute::RotateName(_))
+        && has_prefix(owm.id()).is_none();
+    // Detect a positive RotateInterval being set on a SQL (non-HSM) key.  Used below to
+    // implicitly enable `rotate_automatic` so the scheduler's `find_due_for_rotation` query
+    // picks up keys where the client only set the schedule (interval/offset) but not the flag.
+    let is_setting_positive_rotate_interval_on_sql = matches!(&request.new_attribute, Attribute::RotateInterval(v) if *v > 0)
         && has_prefix(owm.id()).is_none();
 
     // Check if the attribute is allowed to be set
@@ -262,6 +267,19 @@ pub(crate) async fn set_attribute(
         if attributes.rotate_latest.is_none() {
             attributes.rotate_latest = Some(true);
         }
+    }
+
+    // When the client sets RotateInterval > 0 on a SQL key without also setting
+    // RotateAutomatic, implicitly enable auto-rotation.  The scheduler's
+    // `find_due_for_rotation` query filters on `rotate_automatic = true`, so a key
+    // that only has an interval set would otherwise never be rotated.
+    // An explicit `rotate_automatic = Some(false)` is respected and not overridden.
+    if is_setting_positive_rotate_interval_on_sql && attributes.rotate_automatic.is_none() {
+        debug!(
+            "SetAttribute: implicitly enabling rotate_automatic for key '{}' (RotateInterval > 0 with no explicit RotateAutomatic)",
+            owm.id()
+        );
+        attributes.rotate_automatic = Some(true);
     }
     // `HsmStore::update_object` is a no-op for attributes (the HSM has no
     // generic KV attribute storage), so we must explicitly write CKA_LABEL and

--- a/crate/server/src/core/operations/auto_rotate.rs
+++ b/crate/server/src/core/operations/auto_rotate.rs
@@ -4,41 +4,1366 @@
 //! - [`run_auto_rotation`] — iterates keys due for rotation and triggers re-key operations.
 //! - [`dispatch_renewal_warnings`] — sends notifications when keys approach their rotation date.
 
-use cosmian_logger::debug;
+use std::collections::HashMap;
 
-use crate::core::KMS;
+use cosmian_kms_server_database::reexport::cosmian_kmip::kmip_2_1::{
+    kmip_objects::ObjectType,
+    kmip_operations::{ReCertify, ReKey, ReKeyKeyPair},
+    kmip_types::UniqueIdentifier,
+};
+use cosmian_logger::{debug, info, warn};
+
+use crate::{
+    core::{
+        KMS,
+        operations::{
+            recertify::recertify,
+            rekey::{rekey, rekey_keypair},
+        },
+        uid_utils::has_prefix,
+    },
+    result::KResult,
+};
+
+/// Threshold days at which renewal warnings are emitted before the next scheduled rotation.
+///
+/// Ordered ascending so that `.find(|&&t| days <= t)` returns the most specific (smallest)
+/// matching threshold — e.g. a key due in 5 days matches threshold 7, not 30.
+const WARNING_THRESHOLDS_DAYS: [i64; 3] = [1, 7, 30];
 
 /// Rotate all keys that are past their scheduled rotation time.
 ///
-/// The function queries the database for active keys whose `rotate_interval`
-/// has elapsed since their last rotation (or initial date + offset for first rotation),
-/// then issues a Re-Key or Re-Key Key Pair operation for each.
+/// Queries the database for Active keys whose `rotate_interval` has elapsed
+/// since their last rotation (or `initial_date + rotate_offset` for first rotation),
+/// then issues a `ReKey` or `ReKeyKeyPair` on behalf of the key owner.
+///
+/// Each key is rotated independently: a failure on one key never blocks the others.
+/// HSM-resident keys (UID prefix `hsm::`) are skipped — the KMS cannot generate
+/// key material inside an HSM.
+///
+/// # Metrics
+///
+/// Increments the `kms.key.auto_rotation` `OTel` counter on each attempt, labeled
+/// with `uid`, `algorithm`, and `outcome` (`"success"` / `"failure"`).
 pub(crate) async fn run_auto_rotation(kms: &KMS) {
     let now = time::OffsetDateTime::now_utc();
     let due_keys = match kms.database.find_due_for_rotation(now).await {
         Ok(keys) => keys,
         Err(e) => {
-            debug!("[auto-rotate] Failed to query keys due for rotation: {e}");
+            warn!("[auto-rotate] Failed to query keys due for rotation: {e}");
             return;
         }
     };
 
     if due_keys.is_empty() {
+        debug!("[auto-rotate] No keys due for rotation at {now}");
         return;
     }
-    debug!(
+    info!(
         "[auto-rotate] Found {} key(s) due for rotation",
         due_keys.len()
     );
 
     for (uid, owner) in &due_keys {
-        debug!("[auto-rotate] Rotating key {uid} (owner={owner})");
-        // TODO: issue Re-Key / Re-Key Key Pair operation for the key
+        if let Err(e) = Box::pin(rotate_one_key(kms, uid, owner)).await {
+            // Logged inside rotate_one_key; the outer loop continues.
+            debug!("[auto-rotate] rotate_one_key returned: {e}");
+        }
     }
 }
 
-/// Check keys approaching rotation and emit renewal-warning notifications.
-pub(crate) async fn dispatch_renewal_warnings(_kms: &KMS) {
-    // TODO: implement renewal-warning notification dispatch
-    debug!("[auto-rotate] Renewal-warning dispatch complete (no-op stub)");
+/// Attempt to rotate a single key, returning `Ok(())` on success.
+///
+/// After a successful rotation the replacement key inherits the original key's
+/// rotation policy (`rotate_automatic = true`, `rotate_interval = old_interval`)
+/// so that auto-rotation continues indefinitely — matching the behaviour of
+/// AWS KMS, Azure Key Vault, and GCP Cloud KMS.
+///
+/// Errors are also logged as `warn!` here so the caller loop can continue.
+async fn rotate_one_key(kms: &KMS, uid: &str, owner: &str) -> KResult<()> {
+    // HSM keys: the KMS cannot generate new key material inside an HSM
+    if has_prefix(uid).is_some() {
+        debug!("[auto-rotate] Skipping HSM key {uid}");
+        return Ok(());
+    }
+
+    // Retrieve the object to determine its type, algorithm, and rotation policy.
+    // We capture `old_interval` here so the replacement can be re-armed after rotation.
+    let owm = match kms.database.retrieve_object(uid).await {
+        Ok(Some(owm)) => owm,
+        Ok(None) => {
+            warn!("[auto-rotate] Key {uid} not found; skipping");
+            return Ok(());
+        }
+        Err(e) => {
+            warn!("[auto-rotate] Failed to retrieve key {uid}: {e}; skipping");
+            return Ok(());
+        }
+    };
+
+    let object_type = owm.object().object_type();
+    let algorithm = owm
+        .attributes()
+        .cryptographic_algorithm
+        .map_or_else(|| "unknown".to_owned(), |a| format!("{a:?}"));
+
+    // Capture the rotation policy before dispatching so we can re-arm the replacement.
+    let old_interval = owm.attributes().rotate_interval.filter(|&i| i > 0);
+
+    // Dispatch to the appropriate KMIP rotation operation and return the new key's UID.
+    let new_uid_result: KResult<String> = match object_type {
+        ObjectType::SymmetricKey => {
+            let request = ReKey {
+                unique_identifier: Some(UniqueIdentifier::TextString(uid.to_owned())),
+                offset: None,
+                attributes: None,
+                protection_storage_masks: None,
+            };
+            Box::pin(rekey(kms, request, owner))
+                .await
+                .map(|r| r.unique_identifier.to_string())
+        }
+        ObjectType::PrivateKey => {
+            let request = ReKeyKeyPair {
+                private_key_unique_identifier: Some(UniqueIdentifier::TextString(uid.to_owned())),
+                ..ReKeyKeyPair::default()
+            };
+            Box::pin(rekey_keypair(kms, request, owner))
+                .await
+                .map(|r| r.private_key_unique_identifier.to_string())
+        }
+        ObjectType::Certificate => {
+            let request = ReCertify {
+                unique_identifier: Some(UniqueIdentifier::TextString(uid.to_owned())),
+                offset: None,
+                attributes: None,
+                certificate_request_type: None,
+                certificate_request_value: None,
+                protection_storage_masks: None,
+            };
+            Box::pin(recertify(kms, request, owner))
+                .await
+                .map(|r| r.unique_identifier.to_string())
+        }
+        // Public keys are rotated atomically as a side-effect of rotating the paired
+        // PrivateKey via `rekey_keypair`. Schedule auto-rotation on the PrivateKey instead.
+        ObjectType::PublicKey => {
+            debug!(
+                "[auto-rotate] Skipping {uid}: PublicKey is rotated as part of its paired \
+                 PrivateKey rotation"
+            );
+            return Ok(());
+        }
+        other => {
+            debug!(
+                "[auto-rotate] Skipping {uid}: object type {other:?} has no auto-rotation support"
+            );
+            return Ok(());
+        }
+    };
+
+    match &new_uid_result {
+        Ok(new_uid) => {
+            info!("[auto-rotate] Key {uid} (owner={owner}, algo={algorithm}) rotated successfully");
+            if let Some(ref m) = kms.metrics {
+                m.record_key_auto_rotation(uid, &algorithm, "success");
+            }
+            // Re-arm the replacement key with the original rotation policy so that
+            // auto-rotation continues indefinitely without operator intervention.
+            // `set_rotation_metadata_from` zeroes `rotate_interval` to prevent
+            // accidental double-rotation on manual rekeys; the scheduler is
+            // responsible for re-arming its own replacements.
+            if let Some(interval) = old_interval {
+                if let Err(e) = rearm_rotation_policy(kms, new_uid, interval).await {
+                    warn!(
+                        "[auto-rotate] Failed to re-arm rotation policy on replacement {new_uid}: {e}"
+                    );
+                }
+            }
+        }
+        Err(e) => {
+            warn!("[auto-rotate] Failed to rotate key {uid} (owner={owner}): {e}");
+            if let Some(ref m) = kms.metrics {
+                m.record_key_auto_rotation(uid, &algorithm, "failure");
+            }
+        }
+    }
+
+    new_uid_result.map(|_| ())
+}
+
+/// Re-arm the rotation policy on a replacement key after a successful auto-rotation.
+///
+/// `set_rotation_metadata_from` intentionally zeroes `rotate_interval` on manual rekeys so
+/// the user must opt back in. For auto-rotation, the scheduler re-arms the replacement here,
+/// preserving perpetual rotation — matching AWS KMS, Azure Key Vault, and GCP Cloud KMS.
+async fn rearm_rotation_policy(kms: &KMS, new_uid: &str, interval: i64) -> KResult<()> {
+    let owm = match kms.database.retrieve_object(new_uid).await {
+        Ok(Some(owm)) => owm,
+        Ok(None) => {
+            return Err(crate::error::KmsError::ServerError(format!(
+                "Replacement key {new_uid} not found; cannot re-arm rotation policy"
+            )));
+        }
+        Err(e) => {
+            return Err(crate::error::KmsError::ServerError(format!(
+                "Failed to retrieve replacement key {new_uid}: {e}"
+            )));
+        }
+    };
+
+    let mut new_attrs = owm.attributes().clone();
+    new_attrs.rotate_automatic = Some(true);
+    new_attrs.rotate_interval = Some(interval);
+
+    kms.database
+        .update_object(new_uid, owm.object(), &new_attrs, None)
+        .await
+        .map_err(|e| crate::error::KmsError::ServerError(e.to_string()))
+}
+
+/// Check keys approaching rotation and emit renewal-warning log events.
+///
+/// For each Active key whose next rotation falls within the next
+/// [`WARNING_THRESHOLDS_DAYS`] days, an `info!` event is emitted at the
+/// most urgent matching threshold and an `OTel` counter is incremented.
+///
+/// Deduplication is handled by the caller-supplied `warned` map, which persists
+/// across cron ticks (owned by `spawn_auto_rotation_cron`).  An entry
+/// `uid → threshold` is inserted after each warning; if the same uid already
+/// maps to the same threshold the warning is skipped.  When a key is rotated its
+/// old UID is deactivated and disappears from future query results, so stale
+/// entries never cause problems.  On server restart the map is empty; at most one
+/// extra warning fires per key per restart, which is harmless.
+///
+/// Full notification delivery (SMTP, webhook) is wired in a follow-up PR.
+pub(crate) async fn dispatch_renewal_warnings(kms: &KMS, warned: &mut HashMap<String, i64>) {
+    let now = time::OffsetDateTime::now_utc();
+    let max_horizon = WARNING_THRESHOLDS_DAYS.iter().copied().max().unwrap_or(30);
+    let horizon = now + time::Duration::days(max_horizon);
+
+    // Reuse the existing query with a future horizon to find all keys due within the window
+    let approaching = match kms.database.find_due_for_rotation(horizon).await {
+        Ok(keys) => keys,
+        Err(e) => {
+            debug!("[auto-rotate] Failed to query keys for renewal warnings: {e}");
+            return;
+        }
+    };
+
+    for (uid, owner) in &approaching {
+        // HSM keys are excluded from auto-rotation, skip warnings too
+        if has_prefix(uid).is_some() {
+            continue;
+        }
+
+        let Ok(Some(owm)) = kms.database.retrieve_object(uid).await else {
+            continue;
+        };
+
+        let attrs = owm.attributes();
+        let Some(days) = days_until_next_rotation(attrs, now) else {
+            continue;
+        };
+
+        // Already past deadline → run_auto_rotation handles it; nothing to warn.
+        // Same-day keys (days == 0, i.e. less than one full day remaining) are still
+        // valid warning targets at the 1-day threshold.
+        if days < 0 {
+            continue;
+        }
+
+        // Find the most urgent matching threshold
+        let Some(&threshold) = WARNING_THRESHOLDS_DAYS.iter().find(|&&t| days <= t) else {
+            continue;
+        };
+
+        // Deduplication: skip if this (uid, threshold) pair was already warned in this
+        // process run. The `warned` map is owned by the cron scheduler and survives
+        // across ticks, preventing log flooding when the interval is short.
+        if warned.get(uid.as_str()).copied() == Some(threshold) {
+            continue;
+        }
+
+        let algorithm = attrs
+            .cryptographic_algorithm
+            .map_or_else(|| "unknown".to_owned(), |a| format!("{a:?}"));
+
+        info!(
+            "[auto-rotate] Key {uid} (owner={owner}) rotation due in {days} day(s) \
+             (warning threshold: {threshold} days)"
+        );
+
+        if let Some(ref m) = kms.metrics {
+            m.record_rotation_warning(uid, &algorithm, threshold);
+        }
+
+        warned.insert(uid.clone(), threshold);
+    }
+}
+
+/// Compute the number of whole days until the next scheduled rotation for a key.
+///
+/// Returns `None` if the rotation schedule cannot be determined (no interval, no anchor date).
+/// Returns a negative number if the deadline has already passed.
+fn days_until_next_rotation(
+    attrs: &cosmian_kms_server_database::reexport::cosmian_kmip::kmip_2_1::kmip_attributes::Attributes,
+    now: time::OffsetDateTime,
+) -> Option<i64> {
+    let interval_secs = attrs.rotate_interval.filter(|&s| s > 0)?;
+    let interval = time::Duration::seconds(interval_secs);
+
+    let next_rotation = if let Some(last_rotate) = attrs.rotate_date {
+        last_rotate + interval
+    } else if let Some(initial) = attrs.initial_date {
+        let offset = time::Duration::seconds(attrs.rotate_offset.unwrap_or(0));
+        initial + offset + interval
+    } else {
+        return None;
+    };
+
+    Some((next_rotation - now).whole_days())
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, clippy::panic_in_result_fn)]
+mod tests {
+    use std::{collections::HashSet, sync::Arc};
+
+    use cosmian_kms_server_database::reexport::cosmian_kmip::{
+        kmip_0::kmip_types::State,
+        kmip_2_1::{
+            kmip_attributes::{Attribute, Attributes},
+            kmip_operations::SetAttribute,
+            kmip_types::{CryptographicAlgorithm, UniqueIdentifier},
+            requests::create_symmetric_key_kmip_object,
+        },
+    };
+    use openssl::rand::rand_bytes;
+
+    use super::days_until_next_rotation;
+    use crate::{
+        config::ServerParams,
+        core::{
+            KMS,
+            operations::{
+                auto_rotate::{dispatch_renewal_warnings, run_auto_rotation},
+                set_attribute,
+            },
+        },
+        result::KResult,
+        tests::test_utils::https_clap_config,
+    };
+
+    // ── Helper ────────────────────────────────────────────────────────────────
+
+    async fn test_kms() -> KResult<Arc<KMS>> {
+        crate::openssl_providers::init_openssl_providers_for_tests();
+        let cfg = https_clap_config();
+        Ok(Arc::new(
+            KMS::instantiate(Arc::new(ServerParams::try_from(cfg)?)).await?,
+        ))
+    }
+
+    fn make_aes256_key()
+    -> cosmian_kms_server_database::reexport::cosmian_kmip::kmip_2_1::kmip_objects::Object {
+        let mut bytes = [0_u8; 32];
+        #[expect(clippy::unwrap_used)]
+        rand_bytes(&mut bytes).unwrap();
+        #[expect(clippy::unwrap_used)]
+        create_symmetric_key_kmip_object(
+            "x-vendor",
+            &bytes,
+            &Attributes {
+                cryptographic_algorithm: Some(CryptographicAlgorithm::AES),
+                ..Default::default()
+            },
+        )
+        .unwrap()
+    }
+
+    // ── Unit tests for days_until_next_rotation() ─────────────────────────────
+
+    fn now() -> time::OffsetDateTime {
+        time::OffsetDateTime::now_utc()
+    }
+
+    /// Key with `initial_date` 3 days ago, `rotate_interval` = 1 day → 2 days past deadline.
+    #[test]
+    fn test_overdue_key_initial_date() {
+        let now = now();
+        let attrs = Attributes {
+            rotate_interval: Some(86_400), // 1 day
+            initial_date: Some(now - time::Duration::days(3)),
+            ..Default::default()
+        };
+        let days = days_until_next_rotation(&attrs, now).expect("should have a schedule");
+        assert!(days < 0, "expected negative (overdue), got {days}");
+    }
+
+    /// Key with `initial_date` 30 min ago, `rotate_interval` = 1 h → 0 days remaining (same day).
+    #[test]
+    fn test_upcoming_key_same_day() {
+        let now = now();
+        let attrs = Attributes {
+            rotate_interval: Some(3600),
+            initial_date: Some(now - time::Duration::minutes(30)),
+            ..Default::default()
+        };
+        let days = days_until_next_rotation(&attrs, now).expect("should have a schedule");
+        assert_eq!(days, 0, "30 min remaining → 0 whole days, got {days}");
+    }
+
+    /// Key with `initial_date` 1 week ago, `rotate_interval` = 10 days → 3 days remaining.
+    #[test]
+    fn test_key_not_yet_due() {
+        let now = now();
+        let attrs = Attributes {
+            rotate_interval: Some(10 * 86_400), // 10 days
+            initial_date: Some(now - time::Duration::days(7)),
+            ..Default::default()
+        };
+        let days = days_until_next_rotation(&attrs, now).expect("should have a schedule");
+        assert_eq!(days, 3, "10 - 7 = 3 days remaining, got {days}");
+    }
+
+    /// Key rotated 3 days ago with a 7-day interval → 4 days remaining.
+    #[test]
+    fn test_key_uses_rotate_date_when_set() {
+        let now = now();
+        let attrs = Attributes {
+            rotate_interval: Some(7 * 86_400), // 7 days
+            rotate_date: Some(now - time::Duration::days(3)),
+            initial_date: Some(now - time::Duration::days(30)), // ignored when rotate_date is set
+            ..Default::default()
+        };
+        let days = days_until_next_rotation(&attrs, now).expect("should have a schedule");
+        assert_eq!(
+            days, 4,
+            "rotate_date 3 days ago + 7-day interval → 4 remaining, got {days}"
+        );
+    }
+
+    /// Key with `rotate_offset` shifts the first deadline.
+    #[test]
+    fn test_rotate_offset_applied() {
+        let now = now();
+        let attrs = Attributes {
+            rotate_interval: Some(10 * 86_400),                // 10 days
+            rotate_offset: Some(5 * 86_400),                   // 5-day delay before first rotation
+            initial_date: Some(now - time::Duration::days(6)), // 6 days ago
+            ..Default::default()
+        };
+        // next = initial + offset + interval = -6 + 5 + 10 = +9 days from now
+        let days = days_until_next_rotation(&attrs, now).expect("should have a schedule");
+        assert_eq!(days, 9, "offset applied: 9 days remaining, got {days}");
+    }
+
+    /// Key with no `rotate_interval` → `None` (no rotation schedule).
+    #[test]
+    fn test_no_interval_returns_none() {
+        let now = now();
+        let attrs = Attributes {
+            rotate_interval: None,
+            initial_date: Some(now - time::Duration::hours(2)),
+            ..Default::default()
+        };
+        assert!(
+            days_until_next_rotation(&attrs, now).is_none(),
+            "missing interval should return None"
+        );
+    }
+
+    /// Key with `rotate_interval = 0` → `None` (disabled).
+    #[test]
+    fn test_zero_interval_returns_none() {
+        let now = now();
+        let attrs = Attributes {
+            rotate_interval: Some(0),
+            initial_date: Some(now - time::Duration::hours(2)),
+            ..Default::default()
+        };
+        assert!(
+            days_until_next_rotation(&attrs, now).is_none(),
+            "zero interval should return None"
+        );
+    }
+
+    /// Key with no anchor dates → `None`.
+    #[test]
+    fn test_no_anchor_dates_returns_none() {
+        let now = now();
+        let attrs = Attributes {
+            rotate_interval: Some(3600),
+            initial_date: None,
+            rotate_date: None,
+            ..Default::default()
+        };
+        assert!(
+            days_until_next_rotation(&attrs, now).is_none(),
+            "no anchor dates should return None"
+        );
+    }
+
+    // ── Integration: run_auto_rotation dispatches ReKey for due symmetric key ─
+
+    /// Verify that `run_auto_rotation` issues a `ReKey` for a symmetric key whose
+    /// rotation deadline has already passed:
+    /// - The original key must end up `Deactivated` (KMIP §4.57 transition 6).
+    /// - A new key linked via `ReplacedObjectLink` must exist in the database.
+    #[tokio::test]
+    async fn test_auto_rotation_rotates_due_symmetric_key() -> KResult<()> {
+        let kms = test_kms().await?;
+        let owner = "auto_rotate_test_owner@example.com";
+        let now = time::OffsetDateTime::now_utc();
+
+        // Create a key that is 2 h past its 1-h rotation deadline
+        let uid = uuid::Uuid::new_v4().to_string();
+        let key_object = make_aes256_key();
+        let key_attrs = Attributes {
+            cryptographic_algorithm: Some(CryptographicAlgorithm::AES),
+            state: Some(State::Active),
+            rotate_automatic: Some(true),
+            rotate_interval: Some(3600),
+            initial_date: Some(now - time::Duration::hours(2)),
+            ..Default::default()
+        };
+        kms.database
+            .create(
+                Some(uid.clone()),
+                owner,
+                &key_object,
+                &key_attrs,
+                &HashSet::new(),
+            )
+            .await
+            .map_err(|e| crate::error::KmsError::ServerError(e.to_string()))?;
+
+        // Trigger auto-rotation
+        run_auto_rotation(&kms).await;
+
+        // Original key must be Deactivated
+        let owm = kms
+            .database
+            .retrieve_object(&uid)
+            .await
+            .map_err(|e| crate::error::KmsError::ServerError(e.to_string()))?
+            .expect("original key must still exist after rotation");
+        assert_eq!(
+            owm.state(),
+            State::Deactivated,
+            "original key must be Deactivated after auto-rotation"
+        );
+
+        // A replacement key must be linked via ReplacedObjectLink
+        let replacement_linked = owm
+            .attributes()
+            .link
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .any(|lnk| {
+                lnk.link_type
+                    == cosmian_kms_server_database::reexport::cosmian_kmip::kmip_2_1::kmip_types::LinkType::ReplacementObjectLink
+            });
+        assert!(
+            replacement_linked,
+            "original key must have a ReplacementObjectLink to the new key"
+        );
+
+        Ok(())
+    }
+
+    /// Verify that `run_auto_rotation` skips HSM-resident keys (uid prefix `hsm::`).
+    #[tokio::test]
+    async fn test_auto_rotation_skips_hsm_keys() -> KResult<()> {
+        let kms = test_kms().await?;
+        let owner = "auto_rotate_hsm_test@example.com";
+        let now = time::OffsetDateTime::now_utc();
+
+        // Store a key with an HSM-style UID (bypasses database-level HSM routing
+        // because no real HSM is configured; we just verify the scheduler skips it)
+        let hsm_uid = format!("hsm::softhsm2::0::{}", uuid::Uuid::new_v4());
+        let key_object = make_aes256_key();
+        let key_attrs = Attributes {
+            cryptographic_algorithm: Some(CryptographicAlgorithm::AES),
+            state: Some(State::Active),
+            rotate_automatic: Some(true),
+            rotate_interval: Some(3600),
+            initial_date: Some(now - time::Duration::hours(2)),
+            ..Default::default()
+        };
+
+        // Create in the SQL store directly (the Database will route to the
+        // default SQL backend since the HSM routes are not configured in tests)
+        if kms
+            .database
+            .create(
+                Some(hsm_uid.clone()),
+                owner,
+                &key_object,
+                &key_attrs,
+                &HashSet::new(),
+            )
+            .await
+            .is_ok()
+        {
+            // If the key was created, verify run_auto_rotation does NOT rotate it
+            run_auto_rotation(&kms).await;
+
+            let owm = kms
+                .database
+                .retrieve_object(&hsm_uid)
+                .await
+                .map_err(|e| crate::error::KmsError::ServerError(e.to_string()))?
+                .expect("HSM key must still exist");
+            // State must remain Active (not rotated, not deactivated)
+            assert_eq!(
+                owm.state(),
+                State::Active,
+                "HSM key must remain Active — scheduler must not rotate it"
+            );
+        }
+        // If create() rejected the HSM uid (routing error), the test trivially passes
+        // because there is nothing to be accidentally rotated.
+
+        Ok(())
+    }
+
+    /// Verify that a key whose owner only set `RotateInterval` (without `RotateAutomatic`)
+    /// is still picked up and rotated by the scheduler.
+    ///
+    /// Regression test for the bug where `find_due_for_rotation` requires
+    /// `rotate_automatic = true`, but `SetAttribute RotateInterval` did not implicitly
+    /// set it, causing the cron to silently skip such keys.
+    #[tokio::test]
+    async fn test_auto_rotation_implicit_enable_via_set_interval() -> KResult<()> {
+        let kms = test_kms().await?;
+        let owner = "implicit_enable_test@example.com";
+        let now = time::OffsetDateTime::now_utc();
+
+        // Create an overdue key — but WITHOUT rotate_automatic, simulating a key
+        // that was configured only with interval+offset via SetAttribute.
+        let uid = uuid::Uuid::new_v4().to_string();
+        let key_object = make_aes256_key();
+        let key_attrs = Attributes {
+            cryptographic_algorithm: Some(CryptographicAlgorithm::AES),
+            state: Some(State::Active),
+            rotate_interval: Some(3600),
+            initial_date: Some(now - time::Duration::hours(2)), // already overdue
+            // rotate_automatic intentionally absent
+            ..Default::default()
+        };
+        kms.database
+            .create(
+                Some(uid.clone()),
+                owner,
+                &key_object,
+                &key_attrs,
+                &HashSet::new(),
+            )
+            .await
+            .map_err(|e| crate::error::KmsError::ServerError(e.to_string()))?;
+
+        // Without the fix, the scheduler would never rotate this key.
+        // Confirm it is NOT yet in the due-for-rotation result.
+        let due_before = kms
+            .database
+            .find_due_for_rotation(now)
+            .await
+            .map_err(|e| crate::error::KmsError::ServerError(e.to_string()))?;
+        assert!(
+            !due_before.iter().any(|(u, _)| u == &uid),
+            "key without rotate_automatic must not appear in find_due_for_rotation before SetAttribute"
+        );
+
+        // Now simulate what a user would do: call SetAttribute RotateInterval.
+        // The fix auto-sets rotate_automatic = true when rotate_automatic is absent.
+        set_attribute(
+            &kms,
+            SetAttribute {
+                unique_identifier: Some(UniqueIdentifier::TextString(uid.clone())),
+                new_attribute: Attribute::RotateInterval(3600),
+            },
+            owner,
+        )
+        .await?;
+
+        // rotate_automatic must now be true in the stored attributes.
+        let owm = kms
+            .database
+            .retrieve_object(&uid)
+            .await
+            .map_err(|e| crate::error::KmsError::ServerError(e.to_string()))?
+            .expect("key must exist after SetAttribute");
+        assert_eq!(
+            owm.attributes().rotate_automatic,
+            Some(true),
+            "SetAttribute RotateInterval must implicitly set rotate_automatic = true"
+        );
+
+        // The key must now appear in find_due_for_rotation.
+        let due_after = kms
+            .database
+            .find_due_for_rotation(now)
+            .await
+            .map_err(|e| crate::error::KmsError::ServerError(e.to_string()))?;
+        assert!(
+            due_after.iter().any(|(u, _)| u == &uid),
+            "key must appear in find_due_for_rotation after SetAttribute RotateInterval"
+        );
+
+        // Finally, the scheduler must rotate it.
+        run_auto_rotation(&kms).await;
+        let rotated = kms
+            .database
+            .retrieve_object(&uid)
+            .await
+            .map_err(|e| crate::error::KmsError::ServerError(e.to_string()))?
+            .expect("key must still exist after rotation");
+        assert_eq!(
+            rotated.state(),
+            State::Deactivated,
+            "original key must be Deactivated after scheduler runs"
+        );
+
+        Ok(())
+    }
+
+    /// Verify that `Certify` sets `initial_date` on the new certificate so that the
+    /// auto-rotation scheduler can compute the first rotation deadline without any
+    /// manual override.
+    ///
+    /// Regression test: freshly-created certificates with `rotate_automatic = true`
+    /// and `rotate_interval > 0` were silently skipped by the scheduler because
+    /// `initial_date` was `None`, causing `days_until_next_rotation` to return `None`.
+    #[tokio::test]
+    async fn test_certify_sets_initial_date_for_auto_rotation() -> KResult<()> {
+        use cosmian_kms_server_database::reexport::cosmian_kmip::kmip_2_1::{
+            kmip_operations::Certify,
+            kmip_types::{CertificateAttributes, CryptographicDomainParameters, RecommendedCurve},
+        };
+
+        let kms = test_kms().await?;
+        let owner = "initial_date_cert_test@example.com";
+
+        // Create a self-signed EC certificate.
+        let certify_req = Certify {
+            attributes: Some(Attributes {
+                cryptographic_algorithm: Some(CryptographicAlgorithm::ECDSA),
+                cryptographic_domain_parameters: Some(CryptographicDomainParameters {
+                    recommended_curve: Some(RecommendedCurve::P256),
+                    ..CryptographicDomainParameters::default()
+                }),
+                certificate_attributes: Some(CertificateAttributes::parse_subject_line(
+                    "CN=initial-date-test",
+                )?),
+                ..Attributes::default()
+            }),
+            ..Certify::default()
+        };
+        let cert_id = kms
+            .certify(certify_req, owner)
+            .await?
+            .unique_identifier
+            .to_string();
+
+        let cert_owm = kms
+            .database
+            .retrieve_object(&cert_id)
+            .await
+            .map_err(|e| crate::error::KmsError::ServerError(e.to_string()))?
+            .expect("certificate must exist after Certify");
+
+        assert!(
+            cert_owm.attributes().initial_date.is_some(),
+            "Certify must set initial_date so the scheduler can compute the first rotation deadline"
+        );
+
+        // Now enable auto-rotation via SetAttribute RotateInterval
+        // (which also auto-sets rotate_automatic = true).
+        set_attribute(
+            &kms,
+            SetAttribute {
+                unique_identifier: Some(UniqueIdentifier::TextString(cert_id.clone())),
+                new_attribute: Attribute::RotateInterval(3600),
+            },
+            owner,
+        )
+        .await?;
+
+        // The cert must appear in find_due_for_rotation at now + 2h
+        // because next_rotation = initial_date + 1h < now + 2h.
+        let horizon = time::OffsetDateTime::now_utc() + time::Duration::hours(2);
+        let due = kms
+            .database
+            .find_due_for_rotation(horizon)
+            .await
+            .map_err(|e| crate::error::KmsError::ServerError(e.to_string()))?;
+        assert!(
+            due.iter().any(|(uid, _)| uid == &cert_id),
+            "certificate must appear in find_due_for_rotation once initial_date + interval has elapsed"
+        );
+
+        Ok(())
+    }
+
+    /// Verify that `Certify` with `rotate_automatic = true` and `rotate_interval` embedded
+    /// in the request attributes is enough to make `find_due_for_rotation` pick up the
+    /// certificate once the interval has elapsed — without any subsequent `SetAttribute` call.
+    ///
+    /// This is the ergonomic "one-shot" API for callers who know the rotation policy at
+    /// creation time.
+    #[tokio::test]
+    async fn test_certify_with_rotation_policy_found_by_scheduler() -> KResult<()> {
+        use cosmian_kms_server_database::reexport::cosmian_kmip::kmip_2_1::{
+            kmip_operations::Certify,
+            kmip_types::{CertificateAttributes, CryptographicDomainParameters, RecommendedCurve},
+        };
+
+        let kms = test_kms().await?;
+        let owner = "certify_with_policy_test@example.com";
+
+        // Certify with rotation policy baked in — no separate SetAttribute needed.
+        let certify_req = Certify {
+            attributes: Some(Attributes {
+                cryptographic_algorithm: Some(CryptographicAlgorithm::ECDSA),
+                cryptographic_domain_parameters: Some(CryptographicDomainParameters {
+                    recommended_curve: Some(RecommendedCurve::P256),
+                    ..CryptographicDomainParameters::default()
+                }),
+                certificate_attributes: Some(CertificateAttributes::parse_subject_line(
+                    "CN=policy-at-creation-test",
+                )?),
+                rotate_automatic: Some(true),
+                rotate_interval: Some(3600), // 1 hour
+                ..Attributes::default()
+            }),
+            ..Certify::default()
+        };
+        let cert_id = kms
+            .certify(certify_req, owner)
+            .await?
+            .unique_identifier
+            .to_string();
+
+        // The cert must appear in find_due_for_rotation at now + 2h.
+        let horizon = time::OffsetDateTime::now_utc() + time::Duration::hours(2);
+        let due = kms
+            .database
+            .find_due_for_rotation(horizon)
+            .await
+            .map_err(|e| crate::error::KmsError::ServerError(e.to_string()))?;
+        assert!(
+            due.iter().any(|(uid, _)| uid == &cert_id),
+            "certificate with rotation policy embedded in Certify request must appear in \
+             find_due_for_rotation once initial_date + interval has elapsed"
+        );
+
+        Ok(())
+    }
+
+    /// Verify that `run_auto_rotation` issues a `ReCertify` for a self-signed certificate whose
+    /// rotation deadline has already passed:
+    /// - The original certificate must end up `Deactivated`.
+    /// - A new certificate linked via `ReplacementObjectLink` must exist in the database.
+    ///
+    /// This test exercises the `Certificate` arm added to `rotate_one_key`.
+    #[tokio::test]
+    async fn test_auto_rotation_rotates_due_certificate() -> KResult<()> {
+        use cosmian_kms_server_database::reexport::cosmian_kmip::kmip_2_1::{
+            kmip_operations::Certify,
+            kmip_types::{
+                CertificateAttributes, CryptographicAlgorithm, CryptographicDomainParameters,
+                RecommendedCurve,
+            },
+        };
+
+        let kms = test_kms().await?;
+        let owner = "auto_rotate_cert_test@example.com";
+        let now = time::OffsetDateTime::now_utc();
+
+        // Step 1: Create a self-signed EC certificate via the Certify operation.
+        // Certify with no unique_identifier and only certificate_attributes generates
+        // a fresh EC keypair and signs a self-signed certificate.
+        let certify_req = Certify {
+            attributes: Some(Attributes {
+                cryptographic_algorithm: Some(CryptographicAlgorithm::ECDSA),
+                cryptographic_domain_parameters: Some(CryptographicDomainParameters {
+                    recommended_curve: Some(RecommendedCurve::P256),
+                    ..CryptographicDomainParameters::default()
+                }),
+                certificate_attributes: Some(CertificateAttributes::parse_subject_line(
+                    "CN=auto-rotate-test",
+                )?),
+                ..Attributes::default()
+            }),
+            ..Certify::default()
+        };
+        let cert_id = kms
+            .certify(certify_req, owner)
+            .await?
+            .unique_identifier
+            .to_string();
+
+        // The Certify operation creates the new keypair in Active state — no explicit
+        // Activate call needed. The signing private key is ready for recertify().
+        let cert_owm = kms
+            .database
+            .retrieve_object(&cert_id)
+            .await
+            .map_err(|e| crate::error::KmsError::ServerError(e.to_string()))?
+            .expect("certificate must exist after Certify");
+
+        // Step 2: Set rotation attributes on the certificate so it is immediately due.
+        let mut cert_attrs = cert_owm.attributes().clone();
+        cert_attrs.rotate_automatic = Some(true);
+        cert_attrs.rotate_interval = Some(3600); // 1 hour
+        cert_attrs.initial_date = Some(now - time::Duration::hours(2)); // 2 h ago → overdue
+        kms.database
+            .update_object(&cert_id, cert_owm.object(), &cert_attrs, None)
+            .await
+            .map_err(|e| crate::error::KmsError::ServerError(e.to_string()))?;
+
+        // Diagnostic: verify find_due_for_rotation returns this cert.
+        let due = kms
+            .database
+            .find_due_for_rotation(time::OffsetDateTime::now_utc())
+            .await
+            .map_err(|e| crate::error::KmsError::ServerError(e.to_string()))?;
+        let found_cert = due.iter().any(|(uid, _)| uid == &cert_id);
+        assert!(
+            found_cert,
+            "certificate {cert_id} must appear in find_due_for_rotation before auto-rotation"
+        );
+
+        // Step 4: Trigger auto-rotation.
+        run_auto_rotation(&kms).await;
+
+        // Step 5: The original certificate must be Deactivated.
+        let updated_owm = kms
+            .database
+            .retrieve_object(&cert_id)
+            .await
+            .map_err(|e| crate::error::KmsError::ServerError(e.to_string()))?
+            .expect("original certificate must still exist after rotation");
+        assert_eq!(
+            updated_owm.state(),
+            State::Deactivated,
+            "original certificate must be Deactivated after auto-rotation"
+        );
+
+        // Step 6: A ReplacementObjectLink must point to the new certificate.
+        let has_replacement = updated_owm
+            .attributes()
+            .link
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .any(|lnk| {
+                lnk.link_type == cosmian_kms_server_database::reexport::cosmian_kmip::kmip_2_1::kmip_types::LinkType::ReplacementObjectLink
+            });
+        assert!(
+            has_replacement,
+            "original certificate must have a ReplacementObjectLink to the new certificate"
+        );
+
+        Ok(())
+    }
+
+    /// Verify that after a successful auto-rotation the replacement key is re-armed with the
+    /// original rotation policy so that perpetual rotation chains work without operator
+    /// intervention — matching the behaviour of AWS KMS, Azure Key Vault, and GCP Cloud KMS.
+    #[tokio::test]
+    async fn test_auto_rotation_perpetual_chain() -> KResult<()> {
+        let kms = test_kms().await?;
+        let owner = "perpetual_chain_test@example.com";
+        let now = time::OffsetDateTime::now_utc();
+
+        // Create a key that is 2 h past its 1-h rotation deadline.
+        let uid = uuid::Uuid::new_v4().to_string();
+        let key_object = make_aes256_key();
+        let key_attrs = Attributes {
+            cryptographic_algorithm: Some(CryptographicAlgorithm::AES),
+            state: Some(State::Active),
+            rotate_automatic: Some(true),
+            rotate_interval: Some(3600), // 1 hour
+            initial_date: Some(now - time::Duration::hours(2)),
+            ..Default::default()
+        };
+        kms.database
+            .create(
+                Some(uid.clone()),
+                owner,
+                &key_object,
+                &key_attrs,
+                &HashSet::new(),
+            )
+            .await
+            .map_err(|e| crate::error::KmsError::ServerError(e.to_string()))?;
+
+        // First rotation cycle.
+        run_auto_rotation(&kms).await;
+
+        // Retrieve the original key and follow ReplacementObjectLink to the new key.
+        let old_owm = kms
+            .database
+            .retrieve_object(&uid)
+            .await
+            .map_err(|e| crate::error::KmsError::ServerError(e.to_string()))?
+            .expect("original key must exist");
+        assert_eq!(
+            old_owm.state(),
+            State::Deactivated,
+            "original key must be Deactivated after first rotation"
+        );
+
+        let new_uid = old_owm
+            .attributes()
+            .link
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .find(|lnk| {
+                lnk.link_type
+                    == cosmian_kms_server_database::reexport::cosmian_kmip::kmip_2_1::kmip_types::LinkType::ReplacementObjectLink
+            })
+            .map(|lnk| lnk.linked_object_identifier.to_string())
+            .expect("original key must have a ReplacementObjectLink");
+
+        // The replacement key MUST have the same rotation policy re-armed.
+        let new_owm = kms
+            .database
+            .retrieve_object(&new_uid)
+            .await
+            .map_err(|e| crate::error::KmsError::ServerError(e.to_string()))?
+            .expect("replacement key must exist");
+
+        let new_attrs = new_owm.attributes();
+        assert_eq!(
+            new_attrs.rotate_automatic,
+            Some(true),
+            "replacement key must have rotate_automatic = true"
+        );
+        assert_eq!(
+            new_attrs.rotate_interval,
+            Some(3600),
+            "replacement key must inherit the original rotate_interval"
+        );
+
+        Ok(())
+    }
+
+    /// Verify that `dispatch_renewal_warnings` deduplicates: the same threshold must
+    /// only emit once across consecutive cron ticks, and a different (more urgent)
+    /// threshold must emit when the deadline draws nearer.
+    #[tokio::test]
+    async fn test_renewal_warning_deduplication() -> KResult<()> {
+        let kms = test_kms().await?;
+        let owner = "warning_dedup_test@example.com";
+        let now = time::OffsetDateTime::now_utc();
+
+        // Create a key due in 5 days — matches the 7-day threshold.
+        let uid = uuid::Uuid::new_v4().to_string();
+        let key_object = make_aes256_key();
+        let key_attrs = Attributes {
+            cryptographic_algorithm: Some(CryptographicAlgorithm::AES),
+            state: Some(State::Active),
+            rotate_automatic: Some(true),
+            rotate_interval: Some(7 * 86_400), // 7 days
+            initial_date: Some(now - time::Duration::days(2)), // 2 days ago → due in 5 days
+            ..Default::default()
+        };
+        kms.database
+            .create(
+                Some(uid.clone()),
+                owner,
+                &key_object,
+                &key_attrs,
+                &HashSet::new(),
+            )
+            .await
+            .map_err(|e| crate::error::KmsError::ServerError(e.to_string()))?;
+
+        let mut warned = std::collections::HashMap::new();
+
+        // First call: warning must be emitted and recorded in `warned`.
+        dispatch_renewal_warnings(&kms, &mut warned).await;
+        assert_eq!(
+            warned.get(uid.as_str()).copied(),
+            Some(7),
+            "warned map must record threshold 7 after the first call"
+        );
+
+        // Second call at the same threshold: must be deduplicated — `warned` stays unchanged.
+        dispatch_renewal_warnings(&kms, &mut warned).await;
+        assert_eq!(
+            warned.get(uid.as_str()).copied(),
+            Some(7),
+            "warned map must remain at threshold 7 (dedup suppressed second warning)"
+        );
+
+        // Manually advance to within 1 day by updating initial_date.
+        let owm = kms
+            .database
+            .retrieve_object(&uid)
+            .await
+            .map_err(|e| crate::error::KmsError::ServerError(e.to_string()))?
+            .expect("key must exist");
+        let mut attrs_1d = owm.attributes().clone();
+        attrs_1d.initial_date = Some(now - time::Duration::days(6)); // due in 1 day
+        kms.database
+            .update_object(&uid, owm.object(), &attrs_1d, None)
+            .await
+            .map_err(|e| crate::error::KmsError::ServerError(e.to_string()))?;
+
+        // Third call: a more urgent threshold (1 day) must fire and update `warned`.
+        dispatch_renewal_warnings(&kms, &mut warned).await;
+        assert_eq!(
+            warned.get(uid.as_str()).copied(),
+            Some(1),
+            "warned map must update to threshold 1 when a more urgent threshold fires"
+        );
+
+        Ok(())
+    }
+
+    /// Verify that the private key generated by the `Certify` operation (the "generate key pair
+    /// and issue a certificate" path) has `initial_date` set so that the auto-rotation scheduler
+    /// can compute the first rotation deadline after the user calls `SetAttribute RotateInterval`.
+    ///
+    /// Regression test: without the fix, `certify_op.rs` stored the generated key pair via
+    /// `AtomicOperation::Upsert` without calling `setup_with_lifecycle()`, leaving
+    /// `initial_date = None`.  `is_due_for_rotation` then returned `false` immediately because
+    /// neither `rotate_date` nor `initial_date` was set, so the scheduler silently skipped the
+    /// key forever.
+    #[tokio::test]
+    async fn test_auto_rotation_keypair_from_certify_flow() -> KResult<()> {
+        use cosmian_kms_server_database::reexport::cosmian_kmip::kmip_2_1::{
+            kmip_attributes::Attribute,
+            kmip_operations::Certify,
+            kmip_types::{CertificateAttributes, CryptographicAlgorithm, LinkType},
+        };
+
+        let kms = test_kms().await?;
+        let owner = "certify_keypair_rotation_test@example.com";
+
+        // Create a self-signed RSA certificate via Certify — this also creates a fresh RSA
+        // keypair internally (the `Subject::KeypairAndSubjectName` code path).
+        let certify_req = Certify {
+            attributes: Some(Attributes {
+                cryptographic_algorithm: Some(CryptographicAlgorithm::RSA),
+                cryptographic_length: Some(2048),
+                certificate_attributes: Some(CertificateAttributes::parse_subject_line(
+                    "CN=keypair-rotation-test",
+                )?),
+                ..Attributes::default()
+            }),
+            ..Certify::default()
+        };
+        let cert_id = kms
+            .certify(certify_req, owner)
+            .await?
+            .unique_identifier
+            .to_string();
+
+        // Follow PrivateKeyLink to get the private key UID.
+        let cert_owm = kms
+            .database
+            .retrieve_object(&cert_id)
+            .await
+            .map_err(|e| crate::error::KmsError::ServerError(e.to_string()))?
+            .expect("certificate must exist after Certify");
+        let sk_uid = cert_owm
+            .attributes()
+            .link
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .find(|lnk| lnk.link_type == LinkType::PrivateKeyLink)
+            .map(|lnk| lnk.linked_object_identifier.to_string())
+            .expect("certificate must have a PrivateKeyLink");
+
+        // Regression: the private key must have `initial_date` set so the scheduler can compute
+        // the first rotation deadline without any manual override.
+        let sk_owm = kms
+            .database
+            .retrieve_object(&sk_uid)
+            .await
+            .map_err(|e| crate::error::KmsError::ServerError(e.to_string()))?
+            .expect("private key must exist after Certify");
+        assert!(
+            sk_owm.attributes().initial_date.is_some(),
+            "Certify must set initial_date on the generated private key so the scheduler can \
+             compute the first rotation deadline (regression: setup_with_lifecycle was never \
+             called in certify_op.rs)"
+        );
+
+        // Set RotateInterval on the private key — this implicitly enables auto-rotation
+        // (rotate_automatic = true) and sets rotate_name.
+        set_attribute(
+            &kms,
+            SetAttribute {
+                unique_identifier: Some(UniqueIdentifier::TextString(sk_uid.clone())),
+                new_attribute: Attribute::RotateInterval(3600),
+            },
+            owner,
+        )
+        .await?;
+
+        // Confirm the key appears in find_due_for_rotation at now + 2 h
+        // (initial_date ≈ now, interval = 1 h → next rotation ≈ now + 1 h < now + 2 h).
+        let horizon = time::OffsetDateTime::now_utc() + time::Duration::hours(2);
+        let due = kms
+            .database
+            .find_due_for_rotation(horizon)
+            .await
+            .map_err(|e| crate::error::KmsError::ServerError(e.to_string()))?;
+        assert!(
+            due.iter().any(|(uid, _)| uid == &sk_uid),
+            "private key from Certify flow must appear in find_due_for_rotation after \
+             SetAttribute RotateInterval"
+        );
+
+        // Make the key immediately overdue so run_auto_rotation (which uses now internally)
+        // will pick it up.  Backdate initial_date to 2 h ago — the same pattern used by
+        // test_auto_rotation_rotates_due_certificate and similar tests.
+        let sk_owm2 = kms
+            .database
+            .retrieve_object(&sk_uid)
+            .await
+            .map_err(|e| crate::error::KmsError::ServerError(e.to_string()))?
+            .expect("private key must still exist");
+        let mut overdue_attrs = sk_owm2.attributes().clone();
+        overdue_attrs.initial_date =
+            Some(time::OffsetDateTime::now_utc() - time::Duration::hours(2));
+        kms.database
+            .update_object(&sk_uid, sk_owm2.object(), &overdue_attrs, None)
+            .await
+            .map_err(|e| crate::error::KmsError::ServerError(e.to_string()))?;
+
+        // Trigger auto-rotation: the scheduler must issue a ReKeyKeyPair.
+        run_auto_rotation(&kms).await;
+
+        // The original private key must be Deactivated after rotation.
+        let updated_sk = kms
+            .database
+            .retrieve_object(&sk_uid)
+            .await
+            .map_err(|e| crate::error::KmsError::ServerError(e.to_string()))?
+            .expect("private key must still exist after auto-rotation");
+        assert_eq!(
+            updated_sk.state(),
+            State::Deactivated,
+            "private key from Certify flow must be Deactivated after auto-rotation"
+        );
+
+        Ok(())
+    }
+
+    /// Verify that a certificate enrolled in a keyset follows the documented `@N` UID scheme
+    /// (`cert-id@1`, `cert-id@2`, …) on each successive auto-rotation, matching the symmetric
+    /// and key-pair keyset UID scheme.
+    #[tokio::test]
+    async fn test_recertify_keyset_uid_scheme() -> KResult<()> {
+        use cosmian_kms_server_database::reexport::cosmian_kmip::kmip_2_1::{
+            kmip_operations::Certify,
+            kmip_types::{
+                CertificateAttributes, CryptographicDomainParameters, LinkType, RecommendedCurve,
+            },
+        };
+
+        let kms = test_kms().await?;
+        let owner = "keyset_cert_uid_test@example.com";
+        let now = time::OffsetDateTime::now_utc();
+
+        // Issue a self-signed EC certificate; its auto-assigned UID becomes the keyset name.
+        let certify_req = Certify {
+            attributes: Some(Attributes {
+                cryptographic_algorithm: Some(CryptographicAlgorithm::ECDSA),
+                cryptographic_domain_parameters: Some(CryptographicDomainParameters {
+                    recommended_curve: Some(RecommendedCurve::P256),
+                    ..CryptographicDomainParameters::default()
+                }),
+                certificate_attributes: Some(CertificateAttributes::parse_subject_line(
+                    "CN=keyset-uid-test",
+                )?),
+                ..Attributes::default()
+            }),
+            ..Certify::default()
+        };
+        let cert_id = kms
+            .certify(certify_req, owner)
+            .await?
+            .unique_identifier
+            .to_string();
+
+        // Enroll the certificate in a keyset and make it immediately overdue.
+        let owm = kms
+            .database
+            .retrieve_object(&cert_id)
+            .await
+            .map_err(|e| crate::error::KmsError::ServerError(e.to_string()))?
+            .expect("certificate must exist after Certify");
+        let mut attrs = owm.attributes().clone();
+        attrs.rotate_name = Some(cert_id.clone()); // keyset name = cert UID (gen 0 invariant)
+        attrs.rotate_automatic = Some(true);
+        attrs.rotate_interval = Some(3600); // 1 hour
+        attrs.initial_date = Some(now - time::Duration::hours(2)); // overdue
+        kms.database
+            .update_object(&cert_id, owm.object(), &attrs, None)
+            .await
+            .map_err(|e| crate::error::KmsError::ServerError(e.to_string()))?;
+
+        // First auto-rotation — new UID must be `{cert_id}@1`.
+        run_auto_rotation(&kms).await;
+
+        let gen0_owm = kms
+            .database
+            .retrieve_object(&cert_id)
+            .await
+            .map_err(|e| crate::error::KmsError::ServerError(e.to_string()))?
+            .expect("gen-0 cert must still exist after rotation");
+        assert_eq!(
+            gen0_owm.state(),
+            State::Deactivated,
+            "gen-0 certificate must be Deactivated after auto-rotation"
+        );
+
+        let gen1_uid = gen0_owm
+            .attributes()
+            .link
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .find(|lnk| lnk.link_type == LinkType::ReplacementObjectLink)
+            .map(|lnk| lnk.linked_object_identifier.to_string())
+            .expect("gen-0 cert must have a ReplacementObjectLink");
+        assert_eq!(
+            gen1_uid,
+            format!("{cert_id}@1"),
+            "first rotation must produce UID '{cert_id}@1'"
+        );
+
+        // Verify gen-1 attributes.
+        let gen1_owm = kms
+            .database
+            .retrieve_object(&gen1_uid)
+            .await
+            .map_err(|e| crate::error::KmsError::ServerError(e.to_string()))?
+            .expect("gen-1 cert must exist");
+        let gen1_attrs = gen1_owm.attributes();
+        assert_eq!(
+            gen1_attrs.rotate_name.as_deref(),
+            Some(cert_id.as_str()),
+            "gen-1 cert must inherit rotate_name"
+        );
+        assert_eq!(
+            gen1_attrs.rotate_generation,
+            Some(1),
+            "gen-1 cert must have rotate_generation = 1"
+        );
+
+        Ok(())
+    }
 }

--- a/crate/server/src/core/operations/certify/build_certificate.rs
+++ b/crate/server/src/core/operations/certify/build_certificate.rs
@@ -3,12 +3,15 @@ use std::{cmp::min, collections::HashSet, default::Default};
 #[cfg(feature = "non-fips")]
 use cosmian_kms_server_database::reexport::cosmian_kmip::kmip_2_1::kmip_types::CryptographicAlgorithm;
 use cosmian_kms_server_database::reexport::{
-    cosmian_kmip::kmip_2_1::{
-        extra::{VENDOR_ATTR_X509_EXTENSION, tagging::SYSTEM_TAG_CERTIFICATE},
-        kmip_attributes::Attributes,
-        kmip_objects::{Object, ObjectType},
-        kmip_operations::Certify,
-        kmip_types::{KeyFormatType, LinkType, VendorAttributeValue},
+    cosmian_kmip::{
+        kmip_2_1::{
+            extra::{VENDOR_ATTR_X509_EXTENSION, tagging::SYSTEM_TAG_CERTIFICATE},
+            kmip_attributes::Attributes,
+            kmip_objects::{Object, ObjectType},
+            kmip_operations::Certify,
+            kmip_types::{KeyFormatType, LinkType, VendorAttributeValue},
+        },
+        time_normalize,
     },
     cosmian_kms_crypto::openssl::{
         openssl_certificate_to_kmip, openssl_x509_to_certificate_attributes, x509_extensions,
@@ -147,6 +150,11 @@ pub(crate) fn build_and_sign_certificate(
     // Add certificate attributes
     let certificate_attributes = openssl_x509_to_certificate_attributes(&x509);
     attributes.certificate_attributes = Some(certificate_attributes);
+
+    // KMIP §4.48 / §4.51: set initial_date so the auto-rotation scheduler can
+    // compute the first rotation deadline via `initial_date + rotate_offset + interval`
+    // without requiring a prior `rotate_date` (which is only set after the first rotation).
+    attributes.initial_date = Some(time_normalize()?);
 
     Ok((
         openssl_certificate_to_kmip(&x509).map_err(KmsError::from)?,

--- a/crate/server/src/core/operations/certify/certify_op.rs
+++ b/crate/server/src/core/operations/certify/certify_op.rs
@@ -2,6 +2,7 @@ use cosmian_kms_server_database::reexport::{
     cosmian_kmip::{
         kmip_0::kmip_types::State,
         kmip_2_1::{
+            kmip_objects::ObjectType,
             kmip_operations::{Certify, CertifyResponse},
             kmip_types::{LinkType, LinkedObjectIdentifier},
         },
@@ -14,7 +15,12 @@ use super::{
     build_certificate::build_and_sign_certificate, resolve_issuer::get_issuer,
     resolve_subject::get_subject, subject::Subject,
 };
-use crate::{core::KMS, error::KmsError, kms_bail, result::KResult};
+use crate::{
+    core::{KMS, operations::key_ops::ObjectLifecycleExt},
+    error::KmsError,
+    kms_bail,
+    result::KResult,
+};
 
 /// Certify a certificate.
 /// This operation is used to issue a certificate based on a public key, a CSR or a key pair.
@@ -99,6 +105,19 @@ pub(crate) async fn certify(kms: &KMS, request: Certify, user: &str) -> KResult<
             trace!(
                 "Certify KeypairAndSubjectName:{unique_identifier} : keypair data: {keypair_data}"
             );
+            // Initialise lifecycle attributes (state, initial_date, activation_date, digest)
+            // on both keys.  Without this call, `initial_date` is `None` in the stored
+            // `attributes_json`, which causes `is_due_for_rotation` to return `false`
+            // forever — the auto-rotation scheduler silently skips the key.
+            // Pass `Some(now)` so the embedded state matches the `State::Active` value
+            // supplied to `AtomicOperation::Upsert` below.
+            let now = time::OffsetDateTime::now_utc();
+            keypair_data
+                .private_key_object
+                .setup_with_lifecycle(ObjectType::PrivateKey, Some(now))?;
+            keypair_data
+                .public_key_object
+                .setup_with_lifecycle(ObjectType::PublicKey, Some(now))?;
             // update the private key attributes with the public key identifier
             keypair_data.private_key_object.attributes_mut()?.set_link(
                 LinkType::PublicKeyLink,

--- a/crate/server/src/core/operations/recertify.rs
+++ b/crate/server/src/core/operations/recertify.rs
@@ -5,9 +5,10 @@
 //! `ReCertify` creates a **new certificate with a fresh UID** and links it to the
 //! old certificate via `ReplacedObject` / `ReplacementObject` links.
 //!
-//! The old certificate remains Active but is marked with a `ReplacementObjectLink`
-//! pointing to the new certificate. Keys linked to the old certificate are updated
-//! to point to the new certificate via their `CertificateLink`.
+//! The old certificate is marked `Deactivated` (KMIP §4.57 transition 6) and
+//! receives a `ReplacementObjectLink` pointing to the new certificate. Keys linked
+//! to the old certificate are updated to point to the new certificate via their
+//! `CertificateLink`.
 
 use cosmian_kms_server_database::reexport::{
     cosmian_kmip::{
@@ -151,8 +152,14 @@ impl RekeyOperation for CertificateRekey {
         candidates: &[RotationCandidate; 1],
     ) -> KResult<[ReplacementObject; 1]> {
         let [candidate] = candidates;
-        // Certificates are never members of a named keyset — always use a fresh UUID.
-        let new_uid = UniqueIdentifier::rotation_successor(None, None);
+        // Derive the new UID: if the certificate is enrolled in a keyset
+        // (`rotate_name` is set), follow the SQL keyset UID scheme (`name@N`);
+        // otherwise generate a fresh UUID.
+        let old_attrs = candidate.owm.attributes();
+        let new_uid = UniqueIdentifier::rotation_successor(
+            old_attrs.rotate_name.as_deref(),
+            old_attrs.rotate_generation,
+        );
 
         // Build a Certify request that references the existing certificate for renewal.
         // We pass the old certificate's UID so `get_subject` produces a `Subject::Certificate`.
@@ -294,12 +301,19 @@ impl RekeyOperation for CertificateRekey {
             obj_attrs.retire_for_replacement(&replacement.new_uid)?;
         }
 
-        let mut operations = vec![AtomicOperation::UpdateObject((
-            candidate.uid.clone(),
-            old_object,
-            old_attributes,
-            None,
-        ))];
+        let mut operations = vec![
+            AtomicOperation::UpdateObject((
+                candidate.uid.clone(),
+                old_object,
+                old_attributes,
+                None,
+            )),
+            // KMIP §4.57 transition 6: old certificate becomes Deactivated after ReCertify.
+            // UpdateObject alone only rewrites the `attributes` JSON column; the `state`
+            // column must be updated separately so that subsequent queries (including
+            // `find_due_for_rotation`) see the correct lifecycle state.
+            AtomicOperation::UpdateState((candidate.uid.clone(), State::Deactivated)),
+        ];
 
         // Relink keys: update CertificateLink on linked PK/SK to point to new cert UID
         relink_keys_to_new_certificate(

--- a/crate/server/src/core/otel_metrics.rs
+++ b/crate/server/src/core/otel_metrics.rs
@@ -136,6 +136,16 @@ pub struct OtelMetrics {
 
     /// HSM operation counts (if HSM is enabled)
     pub hsm_operations_total: Counter<u64>,
+
+    /// Count of automatic key rotations triggered by the background scheduler.
+    ///
+    /// Labelled with `uid`, `algorithm`, and `outcome` (`"success"` / `"failure"`).
+    pub key_auto_rotation_total: Counter<u64>,
+
+    /// Count of rotation renewal warnings emitted by the background scheduler.
+    ///
+    /// Labelled with `uid`, `algorithm`, and `threshold` (1, 7, or 30 days).
+    pub key_rotation_warning_total: Counter<u64>,
 }
 
 impl OtelMetrics {
@@ -282,6 +292,20 @@ impl OtelMetrics {
             "Total number of HSM operations",
             "{operation}"
         );
+        let key_auto_rotation_total = metric!(
+            meter,
+            u64_counter,
+            "kms.key.auto_rotation",
+            "Total number of automatic key rotations triggered by the background scheduler",
+            "{rotation}"
+        );
+        let key_rotation_warning_total = metric!(
+            meter,
+            u64_counter,
+            "kms.key.rotation_warning",
+            "Total number of rotation renewal warnings emitted by the background scheduler",
+            "{warning}"
+        );
 
         // Seed server start time on startup
         let start_time = std::time::SystemTime::now()
@@ -317,6 +341,8 @@ impl OtelMetrics {
             active_keys_count,
             cache_operations_total,
             hsm_operations_total,
+            key_auto_rotation_total,
+            key_rotation_warning_total,
         })
     }
 
@@ -523,6 +549,38 @@ impl OtelMetrics {
             &[
                 KeyValue::new("operation", operation),
                 KeyValue::new("result", result),
+            ],
+        );
+    }
+
+    /// Record an automatic key rotation attempt.
+    ///
+    /// - `uid` — the key being rotated (high cardinality; use with care)
+    /// - `algorithm` — cryptographic algorithm label (e.g. `"Aes"`, `"Rsa"`)
+    /// - `outcome` — `"success"` or `"failure"`
+    pub fn record_key_auto_rotation(&self, uid: &str, algorithm: &str, outcome: &str) {
+        self.key_auto_rotation_total.add(
+            1,
+            &[
+                KeyValue::new("uid", uid.to_owned()),
+                KeyValue::new("algorithm", algorithm.to_owned()),
+                KeyValue::new("outcome", outcome.to_owned()),
+            ],
+        );
+    }
+
+    /// Record a rotation renewal warning.
+    ///
+    /// - `uid` — the key approaching its rotation deadline
+    /// - `algorithm` — cryptographic algorithm label (e.g. `"Aes"`, `"Rsa"`)
+    /// - `threshold` — the warning threshold that was matched (1, 7, or 30 days)
+    pub fn record_rotation_warning(&self, uid: &str, algorithm: &str, threshold: i64) {
+        self.key_rotation_warning_total.add(
+            1,
+            &[
+                KeyValue::new("uid", uid.to_owned()),
+                KeyValue::new("algorithm", algorithm.to_owned()),
+                KeyValue::new("threshold_days", threshold.to_string()),
             ],
         );
     }

--- a/crate/server/src/cron.rs
+++ b/crate/server/src/cron.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use cosmian_logger::debug;
 use tokio::sync::oneshot;
@@ -31,13 +31,14 @@ pub fn spawn_auto_rotation_cron(kms: Arc<KMS>) -> oneshot::Sender<()> {
 
         rt.block_on(async move {
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(interval_secs));
+            let mut warned: HashMap<String, i64> = HashMap::new();
             let mut shutdown_rx = shutdown_rx;
             loop {
                 tokio::select! {
                     _ = interval.tick() => {
                         debug!("[auto-rotate-cron] Running scheduled key auto-rotation check");
                         run_auto_rotation(&kms).await;
-                        dispatch_renewal_warnings(&kms).await;
+                        dispatch_renewal_warnings(&kms, &mut warned).await;
                     }
                     _ = &mut shutdown_rx => {
                         debug!("[auto-rotate-cron] Shutdown signal received; stopping cron thread");

--- a/documentation/docs/adr/0002-key-auto-rotation-keyset-chain-design.md
+++ b/documentation/docs/adr/0002-key-auto-rotation-keyset-chain-design.md
@@ -2,6 +2,7 @@
 title: "ADR-0002: KMIP-Compliant Key Auto-Rotation with Keyset Chain Design"
 status: "Accepted"
 date: "2026-06-21"
+updated: "2026-06-30"
 authors: "contributors, security architects, HSM operators"
 tags: ["architecture", "decision", "cryptography", "kmip", "key-management"]
 supersedes: ""
@@ -138,14 +139,22 @@ No response header is added to the client response.
 
 `cron.rs` (`spawn_auto_rotation_cron`) spawns a dedicated native thread that owns a single-
 threaded Tokio runtime. On each tick (driven by `tokio::time::interval`) it calls
-`run_auto_rotation(kms)`, which queries `find_due_for_rotation(now)` and dispatches a
-`Re-Key` or `Re-Key Key Pair` for each due UID. The thread is started only when
-`auto_rotation_check_interval_secs > 0` (disabled by default); the minimum allowed interval
-is 60 s.
+`run_auto_rotation(kms)`, which queries `find_due_for_rotation(now)` and dispatches the
+appropriate KMIP rotation operation for each due UID:
 
-The cron wiring and scheduler infrastructure are fully implemented. The rotation dispatch
-inside `run_auto_rotation` (i.e. triggering the actual `Re-Key` operation per UID) is
-marked as a TODO stub and is not yet implemented.
+| `object_type` | Operation dispatched |
+|---|---|
+| `SymmetricKey` | `ReKey` → `rekey()` |
+| `PrivateKey` | `ReKeyKeyPair` → `rekey_keypair()` |
+| `Certificate` | `ReCertify` → `recertify()` |
+| `PublicKey` | Skipped — rotated atomically as a side-effect of its paired `PrivateKey` rotation |
+| All other types | Skipped — no KMIP rotation operation exists for these types |
+
+All three async dispatch branches (`rekey`, `rekey_keypair`, `recertify`) are wrapped with
+`Box::pin(…).await` to bound the generated future size and satisfy `clippy::large_futures`.
+
+The thread is started only when `auto_rotation_check_interval_secs > 0` (disabled by default);
+the minimum allowed interval is 60 s.
 
 ### 7 — Security guardrails enforced server-side
 
@@ -193,6 +202,11 @@ marked as a TODO stub and is not yet implemented.
   server.
 - **NEG-004**: HSM `rotate_offset` is not supported (HSM rotation scheduling uses
   `CKA_START_DATE`/`CKA_END_DATE`); attempting to set it returns `NotSupported`.
+- **NEG-005**: Certificate auto-rotation via `run_auto_rotation` uses the cert's stored
+  `PrivateKeyLink` as the issuer signing key. For CA-signed certificates this is the
+  subject's private key, not the issuer CA key. The self-signed case is handled correctly;
+  CA-signed auto-rotation produces a self-signed replacement and is a known limitation. Operators
+  who require true CA-chain renewal must invoke `ReCertify` directly with explicit issuer links.
 
 ## Alternatives Considered
 
@@ -245,6 +259,12 @@ marked as a TODO stub and is not yet implemented.
 - **IMP-004**: HSM keyset recovery after a `Re-Key` crash must update `CKA_LABEL` on both the
   old key (strip `::latest` suffix if present) and the new key; key ordering relies on the
   parsed `rotate_generation` integer in the label, not the `::latest` suffix.
+- **IMP-005**: `CertificateRekey::finalize_dependants` must issue both an
+  `AtomicOperation::UpdateObject` (to persist `ReplacementObjectLink` and `deactivation_date`
+  in the attributes JSON column) **and** an `AtomicOperation::UpdateState(Deactivated)` (to
+  update the separate `state` column). Omitting the latter leaves the old certificate `Active`
+  in SQL queries that filter on the `state` column — notably `find_due_for_rotation` — causing
+  the scheduler to attempt repeated re-certification of an already-rotated certificate.
 
 ## References
 
@@ -268,3 +288,7 @@ marked as a TODO stub and is not yet implemented.
 - **REF-009**: PKCS#11 specification v2.40 — `CKA_LABEL`, `CKA_START_DATE`, `CKA_END_DATE`
 - **REF-010**: PR #968 — auto-rotation feature implementation
   (`https://github.com/Cosmian/kms/pull/968`)
+- **REF-011**: Auto-rotation scheduler dispatch
+  (`crate/server/src/core/operations/auto_rotate.rs`)
+- **REF-012**: `ReCertify` rotation implementation and `Deactivated`-state fix
+  (`crate/server/src/core/operations/recertify.rs`)

--- a/documentation/docs/configuration/log-reference.md
+++ b/documentation/docs/configuration/log-reference.md
@@ -548,9 +548,6 @@ Crate path: `crate/server`
 | `debug` | `[auto-rotate-cron] Failed to build runtime: {}` | `src/cron.rs` | - | - |
 | `debug` | `[auto-rotate-cron] Running scheduled key auto-rotation check` | `src/cron.rs` | - | - |
 | `debug` | `[auto-rotate-cron] Shutdown signal received; stopping cron thread` | `src/cron.rs` | - | - |
-| `debug` | `[auto-rotate] Failed to query keys due for rotation: {e}` | `src/core/operations/auto_rotate.rs` | `e` | - |
-| `debug` | `[auto-rotate] Found {} key(s) due for rotation` | `src/core/operations/auto_rotate.rs` | - | - |
-| `debug` | `[auto-rotate] Renewal-warning dispatch complete (no-op stub)` | `src/core/operations/auto_rotate.rs` | - | - |
 | `trace` | `Auto-deactivating object {} (deactivation_date {} <= now {})` | `src/core/retrieve_object_utils.rs` | - | ×2 in this file |
 | `trace` | `execute_keyset_try_each: key {} failed for {}: {}` | `src/core/operations/key_ops/crypto_op.rs` | - | - |
 | `trace` | `HSM ReKey: old={uid} → new={new_uid} (slot={slot_id}, gen={new_gen}), user={user}` | `src/core/operations/rekey/symmetric/hsm.rs` | `uid`, `new_uid`, `slot_id`, `new_gen`, `user` | - |
@@ -594,8 +591,22 @@ Crate path: `crate/server`
 | `trace` | `` PKCS#11 `C_WrapKey` not yet implemented `` | `src/core/operations/pkcs11.rs` | - | - |
 | `trace` | `ReKeyKeyPair: resolved keyset ref '{}' → '{}'` | `src/core/operations/rekey/keypair/mod.rs` | - | - |
 | `info` | `KMS HTTP server configured with {n} worker thread(s)` | `src/start_kms_server.rs` | `n` | - |
-| `debug` | `[auto-rotate] Rotating key {uid} (owner={owner})` | `src/core/operations/auto_rotate.rs` | `uid`, `owner` | - |
 | `warn` | `find_wrapped_by({old_uid}) failed — skipping re-wrap of dependants: {e}` | `src/core/operations/rekey/common.rs` | `old_uid`, `e` | - |
+| `warn` | `[auto-rotate] Failed to query keys due for rotation: {e}` | `src/core/operations/auto_rotate.rs` | `e` | - |
+| `warn` | `[auto-rotate] Failed to re-arm rotation policy on replacement {new_uid}: {e}` | `src/core/operations/auto_rotate.rs` | `new_uid`, `e` | - |
+| `warn` | `[auto-rotate] Failed to retrieve key {uid}: {e}; skipping` | `src/core/operations/auto_rotate.rs` | `uid`, `e` | - |
+| `warn` | `[auto-rotate] Failed to rotate key {uid} (owner={owner}): {e}` | `src/core/operations/auto_rotate.rs` | `uid`, `owner`, `e` | - |
+| `warn` | `[auto-rotate] Key {uid} not found; skipping` | `src/core/operations/auto_rotate.rs` | `uid` | - |
+| `info` | `[auto-rotate] Found {} key(s) due for rotation` | `src/core/operations/auto_rotate.rs` | - | - |
+| `info` | `[auto-rotate] Key {uid} (owner={owner}) rotation due in {days} day(s)              (warning threshold: {threshold} days)` | `src/core/operations/auto_rotate.rs` | `uid`, `owner`, `days`, `threshold` | - |
+| `info` | `[auto-rotate] Key {uid} (owner={owner}, algo={algorithm}) rotated successfully` | `src/core/operations/auto_rotate.rs` | `uid`, `owner`, `algorithm` | - |
+| `debug` | `[auto-rotate] Failed to query keys for renewal warnings: {e}` | `src/core/operations/auto_rotate.rs` | `e` | - |
+| `debug` | `[auto-rotate] No keys due for rotation at {now}` | `src/core/operations/auto_rotate.rs` | `now` | - |
+| `debug` | `[auto-rotate] rotate_one_key returned: {e}` | `src/core/operations/auto_rotate.rs` | `e` | - |
+| `debug` | `[auto-rotate] Skipping HSM key {uid}` | `src/core/operations/auto_rotate.rs` | `uid` | - |
+| `debug` | `[auto-rotate] Skipping {uid}: object type {other:?} has no auto-rotation support` | `src/core/operations/auto_rotate.rs` | `uid`, `other` | - |
+| `debug` | `[auto-rotate] Skipping {uid}: PublicKey is rotated as part of its paired                  PrivateKey rotation` | `src/core/operations/auto_rotate.rs` | `uid` | - |
+| `debug` | `SetAttribute: implicitly enabling rotate_automatic for key '{}' (RotateInterval > 0 with no explicit RotateAutomatic)` | `src/core/operations/attributes/set.rs` | - | - |
 
 ### `cosmian_kms_server_database`
 

--- a/ui/src/actions/Certificates/CertificateCertify.tsx
+++ b/ui/src/actions/Certificates/CertificateCertify.tsx
@@ -1,4 +1,4 @@
-import { Button, Card, Checkbox, Form, Input, Radio, RadioChangeEvent, Select, Space } from "antd";
+import { Button, Card, Checkbox, Divider, Form, Input, InputNumber, Radio, RadioChangeEvent, Select, Space } from "antd";
 import React, { useEffect, useState } from "react";
 import { ActionResponse } from "../../components/common/ActionResponse";
 import { FormUploadDragger } from "../../components/common/FormUpload";
@@ -20,6 +20,9 @@ interface CertificateCertifyFormData {
     numberOfDays: number;
     certificateExtensions?: Uint8Array;
     tags: string[];
+    enrollKeyset: boolean;
+    rotateInterval?: number;
+    rotateOffset?: number;
 }
 
 type AlgoOption = { label: string; value: string };
@@ -78,7 +81,20 @@ const CertificateCertifyForm: React.FC = () => {
                 const result_str = await sendKmipRequest(request, idToken, serverUrl);
                 if (result_str) {
                     const response = await wasm.parse_re_certify_ttlv_response(result_str);
-                    return `Certificate successfully re-certified with new ID: ${response.UniqueIdentifier}`;
+                    const newCertId = response.UniqueIdentifier;
+                    if (values.enrollKeyset) {
+                        const req = wasm.set_rotate_name_ttlv_request(newCertId, newCertId);
+                        await sendKmipRequest(req, idToken, serverUrl);
+                    }
+                    if (values.enrollKeyset && values.rotateInterval !== undefined) {
+                        const req = wasm.set_rotate_interval_ttlv_request(newCertId, BigInt(values.rotateInterval));
+                        await sendKmipRequest(req, idToken, serverUrl);
+                    }
+                    if (values.enrollKeyset && values.rotateOffset !== undefined) {
+                        const req = wasm.set_rotate_offset_ttlv_request(newCertId, BigInt(values.rotateOffset));
+                        await sendKmipRequest(req, idToken, serverUrl);
+                    }
+                    return `Certificate successfully re-certified with new ID: ${newCertId}`;
                 }
                 return;
             }
@@ -101,7 +117,20 @@ const CertificateCertifyForm: React.FC = () => {
             const result_str = await sendKmipRequest(request, idToken, serverUrl);
             if (result_str) {
                 const response = await wasm.parse_certify_ttlv_response(result_str);
-                return `Certificate successfully created with ID: ${response.UniqueIdentifier}`;
+                const newCertId = response.UniqueIdentifier;
+                if (values.enrollKeyset) {
+                    const req = wasm.set_rotate_name_ttlv_request(newCertId, newCertId);
+                    await sendKmipRequest(req, idToken, serverUrl);
+                }
+                if (values.enrollKeyset && values.rotateInterval !== undefined) {
+                    const req = wasm.set_rotate_interval_ttlv_request(newCertId, BigInt(values.rotateInterval));
+                    await sendKmipRequest(req, idToken, serverUrl);
+                }
+                if (values.enrollKeyset && values.rotateOffset !== undefined) {
+                    const req = wasm.set_rotate_offset_ttlv_request(newCertId, BigInt(values.rotateOffset));
+                    await sendKmipRequest(req, idToken, serverUrl);
+                }
+                return `Certificate successfully created with ID: ${newCertId}`;
             }
         });
     };
@@ -130,6 +159,7 @@ const CertificateCertifyForm: React.FC = () => {
                     numberOfDays: 365,
                     generateKeyPair: false,
                     tags: [],
+                    enrollKeyset: false,
                 }}
             >
                 <Space direction="vertical" size="middle" style={{ display: "flex" }}>
@@ -306,6 +336,52 @@ const CertificateCertifyForm: React.FC = () => {
 
                         <Form.Item name="tags" label="Tags" help="Tags to associate with the certificate (optional)">
                             <Select mode="tags" placeholder="Enter tags" open={false} />
+                        </Form.Item>
+
+                        <Divider orientation="left" plain>
+                            Rotation Policy (optional)
+                        </Divider>
+
+                        <Form.Item
+                            name="enrollKeyset"
+                            valuePropName="checked"
+                            help="When enabled, sets the rotation name to the certificate ID so this certificate can be addressed via name@latest, name@first, name@N syntax. Also configures the rotation interval and offset below."
+                        >
+                            <Checkbox data-testid="cert-enroll-keyset">Enroll in keyset (rotation name = certificate ID)</Checkbox>
+                        </Form.Item>
+
+                        <Form.Item noStyle shouldUpdate={(prev, curr) => prev.enrollKeyset !== curr.enrollKeyset}>
+                            {({ getFieldValue }) =>
+                                getFieldValue("enrollKeyset") ? (
+                                    <>
+                                        <Form.Item
+                                            name="rotateInterval"
+                                            label="Rotation Interval (seconds)"
+                                            help="Auto-rotate the certificate every N seconds (e.g. 7776000 = 90 days)."
+                                        >
+                                            <InputNumber
+                                                className="w-[200px]"
+                                                min={1}
+                                                placeholder="e.g. 7776000"
+                                                data-testid="cert-rotation-interval"
+                                            />
+                                        </Form.Item>
+
+                                        <Form.Item
+                                            name="rotateOffset"
+                                            label="Rotation Offset (seconds)"
+                                            help="Delay before the first rotation occurs (optional)."
+                                        >
+                                            <InputNumber
+                                                className="w-[200px]"
+                                                min={0}
+                                                placeholder="e.g. 3600"
+                                                data-testid="cert-rotation-offset"
+                                            />
+                                        </Form.Item>
+                                    </>
+                                ) : null
+                            }
                         </Form.Item>
                     </Card>
 


### PR DESCRIPTION
- add scheduler to monitor key to rotate
- when creating new cert, fix public/private key lifecycle 
- certs benefit now of the keyset feature