### PR TITLE
fix: clean docs

### DIFF
--- a/crate/server/README.md
+++ b/crate/server/README.md
@@ -20,20 +20,17 @@ The KMS server is a high-performance, FIPS 140-3 compliant server application th
 ### Security Features
 
 - **FIPS 140-3 Compliance**: Certified cryptographic modules
-- **Multi-Factor Authentication**: Support for various authentication methods
-- **Access Control**: Fine-grained permissions and role-based access
-- **Audit Logging**: Comprehensive logging of all operations
 - **HSM Integration**: Hardware Security Module support
 
 ### Compilation Features
 
 The KMS server provides several features which can be enabled at compilation time:
 
-| Feature    | Description                                                                                                         | Development | Production |
-| ---------- | ------------------------------------------------------------------------------------------------------------------- | ----------- | ---------- |
-| `non-fips` | Enable non-FIPS cryptographic algorithms and features                                                              | ✅          |            |
-| `insecure` | Disable authentication and use HTTP (development only)                                                             | ✅          |            |
-| `timeout`  | Binary stops after 3 months from compilation date                                                                  |             |            |
+| Feature    | Description                                            | Development | Production |
+| ---------- | ------------------------------------------------------ | ----------- | ---------- |
+| `non-fips` | Enable non-FIPS cryptographic algorithms and features  | ✅          |            |
+| `insecure` | Disable authentication and use HTTP (development only) | ✅          |            |
+| `timeout`  | Binary stops after 3 months from compilation date      |             |            |
 
 **Legend**: ✅ = Recommended for this environment
 


### PR DESCRIPTION
Cosmian KMS codebase has widespread AI-generated documentation anti-patterns.

Examples :
- Circular bullet points: "X: description of X"
- Sentences like: **HTTP Communication**: Secure HTTPS communication with the KMS server /  **Error Management**: Comprehensive error handling and reporting -> **zero added value, only noise**
- Boilerplate "Overview" sections 
- Empty "Features" lists (isting obvious capabilities)

another issue is identical boilerplate sections wasting space:
```
## Dependencies (just lists deps; people can read Cargo.toml)
## Building (standard cargo build commands)
## Testing (standard cargo test commands)
## License (identical BUSL-1.1 on every file)
```

**This writing noise makes working harder for both humans (a lot of reading, no useful info) and agents (token waste, the agent most likely never even reads readme)**

README is meant to help human operators

Solution will be decided soon