### PR TITLE
fix(spire): bump SPIRE images to 1.15.2 and accept PUT on transit key…

### DIFF
--- a/crate/server/src/routes/spire/transit.rs
+++ b/crate/server/src/routes/spire/transit.rs
@@ -1,7 +1,8 @@
 //! SPIRE-compatible Transit engine — key management and signing.
 //!
 //! Routes:
-//!   `POST   /keys/{name}`             — create transit key
+//!   `POST/PUT /keys/{name}`           — create transit key (PUT: SPIRE 1.15+
+//!                                       `hashicorp_vault` `KeyManager` plugin)
 //!   `POST   /keys/{name}/config`      — update key config (`deletion_allowed`; no-op)
 //!   `GET    /keys/{name}`             — read transit key info (public key + version map)
 //!   `GET    /keys`                    — list transit keys
@@ -22,7 +23,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use actix_web::{
-    HttpRequest, HttpResponse, delete, get, post,
+    HttpRequest, HttpResponse, delete, get, post, put,
     web::{Data, Json, Path},
 };
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
@@ -420,13 +421,40 @@ pub(crate) async fn create_transit_key(
     name: Path<String>,
     body: Json<CreateTransitKeyRequest>,
 ) -> SpireResult<Json<TransitKeyInfoWrapper>> {
+    create_transit_key_impl(req, kms, name, body).await
+}
+
+/// `PUT /keys/{name}` — same as `POST /keys/{name}` (see below).
+///
+/// SPIRE's `hashicorp_vault` `KeyManager` plugin (landed in SPIRE 1.15.0) issues
+/// `PUT /v1/transit/keys/{name}` to create its signing keys, while the Vault
+/// HTTP API itself (and this KMS's own negative-scenario tests) use `POST` —
+/// both must create the same key.
+#[put("/keys/{name}")]
+pub(crate) async fn create_transit_key_put(
+    req: HttpRequest,
+    kms: Data<Arc<KMS>>,
+    name: Path<String>,
+    body: Json<CreateTransitKeyRequest>,
+) -> SpireResult<Json<TransitKeyInfoWrapper>> {
+    create_transit_key_impl(req, kms, name, body).await
+}
+
+async fn create_transit_key_impl(
+    req: HttpRequest,
+    kms: Data<Arc<KMS>>,
+    name: Path<String>,
+    body: Json<CreateTransitKeyRequest>,
+) -> SpireResult<Json<TransitKeyInfoWrapper>> {
     let user = kms.get_user(&req);
     let name = name.into_inner();
     let body = body.into_inner();
 
     trace!(
         user = user,
-        "POST vault transit keys/{name} type={}", body.key_type
+        "{} vault transit keys/{name} type={}",
+        req.method(),
+        body.key_type
     );
 
     // The KMS performs no time-based key rotation; reject a non-zero
@@ -729,13 +757,37 @@ pub(crate) async fn sign_with_transit_key(
     path: Path<(String, String)>,
     body: Json<SignTransitRequest>,
 ) -> SpireResult<Json<SignTransitResponse>> {
+    sign_with_transit_key_impl(req, kms, path, body).await
+}
+
+/// `PUT /sign/{name}/{hash_alg}` — same as `POST /sign/{name}/{hash_alg}` (see below).
+///
+/// SPIRE's `hashicorp_vault` `KeyManager` plugin issues `PUT` for its transit
+/// sign calls, while the Vault HTTP API itself uses `POST`.
+#[put("/sign/{name}/{hash_alg}")]
+pub(crate) async fn sign_with_transit_key_put(
+    req: HttpRequest,
+    kms: Data<Arc<KMS>>,
+    path: Path<(String, String)>,
+    body: Json<SignTransitRequest>,
+) -> SpireResult<Json<SignTransitResponse>> {
+    sign_with_transit_key_impl(req, kms, path, body).await
+}
+
+async fn sign_with_transit_key_impl(
+    req: HttpRequest,
+    kms: Data<Arc<KMS>>,
+    path: Path<(String, String)>,
+    body: Json<SignTransitRequest>,
+) -> SpireResult<Json<SignTransitResponse>> {
     let user = kms.get_user(&req);
     let (name, hash_alg_path) = path.into_inner();
     let body = body.into_inner();
 
     trace!(
         user = user,
-        "POST vault transit sign/{name}/{hash_alg_path}"
+        "{} vault transit sign/{name}/{hash_alg_path}",
+        req.method()
     );
 
     let input_bytes = BASE64_STANDARD

--- a/crate/server/src/start_kms_server.rs
+++ b/crate/server/src/start_kms_server.rs
@@ -70,8 +70,9 @@ use crate::{
             auth_proxy::proxy_auth_request,
             pki::sign_intermediate,
             transit::{
-                configure_transit_key, create_transit_key, delete_transit_key, get_transit_key,
-                list_transit_keys, sign_with_transit_key,
+                configure_transit_key, create_transit_key, create_transit_key_put,
+                delete_transit_key, get_transit_key,
+                list_transit_keys, sign_with_transit_key, sign_with_transit_key_put,
             },
         },
         swagger,
@@ -1024,6 +1025,10 @@ pub async fn prepare_kms_server(kms_server: Arc<KMS>) -> KResult<actix_web::dev:
                 let transit_mount = kms_server_for_http.params.vault_transit_mount.clone();
                 let transit_scope_path = format!("/v1/{transit_mount}");
                 let transit_scope = web::scope(&transit_scope_path)
+                    // SPIRE's `hashicorp_vault` KeyManager plugin (SPIRE >= 1.15.0) does
+                    // not always set a `Content-Type: application/json` header on its
+                    // `PUT` key-creation request; accept the JSON body regardless.
+                    .app_data(JsonConfig::default().content_type_required(false))
                     .wrap(spire_token_middleware(
                         spire_cache.clone(),
                         auth_verifier_url.clone(),
@@ -1031,11 +1036,13 @@ pub async fn prepare_kms_server(kms_server: Arc<KMS>) -> KResult<actix_web::dev:
                     ))
                     .wrap(Cors::default())
                     .service(create_transit_key)
+                    .service(create_transit_key_put)
                     .service(configure_transit_key)
                     .service(get_transit_key)
                     .service(list_transit_keys)
                     .service(delete_transit_key)
-                    .service(sign_with_transit_key);
+                    .service(sign_with_transit_key)
+                    .service(sign_with_transit_key_put);
                 app = app.service(transit_scope);
 
                 let pki_mount = kms_server_for_http.params.vault_pki_mount.clone();

--- a/crate/server/src/start_kms_server.rs
+++ b/crate/server/src/start_kms_server.rs
@@ -71,8 +71,8 @@ use crate::{
             pki::sign_intermediate,
             transit::{
                 configure_transit_key, create_transit_key, create_transit_key_put,
-                delete_transit_key, get_transit_key,
-                list_transit_keys, sign_with_transit_key, sign_with_transit_key_put,
+                delete_transit_key, get_transit_key, list_transit_keys, sign_with_transit_key,
+                sign_with_transit_key_put,
             },
         },
         swagger,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -252,7 +252,7 @@ services:
 
   # ── Tenant A: trust domain cosmian-test-a.local ─────────────────────────────
   spire-server-a:
-    image: ghcr.io/spiffe/spire-server:1.9.6
+    image: ghcr.io/spiffe/spire-server:1.15.2
     profiles: [spire]
     container_name: spire-server-a
     ports:
@@ -280,7 +280,7 @@ services:
       retries: 12
 
   spire-agent-a:
-    image: ghcr.io/spiffe/spire-agent:1.9.6
+    image: ghcr.io/spiffe/spire-agent:1.15.2
     profiles: [spire]
     container_name: spire-agent-a
     depends_on:
@@ -355,7 +355,7 @@ services:
 
   # ── Tenant B: trust domain cosmian-test-b.local ─────────────────────────────
   spire-server-b:
-    image: ghcr.io/spiffe/spire-server:1.9.6
+    image: ghcr.io/spiffe/spire-server:1.15.2
     profiles: [spire]
     container_name: spire-server-b
     ports:
@@ -380,7 +380,7 @@ services:
       retries: 12
 
   spire-agent-b:
-    image: ghcr.io/spiffe/spire-agent:1.9.6
+    image: ghcr.io/spiffe/spire-agent:1.15.2
     profiles: [spire]
     container_name: spire-agent-b
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -255,6 +255,11 @@ services:
     image: ghcr.io/spiffe/spire-server:1.15.2
     profiles: [spire]
     container_name: spire-server-a
+    # SPIRE 1.15+ images run as non-root (uid 1000); the root-owned named
+    # data volume and the SQLite datastore/keys.json under /data would fail
+    # with "unable to open database file". Run as root to allow writes
+    # (matches the pre-1.15 image behaviour; test-only compose).
+    user: 0:0
     ports:
       - 8081:8081     # SPIRE server gRPC (tenant a)
     volumes:
@@ -283,6 +288,9 @@ services:
     image: ghcr.io/spiffe/spire-agent:1.15.2
     profiles: [spire]
     container_name: spire-agent-a
+    # See spire-server-a: run as root so the agent can write its data_dir
+    # (/data/spire-agent) under the non-root 1.15+ image.
+    user: 0:0
     depends_on:
       spire-server-a:
         condition: service_healthy
@@ -358,6 +366,9 @@ services:
     image: ghcr.io/spiffe/spire-server:1.15.2
     profiles: [spire]
     container_name: spire-server-b
+    # See spire-server-a: run as root so the 1.15+ non-root image can write
+    # its SQLite datastore and keys.json under /data/spire-server.
+    user: 0:0
     ports:
       - 8091:8081     # SPIRE server gRPC (tenant b)
     volumes:
@@ -383,6 +394,9 @@ services:
     image: ghcr.io/spiffe/spire-agent:1.15.2
     profiles: [spire]
     container_name: spire-agent-b
+    # See spire-server-a: run as root so the agent can write its data_dir
+    # (/data/spire-agent) under the non-root 1.15+ image.
+    user: 0:0
     depends_on:
       spire-server-b:
         condition: service_healthy

--- a/documentation/docs/configuration/log-reference.md
+++ b/documentation/docs/configuration/log-reference.md
@@ -631,9 +631,7 @@ Crate path: `crate/server`
 | `debug` | `vault transit: created ML-DSA-65 key '{name}'` | `src/routes/spire/transit.rs` | `name` | - |
 | `debug` | `vault transit: created RSA key '{name}' bits={bits}` | `src/routes/spire/transit.rs` | `name`, `bits` | - |
 | `debug` | `vault transit: deleted key '{name}'` | `src/routes/spire/transit.rs` | `name` | - |
-| `trace` | `POST vault transit keys/{name} type={}` | `src/routes/spire/transit.rs` | `name` | - |
 | `trace` | `POST vault transit keys/{}/config (no-op)` | `src/routes/spire/transit.rs` | - | - |
-| `trace` | `POST vault transit sign/{name}/{hash_alg_path}` | `src/routes/spire/transit.rs` | `name`, `hash_alg_path` | - |
 | `trace` | `POST/PUT vault pki root/sign-intermediate` | `src/routes/spire/pki.rs` | - | - |
 | `warn` | `vault auth proxy: auth-verifier unreachable: {e}` | `src/routes/spire/auth_proxy.rs` | `e`: reqwest error detail | Raised when KMS cannot reach auth-verifier to forward a `/v1/auth/*` request; SPIRE will fail to authenticate |
 | `info` | `Vault-compatible API enabled: transit at /v1/{transit_mount}, PKI at /v1/{pki_mount}, auth proxy at /v1/auth` | `src/start_kms_server.rs` | `transit_mount`: configured transit mount name, `pki_mount`: configured PKI mount name | Emitted once on startup when `vault_api_enabled = true` and `vault_auth_verifier_url` is set |
@@ -644,6 +642,8 @@ Crate path: `crate/server`
 | `debug` | `spire_token_middleware: validated entity={}` | `src/middlewares/spire_token.rs` | - | - |
 | `trace` | `spire_token_middleware: missing X-Vault-Token header` | `src/middlewares/spire_token.rs` | - | - |
 | `warn` | `SPIRE auth proxy: rejected path traversal attempt: {path}` | `src/routes/spire/auth_proxy.rs` | `path` — the offending request path (with `/v1` stripped) that contained a `.`/`..` segment | Security: emitted when the unauthenticated `/v1/auth/*` proxy blocks a path-traversal attempt (HTTP 400). Repeated occurrences may indicate probing of internal auth-verifier endpoints. |
+| `trace` | `{} vault transit keys/{name} type={}` | `src/routes/spire/transit.rs` | `name` | - |
+| `trace` | `{} vault transit sign/{name}/{hash_alg_path}` | `src/routes/spire/transit.rs` | `name`, `hash_alg_path` | - |
 | `warn` | `vault auth proxy: failed to read auth-verifier response body: {e}` | `src/routes/spire/auth_proxy.rs` | `e` | - |
 
 ### `cosmian_kms_server_database`


### PR DESCRIPTION
## PR Description

SPIRE's hashicorp_vault KeyManager plugin (available since SPIRE 1.15.0) uses PUT instead of POST for /v1/transit/keys/{name} and /v1/transit/sign/{name}/{hash_alg}, and does not always set a Content-Type header on those requests. The KMS's Vault-compatible transit routes only accepted POST with a required application/json Content-Type, causing SPIRE 1.15.2 to crash with 404/400 errors when using the hashicorp_vault KeyManager against this KMS.

- crate/server/src/routes/spire/transit.rs: extract create_transit_key and sign_with_transit_key bodies into shared impl fns, add thin PUT wrapper handlers (create_transit_key_put, sign_with_transit_key_put)
- crate/server/src/start_kms_server.rs: register the new PUT handlers in the transit scope, and relax JsonConfig content_type_required to false for that scope
- docker-compose.yml: bump spire-server-a/b and spire-agent-a/b images from 1.9.6 to 1.15.2

Validated live end-to-end via **run-spire-1.15.2-vault.sh:** (see below) SPIRE 1.15.2 with hashicorp_vault KeyManager + vault UpstreamAuthority now boots, rotates its X509 CA, and a workload's SPIFFE identity checks all pass (17/17 assertions).

## Goal

Merci on top of spire

## Artefact : 

```sh
#!/usr/bin/env bash
set -euo pipefail

SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"

# shellcheck source=/home/hatem/Desktop/repos/kms/.mise/lib/common.sh
source "${REPO_ROOT}/.mise/lib/common.sh"
# shellcheck source=/home/hatem/Desktop/repos/kms/.mise/lib/kms_server.sh
source "${REPO_ROOT}/.mise/lib/kms_server.sh"

kms_init_env "non-fips" "static"

COMMAND="${1:-up}"

RUNTIME_DIR="${TMPDIR:-/tmp}/kms-spire-115"
AUTH_LOG="${RUNTIME_DIR}/auth-verifier.log"
KMS_LOG="${RUNTIME_DIR}/kms.log"
SECRETS_ENV="${RUNTIME_DIR}/spire-c.env"
AGENT_CONFIG_DIR="${RUNTIME_DIR}/agent-c"
SERVER_STATE_DIR="${RUNTIME_DIR}/spire-server-c-data"
AGENT_STATE_DIR="${RUNTIME_DIR}/spire-agent-c-data"
SOCKET_DIR="${RUNTIME_DIR}/spire-agent-c-socket"
AUTH_PID_FILE="${RUNTIME_DIR}/auth-verifier.pid"
KMS_PID_FILE="${RUNTIME_DIR}/kms.pid"

TEST_DATA="${REPO_ROOT}/test_data/spire"
COMPOSE_BASE="${REPO_ROOT}/docker-compose.yml"
COMPOSE_OVERRIDE="${SCRIPT_DIR}/spire-1.15.2.compose.yml"
AUTH_CONF="${SCRIPT_DIR}/spire-prodlike-auth_verifier.toml"
KMS_CONF="${SCRIPT_DIR}/spire-prodlike-kms.toml"
AGENT_TEMPLATE="${SCRIPT_DIR}/spire-agent-c-1.15.2.conf"

SPIRE_PROFILE="${SPIRE_PROFILE:-spire115}"
SPIRE_IMAGE_TAG_C="${SPIRE_IMAGE_TAG_C:-1.15.2}"
COMPOSE_PROJECT="${COMPOSE_PROJECT:-kms-spire115}"
AUTH_DB_FILE="/tmp/auth-verifier-spire-prodlike-115.db"
ADMIN_USER="${ADMIN_USER:-admin}"
ADMIN_PASS="${ADMIN_PASS:-change_me}"
VAULT_ADDR="https://localhost:9998"
AUTH_VERIFIER_URL="https://localhost:8443"
VAULT_CACERT="${TEST_DATA}/certs/ca.crt"
TRUST_DOMAIN="cosmian-test-c.local"

export SPIRE_IMAGE_TAG_C
export SPIRE_SERVER_STATE_DIR_C="${SERVER_STATE_DIR}"
export SPIRE_AGENT_STATE_DIR_C="${AGENT_STATE_DIR}"
export SPIRE_AGENT_SOCKET_DIR_C="${SOCKET_DIR}"

usage() {
  cat <<'EOF'
Usage: ./.agents/artifacts/run-spire-1.15.2-vault.sh <command>

Commands:
  up      Build binaries, start auth-verifier + KMS, bootstrap SPIRE 1.15.2 tenant c, run one Mistral workload verification
  verify  Re-run the mistral-agent-c1 identity check against the live stack
  status  Show host-process state and docker compose state
  down    Stop tenant-c containers and host processes started by this launcher

Environment overrides:
  SPIRE_IMAGE_TAG_C   Default: 1.15.2
  COMPOSE_PROJECT     Default: kms-spire115
  KMS_SKIP_BUILD=1    Skip cargo build steps when binaries are already built
  SKIP_VERIFY=1       Skip the mistral-agent-c1 check during `up`
EOF
}

compose() {
  docker compose -p "${COMPOSE_PROJECT}" -f "${COMPOSE_BASE}" -f "${COMPOSE_OVERRIDE}" --profile "${SPIRE_PROFILE}" "$@"
}

port_open() {
  local port="$1"
  python3 - "$port" <<'PY'
import socket, sys
sock = socket.socket()
sock.settimeout(0.5)
try:
    sock.connect(("127.0.0.1", int(sys.argv[1])))
except OSError:
    sys.exit(1)
else:
    sys.exit(0)
finally:
    sock.close()
PY
}

ensure_runtime_dir() {
  mkdir -p "${RUNTIME_DIR}" "${AGENT_CONFIG_DIR}" "${SERVER_STATE_DIR}" "${AGENT_STATE_DIR}" "${SOCKET_DIR}"
  chmod 0777 "${SERVER_STATE_DIR}" "${AGENT_STATE_DIR}" "${SOCKET_DIR}"
}

get_auth_bin() {
  echo "$(cd "${REPO_ROOT}/authentication" && cargo metadata --no-deps --format-version 1 |
    python3 -c "import sys,json; m=json.load(sys.stdin); print(m['target_directory'])")/debug/auth_verifier"
}

require_clean_ports() {
  if [[ ! -f "${AUTH_PID_FILE}" ]] && port_open 8443; then
    print_error "Port 8443 is already in use; stop the existing service or run down first."
  fi
  if [[ ! -f "${KMS_PID_FILE}" ]] && port_open 9998; then
    print_error "Port 9998 is already in use; stop the existing service or run down first."
  fi
}

wait_auth_ready() {
  local tries=0
  until curl -fsS --cacert "${VAULT_CACERT}" "${AUTH_VERIFIER_URL}/public/roles" >/dev/null 2>&1; do
    tries=$((tries + 1))
    if [[ "${tries}" -ge 60 ]]; then
      print_error "auth-verifier did not become ready. Check ${AUTH_LOG}"
    fi
    sleep 1
  done
}

wait_kms_ready() {
  local tries=0 http_code
  until http_code=$(curl -sS --cacert "${VAULT_CACERT}" -o /dev/null -w "%{http_code}" \
      -X POST -H "Content-Type: application/json" -d '{}' "${VAULT_ADDR}/kmip/2_1") && [[ "${http_code}" != "000" ]]; do
    tries=$((tries + 1))
    if [[ "${tries}" -ge 120 ]]; then
      print_error "KMS did not become ready. Check ${KMS_LOG}"
    fi
    sleep 1
  done
}

start_auth_verifier() {
  local auth_bin
  auth_bin="$(get_auth_bin)"
  nohup "${auth_bin}" "${AUTH_CONF}" >"${AUTH_LOG}" 2>&1 &
  echo $! >"${AUTH_PID_FILE}"
  wait_auth_ready
}

start_kms() {
  local kms_bin
  kms_bin="$(get_kms_bin)"
  nohup "${kms_bin}" --config "${KMS_CONF}" >"${KMS_LOG}" 2>&1 &
  echo $! >"${KMS_PID_FILE}"
  wait_kms_ready
}

stop_pid_file() {
  local pid_file="$1"
  if [[ -f "${pid_file}" ]]; then
    local pid
    pid="$(cat "${pid_file}")"
    kill "${pid}" 2>/dev/null || true
    wait "${pid}" 2>/dev/null || true
    rm -f "${pid_file}"
  fi
}

reset_state() {
  compose down --volumes >/dev/null 2>&1 || true
  docker rm -f spire-server-c spire-agent-c mistral-agent-c1 >/dev/null 2>&1 || true
  stop_pid_file "${AUTH_PID_FILE}"
  stop_pid_file "${KMS_PID_FILE}"
  rm -f "${AUTH_DB_FILE}" "${AUTH_DB_FILE}-wal" "${AUTH_DB_FILE}-shm" >/dev/null 2>&1 || true
  rm -rf "${RUNTIME_DIR}"
}

build_binaries() {
  if [[ "${KMS_SKIP_BUILD:-0}" == "1" ]]; then
    print_info "Skipping cargo build (KMS_SKIP_BUILD=1)."
    return
  fi

  print_status "Building cosmian_kms, ckms, and auth_verifier..."
  kms_build_server
  kms_build_cli
  cargo build --manifest-path "${REPO_ROOT}/authentication/Cargo.toml" --bin auth_verifier
}

create_pki_root() {
  local ckms_conf ext_file
  ckms_conf="$(mktemp /tmp/ckms-spire115.XXXXXX.toml)"
  ext_file="$(mktemp /tmp/vault_pki_ca_ext.XXXXXX)"

  cat >"${ckms_conf}" <<EOF
[http_config]
server_url = "${VAULT_ADDR}"
EOF

  cat >"${ext_file}" <<'EOF'
[ v3_ca ]
basicConstraints=critical,CA:TRUE
keyUsage=critical,keyCertSign,crlSign,digitalSignature
EOF

  "$(get_ckms_bin)" --conf-path "${ckms_conf}" \
    --accept-invalid-certs \
    certificates certify \
    --generate-key-pair \
    --algorithm nist-p384 \
    --certificate-id vault_pki_ca_cert \
    --subject-name "CN=Cosmian KMS Root CA,O=Cosmian,C=FR" \
    --tag vault_pki_ca \
    --days 3650 \
    --certificate-extensions "${ext_file}" \
    2>&1 | grep -v '^$'

  rm -f "${ckms_conf}" "${ext_file}"
}

auth_login() {
  local cookie_jar="$1" creds
  creds="$(printf '%s:%s' "${ADMIN_USER}" "${ADMIN_PASS}" | base64)"
  curl -fsS \
    --cacert "${VAULT_CACERT}" \
    -c "${cookie_jar}" \
    -X POST \
    -H "Authorization: Basic ${creds}" \
    -H "Content-Type: application/json" \
    -d '{}' \
    "${AUTH_VERIFIER_URL}/login?realm=_" >/dev/null
}

auth_admin_api() {
  local cookie_jar="$1" method="$2" path="$3"
  shift 3
  curl -fsS \
    --cacert "${VAULT_CACERT}" \
    -b "${cookie_jar}" \
    -X "${method}" \
    -H "Content-Type: application/json" \
    "$@" \
    "${AUTH_VERIFIER_URL}${path}"
}

provision_tenant_c() {
  local cookie_jar role_id secret_id
  cookie_jar="$(mktemp /tmp/spire-c-auth-cookie.XXXXXX)"
  trap 'rm -f "${cookie_jar}"' RETURN

  auth_login "${cookie_jar}"

  auth_admin_api "${cookie_jar}" POST "/auth/approle/role/spire-server-c" -d '{
    "token_ttl": 3600,
    "token_policies": ["default"],
    "secret_id_ttl": 0
  }' >/dev/null

  role_id="$(auth_admin_api "${cookie_jar}" GET "/auth/approle/role/spire-server-c/role-id" |
    python3 -c "import sys,json; print(json.load(sys.stdin)['data']['role_id'])")"
  secret_id="$(auth_admin_api "${cookie_jar}" POST "/auth/approle/role/spire-server-c/secret-id" -d '{}' |
    python3 -c "import sys,json; print(json.load(sys.stdin)['data']['secret_id'])")"

  cat >"${SECRETS_ENV}" <<EOF
export SPIRE_ROLE_ID_C="${role_id}"
export SPIRE_SECRET_ID_C="${secret_id}"
EOF
}

wait_server_healthy() {
  local tries=0 health_status runtime_status
  while true; do
    health_status="$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{end}}' spire-server-c 2>/dev/null || true)"
    runtime_status="$(docker inspect --format='{{.State.Status}}' spire-server-c 2>/dev/null || true)"

    if [[ "${runtime_status}" == "running" && "${health_status}" == "healthy" ]]; then
      return 0
    fi

    if [[ "${runtime_status}" == "exited" || "${runtime_status}" == "dead" ]]; then
      docker logs spire-server-c 2>&1 | tail -80 || true
      print_error "spire-server-c exited before becoming healthy."
    fi

    tries=$((tries + 1))
    if [[ "${tries}" -ge 24 ]]; then
      print_error "spire-server-c did not become healthy. Check docker logs spire-server-c"
    fi
    sleep 5
  done
}

assert_server_running() {
  local runtime_status
  runtime_status="$(docker inspect --format='{{.State.Status}}' spire-server-c 2>/dev/null || true)"
  if [[ "${runtime_status}" != "running" ]]; then
    docker logs spire-server-c 2>&1 | tail -120 || true
    print_error "spire-server-c exited after startup. If the log shows a 404 on PUT /v1/transit/keys/<name>, the current KMS transit surface is still incompatible with SPIRE 1.15.2's hashicorp_vault key-manager create-key flow."
  fi
}

wait_agent_ready() {
  local tries=0
  until docker exec spire-agent-c /opt/spire/bin/spire-agent healthcheck \
    -socketPath /tmp/spire-agent/public/api.sock >/dev/null 2>&1; do
    tries=$((tries + 1))
    if [[ "${tries}" -ge 24 ]]; then
      docker logs spire-agent-c 2>&1 | tail -20 || true
      print_error "spire-agent-c did not become ready."
    fi
    sleep 5
  done
}

start_spire_server() {
  # shellcheck disable=SC1090
  source "${SECRETS_ENV}"
  export VAULT_APPROLE_ID_C="${SPIRE_ROLE_ID_C}"
  export VAULT_APPROLE_SECRET_ID_C="${SPIRE_SECRET_ID_C}"
  export SPIRE_SERVER_CONFIG_FILE_C="${SCRIPT_DIR}/spire-server-c-1.15.2.conf"

  compose up -d spire-server-c >/dev/null
  wait_server_healthy
  assert_server_running
}

start_spire_agent() {
  local join_token
  assert_server_running
  join_token="$(docker exec spire-server-c \
    /opt/spire/bin/spire-server token generate \
    -spiffeID "spiffe://${TRUST_DOMAIN}/spire-agent" \
    -socketPath /tmp/spire-server/private/api.sock |
    awk '/^Token:/{print $2}')"

  if [[ -z "${join_token}" ]]; then
    print_error "Failed to generate SPIRE join token for tenant c."
  fi

  sed "s/join_token = \"cosmian-test-join-token-12345\"/join_token = \"${join_token}\"/" \
    "${AGENT_TEMPLATE}" >"${AGENT_CONFIG_DIR}/agent.conf"

  export SPIRE_AGENT_CONFIG_FILE_C="${AGENT_CONFIG_DIR}/agent.conf"
  compose up -d spire-agent-c >/dev/null
  wait_agent_ready
}

register_workload() {
  docker exec spire-server-c \
    /opt/spire/bin/spire-server entry create \
    -socketPath /tmp/spire-server/private/api.sock \
    -spiffeID "spiffe://${TRUST_DOMAIN}/mistral-agent" \
    -parentID "spiffe://${TRUST_DOMAIN}/spire-agent" \
    -selector "unix:uid:1000" >/dev/null
}

show_transit_keys() {
  local token keys_json
  # shellcheck disable=SC1090
  source "${SECRETS_ENV}"
  token="$(curl -fsS --cacert "${VAULT_CACERT}" -X POST \
    -H "Content-Type: application/json" \
    -d "{\"role_id\":\"${SPIRE_ROLE_ID_C}\",\"secret_id\":\"${SPIRE_SECRET_ID_C}\"}" \
    "${VAULT_ADDR}/v1/auth/approle/login" |
    python3 -c "import sys,json; print(json.load(sys.stdin)['auth']['client_token'])")"

  keys_json="$(curl -fsS --cacert "${VAULT_CACERT}" \
    -H "X-Vault-Token: ${token}" \
    "${VAULT_ADDR}/v1/transit/keys")"
  print_info "Current transit keys: ${keys_json}"
}

verify_stack() {
  compose run --rm mistral-agent-c1
  show_transit_keys
}

show_status() {
  print_info "Host processes:"
  for pid_file in "${AUTH_PID_FILE}" "${KMS_PID_FILE}"; do
    if [[ -f "${pid_file}" ]]; then
      printf '  %s -> PID %s\n' "$(basename "${pid_file}")" "$(cat "${pid_file}")"
    fi
  done
  print_info "Docker compose state:"
  compose ps
}

cmd_up() {
  require_cmd docker
  require_cmd cargo
  require_cmd curl
  require_cmd python3
  ensure_runtime_dir
  reset_state
  ensure_runtime_dir
  require_clean_ports

  if [[ ! -f "${TEST_DATA}/certs/ca.crt" || ! -f "${TEST_DATA}/certs/jwt.key.pem" ]]; then
    print_status "Generating SPIRE test certificates..."
    bash "${TEST_DATA}/certs/generate-test-certs.sh"
  fi

  build_binaries

  print_status "Starting auth-verifier..."
  start_auth_verifier
  print_status "Starting KMS..."
  start_kms
  print_status "Creating KMS PKI root..."
  create_pki_root
  print_status "Provisioning AppRole for tenant c..."
  provision_tenant_c
  print_status "Starting SPIRE 1.15.2 server (tenant c)..."
  start_spire_server
  print_status "Starting SPIRE 1.15.2 agent (tenant c)..."
  start_spire_agent
  print_status "Registering workload entry for mistral-agent-c1..."
  register_workload

  if [[ "${SKIP_VERIFY:-0}" != "1" ]]; then
    print_status "Running mistral-agent-c1 verification..."
    verify_stack
  fi

  print_success "SPIRE 1.15.2 tenant c is live against the local KMS/auth-verifier pair."
  print_info "Logs: ${AUTH_LOG} and ${KMS_LOG}"
  print_info "Re-run verification: ./.agents/artifacts/run-spire-1.15.2-vault.sh verify"
  print_info "Tear down: ./.agents/artifacts/run-spire-1.15.2-vault.sh down"
}

cmd_verify() {
  verify_stack
}

cmd_down() {
  reset_state
  print_success "SPIRE 1.15.2 tenant c stack stopped."
}

case "${COMMAND}" in
up)
  cmd_up
  ;;
verify)
  cmd_verify
  ;;
status)
  show_status
  ;;
down)
  cmd_down
  ;;
help|-h|--help)
  usage
  ;;
*)
  usage
  exit 1
  ;;
esac
```