### PR TITLE
fix: create a dedicated AWS-XKS user and grant permissions for him

### DIFF
--- a/.mise/scripts/test/test_xks.sh
+++ b/.mise/scripts/test/test_xks.sh
@@ -113,6 +113,11 @@ source ./utils/test_config.sh
 # Keep the same principal ARN as the vendored curl-suite.
 aws_principal_arn="arn:aws:iam::123456789012:user/Alice"
 
+# Reserved identity under which the server runs every XKS operation
+# (`AWS_XKS_SERVICE_USER` in crate/server/src/routes/aws_xks/mod.rs). Permissions must be
+# adjusted on this identity — not on the caller ARN, which is audit-only metadata.
+xks_service_user="[aws-xks-service]"
+
 xks_create_key() {
   local key_id="$1"
   local request_id
@@ -151,7 +156,7 @@ EOF
   fi
 }
 
-revoke_op_for_alice() {
+revoke_xks_op() {
   local key_id="$1"
   local op="$2"
 
@@ -165,7 +170,7 @@ revoke_op_for_alice() {
         cat <<EOF
 {
   "unique_identifier": "${key_id}",
-  "user_id": "${aws_principal_arn}",
+  "user_id": "${xks_service_user}",
   "operation_types": ["${op}"]
 }
 EOF
@@ -173,7 +178,7 @@ EOF
   )"
 
   if ! grep -q '"success"' <<<"${response}"; then
-    echo "Failed to revoke ${op} for ${aws_principal_arn} on ${key_id}. Response:" >&2
+    echo "Failed to revoke ${op} for ${xks_service_user} on ${key_id}. Response:" >&2
     echo "${response}" >&2
     return 1
   fi
@@ -185,8 +190,8 @@ xks_create_key "encrypt_only_key"
 xks_create_key "decrypt_only_key"
 
 # Enforce the expected usage restrictions.
-revoke_op_for_alice "encrypt_only_key" "decrypt"
-revoke_op_for_alice "decrypt_only_key" "encrypt"
+revoke_xks_op "encrypt_only_key" "decrypt"
+revoke_xks_op "decrypt_only_key" "encrypt"
 
 echo "Running vendored AWS XKS curl-based test client..."
 

--- a/CHANGELOG/fix_xks-proxy-acl-1093.md
+++ b/CHANGELOG/fix_xks-proxy-acl-1093.md
@@ -1,0 +1,24 @@
+## Bug fixes
+
+- **AWS XKS — key usage no longer restricted to the creator principal**
+  ([#1093](https://github.com/Cosmian/kms/issues/1093)): the XKS proxy previously
+  authorized each `Encrypt`/`Decrypt`/`GetKeyMetadata` request using the caller's
+  `awsPrincipalArn`, and `CreateKey` granted usage only to the ARN that first created the
+  key. As a result only that single principal could use the key, which broke AWS's model
+  where the AWS key policy / IAM is the source of truth and made numerous or dynamic IAM
+  roles (CI/CD, Lambda, EC2, SSO/Control Tower) unusable without a manual per-ARN entry.
+
+  XKS requests are trusted on the basis of their SigV4 signature (the shared XKS credential
+  authenticated by `Sigv4MWare`). XKS operations now run under a stable, reserved KMS
+  service identity instead of the transient caller ARN, so any correctly-signed request may
+  use the key regardless of which IAM role AWS used. The `awsPrincipalArn` is retained for
+  audit logging only.
+
+  Keys stay owned by `default_username`, so operators keep full administrative control
+  (list, revoke, destroy, export) and key creation continues to honour `privileged_users`.
+  The reserved identity is only granted `Encrypt`, `Decrypt` and `GetAttributes`: it is a
+  least-privilege delegate that cannot revoke, destroy or export key material, and the XKS
+  endpoints can therefore only reach XKS keys — no other object.
+
+  XKS keys created by earlier versions are granted to the reserved identity at server
+  startup; the migration is idempotent and requires no operator action.

--- a/CHANGELOG/fix_xks_permissions.md
+++ b/CHANGELOG/fix_xks_permissions.md
@@ -1,0 +1,33 @@
+## Bug Fixes
+
+### AWS XKS
+
+- Reject `ReKey` (manual or via the auto-rotation scheduler) on `aws-xks`-tagged keys.
+  Rotating one in place would assign a new internal unique identifier, but AWS KMS always
+  calls the XKS proxy back with the original external key id and has no way to learn about
+  a new one — silently breaking the key without any visible error on the AWS side. To
+  rotate the material behind an external key, create a new external key (new CMK) in AWS
+  KMS and destroy the old one via `ckms`/the Web UI once traffic has moved.
+- Warn at startup when AWS XKS is enabled and `crypto_officer.users` is empty: since AWS
+  never calls back to list, rotate, revoke, or destroy key material, a Crypto Officer must
+  be configured (a real TLS certificate CN / OIDC subject matching `default_username`) so
+  that XKS keys remain monitorable and manageable through the normal `ckms`/Web UI surface.
+
+## Documentation
+
+### AWS XKS
+
+- Document that lifecycle management of XKS keys (monitoring, revocation, destruction) is
+  entirely an operator responsibility exercised by a designated Crypto Officer, since AWS
+  never triggers these operations itself. Explicitly warn against ever granting the
+  reserved `AWS_XKS_SERVICE_USER` identity a real credential, as that would let any holder
+  bypass AWS's SigV4 trust boundary.
+
+## Testing
+
+### AWS XKS
+
+- Add regression coverage proving the real-credentialed key owner can monitor (`Locate`,
+  `GetAttributes`) and administer (`Revoke`, `Destroy`) XKS keys end to end, that the
+  reserved `AWS_XKS_SERVICE_USER` identity stays unreachable for this purpose, and that
+  `ReKey` on an `aws-xks`-tagged key is rejected.

--- a/crate/crypto/src/openssl/ocsp.rs
+++ b/crate/crypto/src/openssl/ocsp.rs
@@ -17,6 +17,7 @@ use std::{
     ptr,
 };
 
+use cosmian_logger::warn;
 use foreign_types::ForeignTypeRef;
 use openssl::{
     pkey::{PKeyRef, Private},
@@ -35,7 +36,6 @@ use super::ocsp_ffi::{
     V_OCSP_CERTSTATUS_REVOKED, V_OCSP_CERTSTATUS_UNKNOWN,
 };
 use crate::error::CryptoError;
-use cosmian_logger::warn;
 
 /// Maximum number of `SingleRequest`/`CertID` entries accepted in a single
 /// `OCSPRequest`. RFC 5019 (the lightweight OCSP profile most CDN/proxy

--- a/crate/interfaces/src/user_id.rs
+++ b/crate/interfaces/src/user_id.rs
@@ -149,4 +149,15 @@ mod tests {
         set.insert(a);
         assert!(set.contains(&b));
     }
+
+    #[test]
+    fn try_new_rejects_empty_string() {
+        assert!(UserId::try_new("").is_err());
+    }
+
+    #[test]
+    fn try_new_accepts_non_empty_string() {
+        let uid = UserId::try_new("carol@example.com").expect("non-empty string must be accepted");
+        assert_eq!(uid.as_str(), "carol@example.com");
+    }
 }

--- a/crate/interfaces/src/user_id.rs
+++ b/crate/interfaces/src/user_id.rs
@@ -122,6 +122,8 @@ impl PartialEq<UserId> for String {
 }
 
 #[cfg(test)]
+// Test-only: `expect()` and `assert!` on result states are idiomatic in unit tests.
+#[allow(clippy::expect_used, clippy::assertions_on_result_states)]
 mod tests {
     use super::*;
 

--- a/crate/server/src/middlewares/auth_verifier/token.rs
+++ b/crate/server/src/middlewares/auth_verifier/token.rs
@@ -28,7 +28,10 @@ use serde::Deserialize;
 
 use crate::{
     error::KmsError,
-    middlewares::{AuthMethod, AuthenticatedUser, JwksManager, extract_bearer_token},
+    middlewares::{
+        AuthMethod, AuthenticatedUser, JwksManager, UserId, extract_bearer_token,
+        reject_reserved_aws_xks_identity,
+    },
     result::KResult,
 };
 
@@ -68,9 +71,10 @@ pub(super) async fn handle_auth_verifier(
     let token = extract_bearer_token(req)
         .map_err(|e| KmsError::Unauthorized(format!("Auth Verifier: {e}")))?;
 
-    let username = verify_auth_verifier_jwt_subject(jwks_manager, token).await?;
+    let username = UserId::from(verify_auth_verifier_jwt_subject(jwks_manager, token).await?);
+    reject_reserved_aws_xks_identity(&username)?;
     Ok(AuthenticatedUser {
-        username: username.into(),
+        username,
         auth_method: AuthMethod::AuthVerifierJwt,
     })
 }

--- a/crate/server/src/middlewares/jwt/jwt_token_auth.rs
+++ b/crate/server/src/middlewares/jwt/jwt_token_auth.rs
@@ -13,7 +13,9 @@ use cosmian_logger::{debug, trace, warn};
 use super::UserClaim;
 use crate::{
     error::KmsError,
-    middlewares::{AuthMethod, AuthenticatedUser, UserId, jwt::JwtConfig},
+    middlewares::{
+        AuthMethod, AuthenticatedUser, UserId, jwt::JwtConfig, reject_reserved_aws_xks_identity,
+    },
     result::KResult,
 };
 
@@ -98,8 +100,10 @@ pub(super) async fn handle_jwt(
         Ok(Some(email)) => {
             // Authentication successful with valid email
             debug!("JWT Access granted to {email}!");
+            let username = UserId::from(email);
+            reject_reserved_aws_xks_identity(&username)?;
             Ok(AuthenticatedUser {
-                username: UserId::from(email),
+                username,
                 auth_method: AuthMethod::OidcJwt,
             })
         }

--- a/crate/server/src/middlewares/mod.rs
+++ b/crate/server/src/middlewares/mod.rs
@@ -29,7 +29,7 @@ mod session_auth;
 use actix_web::{dev::ServiceRequest, http::header};
 pub(crate) use session_auth::SessionAuth;
 
-use crate::{error::KmsError, result::KResult};
+use crate::{error::KmsError, result::KResult, routes::aws_xks::AWS_XKS_SERVICE_USER};
 
 /// Extract a Bearer token from the `Authorization` header of a request.
 ///
@@ -90,4 +90,36 @@ pub(crate) struct AuthenticatedUser {
     pub username: UserId,
     /// Which authentication method was used
     pub auth_method: AuthMethod,
+}
+
+/// Reject the reserved AWS XKS service identity on externally-derived auth paths.
+pub(crate) fn reject_reserved_aws_xks_identity(username: &UserId) -> KResult<()> {
+    if username.as_str() == AWS_XKS_SERVICE_USER {
+        return Err(KmsError::Unauthorized(format!(
+            "reserved AWS XKS service identity `{AWS_XKS_SERVICE_USER}` cannot be used as an \
+             externally authenticated username"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reject_reserved_aws_xks_identity_rejects_reserved_username() {
+        assert!(matches!(
+            reject_reserved_aws_xks_identity(&UserId::from(AWS_XKS_SERVICE_USER)),
+            Err(KmsError::Unauthorized(_))
+        ));
+    }
+
+    #[test]
+    fn reject_reserved_aws_xks_identity_accepts_regular_username() {
+        assert!(matches!(
+            reject_reserved_aws_xks_identity(&UserId::from("alice@example.com")),
+            Ok(())
+        ));
+    }
 }

--- a/crate/server/src/middlewares/session_auth.rs
+++ b/crate/server/src/middlewares/session_auth.rs
@@ -29,7 +29,7 @@ use futures::{
     future::{Ready, ok},
 };
 
-use crate::middlewares::{AuthMethod, AuthenticatedUser};
+use crate::middlewares::{AuthMethod, AuthenticatedUser, UserId, reject_reserved_aws_xks_identity};
 
 /// Middleware factory — registered unconditionally on all UI-facing scopes.
 pub(crate) struct SessionAuth;
@@ -85,11 +85,23 @@ where
         let session = req.get_session();
         match session.get::<String>("user_id") {
             Ok(Some(user_id)) => {
-                debug!("Session: authenticated user '{user_id}'");
-                req.extensions_mut().insert(AuthenticatedUser {
-                    username: user_id.into(),
-                    auth_method: AuthMethod::Session,
-                });
+                let username = UserId::from(user_id.as_str());
+                match reject_reserved_aws_xks_identity(&username) {
+                    Ok(()) => {
+                        debug!("Session: authenticated user '{user_id}'");
+                        req.extensions_mut().insert(AuthenticatedUser {
+                            username,
+                            auth_method: AuthMethod::Session,
+                        });
+                    }
+                    Err(error) => {
+                        warn!(
+                            "Session: rejecting reserved AWS XKS service identity from stored \
+                             session user_id: {error}"
+                        );
+                        session.purge();
+                    }
+                }
             }
             Ok(None) => {
                 trace!("Session: no user_id in session, passing through");

--- a/crate/server/src/middlewares/spire_token.rs
+++ b/crate/server/src/middlewares/spire_token.rs
@@ -26,7 +26,7 @@ use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use url::Url;
 
-use super::{AuthMethod, AuthenticatedUser};
+use super::{AuthMethod, AuthenticatedUser, reject_reserved_aws_xks_identity};
 
 /// The `X-Vault-Token` header name (wire protocol used by the SPIRE vault plugin).
 pub(crate) const VAULT_TOKEN_HEADER: &str = "X-Vault-Token";
@@ -292,8 +292,18 @@ where
     match check_vault_token(&req, cache, auth_verifier_url, client, default_username).await {
         VaultTokenResult::Valid(user) => {
             debug!("{log_prefix}: validated entity={}", user.entity);
+            let username = user.entity.clone().into();
+            if let Err(error) = reject_reserved_aws_xks_identity(&username) {
+                warn!(
+                    "{log_prefix}: rejecting reserved AWS XKS service identity in SPIRE auth: \
+                     {error}"
+                );
+                return Ok(req
+                    .into_response(forbidden_json("permission denied"))
+                    .map_into_boxed_body());
+            }
             req.extensions_mut().insert(AuthenticatedUser {
-                username: user.entity.clone().into(),
+                username,
                 auth_method: AuthMethod::SpireToken,
             });
             req.extensions_mut().insert(user);

--- a/crate/server/src/middlewares/tls_auth.rs
+++ b/crate/server/src/middlewares/tls_auth.rs
@@ -20,7 +20,7 @@ use openssl::{nid::Nid, x509::X509};
 use crate::{
     error::KmsError,
     kms_bail,
-    middlewares::{AuthMethod, AuthenticatedUser, UserId},
+    middlewares::{AuthMethod, AuthenticatedUser, UserId, reject_reserved_aws_xks_identity},
     result::KResult,
 };
 
@@ -105,8 +105,10 @@ fn tls_auth(req: &ServiceRequest) -> KResult<AuthenticatedUser> {
                     );
                 }
                 trace!("Client certificate common name: {}", username);
+                let username = UserId::from(trimmed);
+                reject_reserved_aws_xks_identity(&username)?;
                 Ok(AuthenticatedUser {
-                    username: UserId::from(trimmed),
+                    username,
                     auth_method: AuthMethod::Mtls,
                 })
             }

--- a/crate/server/src/routes/aws_xks/README.md
+++ b/crate/server/src/routes/aws_xks/README.md
@@ -4,6 +4,36 @@ Specs: <https://github.com/aws/aws-kms-xksproxy-api-spec/blob/main/xks_proxy_api
 
 Code loosely inspired from <https://github.com/aws-samples/aws-kms-xks-proxy/> (License Apache 2.0)
 
+## Authorization model
+
+The `Sigv4MWare` middleware authenticates every request from AWS KMS using the shared
+SigV4 secret. That signature is the trust boundary — it matches AWS's model in which the
+AWS key policy / IAM is the source of truth for which principals may use a key.
+
+Every XKS operation (`encrypt`, `decrypt`, `metadata`) runs under a single reserved KMS
+identity, `AWS_XKS_SERVICE_USER` (`[aws-xks-service]`, defined in `mod.rs`), so any
+correctly-signed request works regardless of the caller ARN. The `awsPrincipalArn` in the
+request body is used for audit logging only, never for authorization.
+
+Keys are **owned by `default_username`**, exactly as before, so operators keep full
+administrative control (list, revoke, destroy, export) and key creation still satisfies the
+`privileged_users` policy. `CreateKey` grants the reserved identity exactly `Encrypt`,
+`Decrypt`, and `GetAttributes` — it is a least-privilege delegate that can neither revoke,
+destroy, nor export key material (`Get` is deliberately not granted).
+
+Two consequences follow from the grant-based model:
+
+- The XKS endpoints can only reach objects that carry this grant, i.e. XKS keys — never any
+  other object owned by `default_username`.
+- Because the identity is wrapped in square brackets, it cannot collide with any identity a
+  client can authenticate as (JWT `email`/subject, TLS certificate CN, AWS principal ARN,
+  API-token user), so it cannot be impersonated over the normal interfaces.
+
+Keys created by earlier KMS versions carried a grant bound to the creating ARN instead. On
+startup, `migrate_aws_xks_key_access` (in `start_kms_server.rs`) grants those
+`aws-xks`-tagged keys to the reserved identity. It is idempotent and performs no writes once
+every key is up to date.
+
 ## Testing
 
 Follow the instructions in `test_data/aws_xks/README.md` to run the AWS XKS tests.

--- a/crate/server/src/routes/aws_xks/README.md
+++ b/crate/server/src/routes/aws_xks/README.md
@@ -34,6 +34,34 @@ startup, `migrate_aws_xks_key_access` (in `start_kms_server.rs`) grants those
 `aws-xks`-tagged keys to the reserved identity. It is idempotent and performs no writes once
 every key is up to date.
 
+## Monitoring and lifecycle management
+
+AWS never calls back into the XKS proxy to list, rotate, revoke, or destroy key material —
+the proxy spec only defines `GetKeyMetadata`/`Encrypt`/`Decrypt`/`GetHealthStatus`. This
+means lifecycle management of `aws-xks`-tagged keys (listing/monitoring, revocation,
+destruction) is entirely an operator responsibility, exercised through the normal
+`ckms`/Web UI surface by whoever authenticates as the real, credentialed `default_username`
+identity (the owner of every XKS key).
+
+**A Crypto Officer must be designated for this** (`crypto_officer.users` /
+`privileged_users`, backed by a real TLS certificate CN or OIDC subject). Server startup logs
+a warning when AWS XKS is enabled and no Crypto Officer is configured
+(`validate_aws_xks_reserved_identity_config` in `start_kms_server.rs`), since that combination
+means no one can currently reach these keys this way.
+
+**XKS keys cannot be rotated in place.** `ReKey` (manual or via the auto-rotation scheduler)
+always assigns a new internal unique identifier and deactivates the old one — but AWS KMS
+always calls the proxy back with the *original* external key id, with no way to learn about
+a new one. `SqlSymmetricRekeyer::validate` therefore rejects `ReKey` on any `aws-xks`-tagged
+key with an explicit error. To rotate the material behind an external key, create a new
+external key (new CMK) in AWS KMS and destroy the old one once it is no longer in use.
+
+**Never** attempt to grant this responsibility to `AWS_XKS_SERVICE_USER` itself, or issue it
+a real credential (TLS cert, OIDC account, etc.) — the `reject_reserved_aws_xks_identity`
+guard exists specifically to keep that identity unreachable outside the SigV4-authenticated
+proxy path. Doing so would let any holder of that credential call `Encrypt`/`Decrypt` on
+every XKS key over plain KMIP/REST, bypassing AWS's SigV4 trust boundary entirely.
+
 ## Testing
 
 Follow the instructions in `test_data/aws_xks/README.md` to run the AWS XKS tests.

--- a/crate/server/src/routes/aws_xks/encrypt_decrypt/decrypt_.rs
+++ b/crate/server/src/routes/aws_xks/encrypt_decrypt/decrypt_.rs
@@ -25,6 +25,7 @@ use crate::{
     middlewares::UserId,
     result::KResult,
     routes::aws_xks::{
+        AWS_XKS_SERVICE_USER,
         encrypt_decrypt::{EncryptionAlgorithm, RequestMetadata},
         error::{XksErrorName, XksErrorReply},
     },
@@ -208,13 +209,17 @@ pub(crate) async fn decrypt(
     }
 }
 
-async fn decrypt_inner(
+pub(crate) async fn decrypt_inner(
     _req_http: HttpRequest,
     request: DecryptRequest,
     key_id_or_tags: String,
     kms: &Arc<KMS>,
 ) -> KResult<DecryptResponse> {
-    let user = request.requestMetadata.awsPrincipalArn;
+    // The request is trusted because it passed SigV4 verification (see `Sigv4MWare`).
+    // The operation runs as the reserved `AWS_XKS_SERVICE_USER`, which holds a least-privilege
+    // grant on every XKS key, so authorization no longer depends on the caller ARN;
+    // `awsPrincipalArn` is retained for audit logging only.
+    let user = UserId::from(AWS_XKS_SERVICE_USER);
     let cryptographic_parameters = match request.encryptionAlgorithm {
         EncryptionAlgorithm::AES_GCM => CryptographicParameters {
             cryptographic_algorithm: Some(CryptographicAlgorithm::AES),
@@ -249,7 +254,7 @@ async fn decrypt_inner(
                 authenticated_encryption_additional_data: aead.clone(),
                 authenticated_encryption_tag: Some(tag),
             },
-            &UserId::from(user.as_str()),
+            &user,
         )
         .await?;
     let plaintext = response

--- a/crate/server/src/routes/aws_xks/encrypt_decrypt/encrypt_.rs
+++ b/crate/server/src/routes/aws_xks/encrypt_decrypt/encrypt_.rs
@@ -29,6 +29,7 @@ use crate::{
     middlewares::UserId,
     result::KResult,
     routes::aws_xks::{
+        AWS_XKS_SERVICE_USER,
         encrypt_decrypt::{CdivAlgorithm, EncryptionAlgorithm, RequestMetadata},
         error::{XksErrorName, XksErrorReply},
     },
@@ -257,13 +258,17 @@ pub(crate) async fn encrypt(
     }
 }
 
-async fn encrypt_inner(
+pub(crate) async fn encrypt_inner(
     _req_http: HttpRequest,
     request: EncryptRequest,
     key_id_or_tags: String,
     kms: &Arc<KMS>,
 ) -> KResult<EncryptResponse> {
-    let user = request.requestMetadata.awsPrincipalArn;
+    // The request is trusted because it passed SigV4 verification (see `Sigv4MWare`).
+    // The operation runs as the reserved `AWS_XKS_SERVICE_USER`, which holds a least-privilege
+    // grant on every XKS key, so authorization no longer depends on the caller ARN;
+    // `awsPrincipalArn` is retained for audit logging only.
+    let user = UserId::from(AWS_XKS_SERVICE_USER);
 
     let cryptographic_parameters = match request.encryptionAlgorithm {
         EncryptionAlgorithm::AES_GCM => CryptographicParameters {
@@ -294,7 +299,7 @@ async fn encrypt_inner(
                 final_indicator: None,
                 authenticated_encryption_additional_data: aead.clone(),
             },
-            &UserId::from(user.as_str()),
+            &user,
         )
         .await?;
     let ciphertext = response

--- a/crate/server/src/routes/aws_xks/encrypt_decrypt/mod.rs
+++ b/crate/server/src/routes/aws_xks/encrypt_decrypt/mod.rs
@@ -1,7 +1,11 @@
 mod decrypt_;
 mod encrypt_;
 pub(crate) use decrypt_::decrypt;
+#[cfg(test)]
+pub(crate) use decrypt_::{DecryptRequest, decrypt_inner};
 pub(crate) use encrypt_::encrypt;
+#[cfg(test)]
+pub(crate) use encrypt_::{EncryptRequest, EncryptResponse, encrypt_inner};
 use serde::{Deserialize, Serialize};
 
 /// Request Payload Parameters: The HTTP body of the request contains the requestMetadata.

--- a/crate/server/src/routes/aws_xks/key_metadata.rs
+++ b/crate/server/src/routes/aws_xks/key_metadata.rs
@@ -27,7 +27,10 @@ use tracing::{debug, info};
 use crate::{
     core::KMS,
     middlewares::UserId,
-    routes::aws_xks::error::{XksErrorName, XksErrorReply},
+    routes::aws_xks::{
+        AWS_XKS_SERVICE_USER,
+        error::{XksErrorName, XksErrorReply},
+    },
 };
 
 /// Returns the current UTC time with milliseconds set to zero.
@@ -190,13 +193,17 @@ pub(crate) async fn get_key_metadata(
     }
 }
 
-async fn get_key_metadata_inner(
+pub(crate) async fn get_key_metadata_inner(
     _req_http: HttpRequest,
-    request: GetKeyMetadataRequest,
+    _request: GetKeyMetadataRequest,
     key_id: String,
     kms: &Arc<KMS>,
 ) -> Result<GetKeyMetadataResponse, XksErrorReply> {
-    let user = request.requestMetadata.awsPrincipalArn;
+    // Run the lookup as the reserved `AWS_XKS_SERVICE_USER`, which holds a `GetAttributes`
+    // grant on every XKS key, so any SigV4-authenticated caller can read the metadata. The
+    // caller ARN (`request.requestMetadata.awsPrincipalArn`) is audit-only and logged by the
+    // handler.
+    let user = UserId::from(AWS_XKS_SERVICE_USER);
 
     let response = kms
         .get_attributes(
@@ -204,7 +211,7 @@ async fn get_key_metadata_inner(
                 unique_identifier: Some(UniqueIdentifier::TextString(key_id)),
                 attribute_reference: None,
             },
-            &UserId::from(user.as_str()),
+            &user,
         )
         .await
         .map_err(|e| XksErrorReply {
@@ -271,13 +278,18 @@ async fn get_key_metadata_inner(
     })
 }
 
-async fn create_key(
+pub(crate) async fn create_key(
     _req_http: HttpRequest,
-    request: GetKeyMetadataRequest,
+    _request: GetKeyMetadataRequest,
     key_id: String,
     kms: &Arc<KMS>,
 ) -> Result<GetKeyMetadataResponse, XksErrorReply> {
-    let aws_user = request.requestMetadata.awsPrincipalArn;
+    // The key is owned by `default_username`, exactly as before, so that operators keep full
+    // administrative control over XKS keys (list, revoke, destroy, export) and so that
+    // creation passes the `privileged_users` check. Usage is then delegated to the reserved
+    // `AWS_XKS_SERVICE_USER` identity via an explicit, least-privilege grant below — never to
+    // the transient caller ARN. The caller ARN is audit-only and logged by the handler.
+    let owner = UserId::from(kms.params.default_username.clone());
     let uid = UniqueIdentifier::TextString(key_id);
     // Set the activation date  in the past to have the key immediately active
     let activation_date = time_normalize().map_err(|e| XksErrorReply {
@@ -312,10 +324,7 @@ async fn create_key(
         protection_storage_masks: None,
     };
 
-    if let Err(e) = kms
-        .create(create, &UserId::from(kms.params.default_username.as_str()))
-        .await
-    {
+    if let Err(e) = kms.create(create, &owner).await {
         // If the key already exists, ignore the creation error (idempotent CreateKey).
         let get_att_response = kms
             .get_attributes(
@@ -323,7 +332,7 @@ async fn create_key(
                     unique_identifier: Some(uid.clone()),
                     attribute_reference: None,
                 },
-                &UserId::from(kms.params.default_username.as_str()),
+                &owner,
             )
             .await
             .map_err(|e| XksErrorReply {
@@ -338,28 +347,34 @@ async fn create_key(
                 errorMessage: Some(format!("Failed to create XKS key {uid}: {e}")),
             });
         }
-    } else {
-        // Grant Encrypt and Decrypt usage for the created key to the AWS user
-        kms.grant_access(
-            &Access {
-                unique_identifier: Some(uid.clone()),
-                user_id: aws_user.clone(),
-                operation_types: vec![
-                    KmipOperation::Encrypt,
-                    KmipOperation::Decrypt,
-                    KmipOperation::GetAttributes,
-                ],
-            },
-            &UserId::from(kms.params.default_username.as_str()),
-        )
-        .await
-        .map_err(|e| XksErrorReply {
-            errorName: XksErrorName::InternalException,
-            errorMessage: Some(format!(
-                "Failed to grant access to key {uid}, to user {aws_user}: {e}"
-            )),
-        })?;
     }
+
+    // Delegate usage to the reserved XKS service identity. Granting exactly these three
+    // operations keeps the XKS endpoints least-privileged: they can never revoke, destroy,
+    // or export the key, and they can only reach keys that carry this grant.
+    //
+    // This runs unconditionally — including on the "key already exists" path — because
+    // `grant_operations` is additive and idempotent. It therefore also repairs keys created
+    // by an earlier version (or by an interrupted CreateKey) that lack the grant.
+    kms.grant_access(
+        &Access {
+            unique_identifier: Some(uid.clone()),
+            user_id: AWS_XKS_SERVICE_USER.to_owned(),
+            operation_types: vec![
+                KmipOperation::Encrypt,
+                KmipOperation::Decrypt,
+                KmipOperation::GetAttributes,
+            ],
+        },
+        &owner,
+    )
+    .await
+    .map_err(|e| XksErrorReply {
+        errorName: XksErrorName::InternalException,
+        errorMessage: Some(format!(
+            "Failed to grant XKS usage on key {uid} to `{AWS_XKS_SERVICE_USER}`: {e}"
+        )),
+    })?;
 
     // Return the key metadata
     let key_spec = "AES_256".to_owned();

--- a/crate/server/src/routes/aws_xks/key_metadata.rs
+++ b/crate/server/src/routes/aws_xks/key_metadata.rs
@@ -16,7 +16,9 @@ use cosmian_kms_server_database::reexport::cosmian_kmip::{
         kmip_attributes::Attributes,
         kmip_objects::ObjectType,
         kmip_operations::{Create, GetAttributes},
-        kmip_types::{CryptographicAlgorithm, KeyFormatType, UniqueIdentifier},
+        kmip_types::{
+            AttributeReference, CryptographicAlgorithm, KeyFormatType, Tag, UniqueIdentifier,
+        },
     },
 };
 use cosmian_logger::warn;
@@ -138,7 +140,7 @@ pub(crate) enum KeyUsage {
 ///     "keyStatus": "ENABLED"
 /// }
 /// ```
-#[derive(Serialize, Default, Deserialize)]
+#[derive(Debug, Serialize, Default, Deserialize)]
 #[allow(non_snake_case)]
 pub(crate) struct GetKeyMetadataResponse {
     /// Specifies the type of external key.
@@ -330,7 +332,10 @@ pub(crate) async fn create_key(
             .get_attributes(
                 GetAttributes {
                     unique_identifier: Some(uid.clone()),
-                    attribute_reference: None,
+                    attribute_reference: Some(vec![
+                        AttributeReference::Standard(Tag::ObjectType),
+                        AttributeReference::Standard(Tag::Tag),
+                    ]),
                 },
                 &owner,
             )
@@ -339,8 +344,19 @@ pub(crate) async fn create_key(
                 errorName: XksErrorName::InternalException,
                 errorMessage: Some(format!("Failed to check prior existence of key {uid}: {e}")),
             })?;
-        if get_att_response.attributes.object_type == Some(ObjectType::SymmetricKey) {
+        let is_xks_key = get_att_response
+            .attributes
+            .get_tags(&kms.params.vendor_identification)
+            .contains("aws-xks");
+        if get_att_response.attributes.object_type == Some(ObjectType::SymmetricKey) && is_xks_key {
             warn!("AWS XKS create: key {uid} already exists (ignoring creation).");
+        } else if get_att_response.attributes.object_type == Some(ObjectType::SymmetricKey) {
+            return Err(XksErrorReply {
+                errorName: XksErrorName::InternalException,
+                errorMessage: Some(format!(
+                    "Key {uid} already exists and is not an AWS XKS key; refusing to grant XKS access"
+                )),
+            });
         } else {
             return Err(XksErrorReply {
                 errorName: XksErrorName::InternalException,

--- a/crate/server/src/routes/aws_xks/mod.rs
+++ b/crate/server/src/routes/aws_xks/mod.rs
@@ -12,7 +12,32 @@ pub(crate) use health_status::get_health_status;
 pub(crate) use key_metadata::get_key_metadata;
 pub use sigv4_middleware::Sigv4MWare;
 
+#[cfg(test)]
+mod tests;
+
 use crate::{error::KmsError, result::KResultHelper};
+
+/// Reserved KMS identity under which every AWS XKS operation is executed.
+///
+/// The AWS XKS proxy authenticates the caller (AWS KMS) through the shared `SigV4` secret in
+/// [`Sigv4MWare`]; that signature — not the `awsPrincipalArn` carried in the request body —
+/// is the real trust boundary, matching AWS's documented "the AWS key policy is the source
+/// of truth" model. All XKS-triggered KMS operations therefore run under this single,
+/// stable identity rather than the transient caller ARN, so any correctly-signed request can
+/// use the key regardless of which IAM role AWS used.
+///
+/// XKS keys remain **owned by `default_username`** so operators keep full administrative
+/// control (list, revoke, destroy, export) and so key creation still satisfies the
+/// `privileged_users` policy. This identity is merely *granted* `Encrypt`, `Decrypt`, and
+/// `GetAttributes` on each XKS key: it is a least-privilege delegate that can perform the
+/// cryptographic operations XKS needs and nothing else.
+///
+/// The value is deliberately wrapped in square brackets so it cannot collide with any
+/// identity a client could authenticate as: JWT `email`/subject, TLS certificate Common
+/// Names, AWS principal ARNs, and API-token user names can never contain the bracket
+/// framing. Combined with the grant-based model, the set of objects reachable through the
+/// XKS endpoints is exactly the set of XKS keys — no other object can be touched.
+pub(crate) const AWS_XKS_SERVICE_USER: &str = "[aws-xks-service]";
 
 #[derive(Debug, Clone)]
 pub struct AwsXksParams {

--- a/crate/server/src/routes/aws_xks/tests.rs
+++ b/crate/server/src/routes/aws_xks/tests.rs
@@ -47,6 +47,7 @@ use crate::{
     config::ServerParams,
     core::KMS,
     error::KmsError,
+    middlewares::UserId,
     result::KResult,
     start_kms_server::migrate_aws_xks_key_access,
     tests::test_utils::{https_clap_config, test_kms},
@@ -160,7 +161,7 @@ async fn provision_xks_key(kms: &Arc<KMS>, key_id: &str, creator_arn: &str) -> K
 
 /// Create an AES-256 symmetric key owned by `owner` **without** the `aws-xks` tag, to model
 /// a non-XKS key that must remain unreachable from the XKS endpoints.
-async fn create_plain_symmetric_key(kms: &Arc<KMS>, key_id: &str, owner: &str) -> KResult<()> {
+async fn create_plain_symmetric_key(kms: &Arc<KMS>, key_id: &str, owner: &UserId) -> KResult<()> {
     let uid = UniqueIdentifier::TextString(key_id.to_owned());
     let mut attributes = Attributes {
         cryptographic_algorithm: Some(CryptographicAlgorithm::AES),
@@ -190,26 +191,28 @@ async fn create_plain_symmetric_key(kms: &Arc<KMS>, key_id: &str, owner: &str) -
 async fn create_key_keeps_operator_ownership_and_grants_reserved_identity() -> KResult<()> {
     let kms = test_kms().await?;
     let key_id = "xks-key-ownership";
+    let creator = UserId::from("arn:aws:iam::1:role/Creator");
+    let xks_service_user = UserId::from(AWS_XKS_SERVICE_USER);
     provision_xks_key(&kms, key_id, "arn:aws:iam::1:role/Creator").await?;
 
     // Ownership stays with `default_username` so operators keep full administrative control
     // (list / revoke / destroy / export) over XKS keys.
     assert!(
         kms.database
-            .is_object_owned_by(key_id, &kms.params.default_username)
+            .is_object_owned_by(key_id, &UserId::from(kms.params.default_username.as_str()))
             .await?
     );
     // The caller ARN gets no rights at all: usage must not be bound to a transient principal.
     let arn_ops = kms
         .database
-        .list_user_operations_on_object(key_id, "arn:aws:iam::1:role/Creator", false)
+        .list_user_operations_on_object(key_id, &creator, false)
         .await?;
     assert!(arn_ops.is_empty(), "caller ARN must not receive any grant");
 
     // The reserved identity holds exactly the three operations XKS needs — no more.
     let ops = kms
         .database
-        .list_user_operations_on_object(key_id, AWS_XKS_SERVICE_USER, false)
+        .list_user_operations_on_object(key_id, &xks_service_user, false)
         .await?;
     assert_eq!(
         ops,
@@ -254,6 +257,7 @@ async fn create_key_succeeds_when_privileged_users_are_configured() -> KResult<(
 async fn create_key_is_idempotent_and_repairs_missing_grant() -> KResult<()> {
     let kms = test_kms().await?;
     let key_id = "xks-key-idempotent";
+    let xks_service_user = UserId::from(AWS_XKS_SERVICE_USER);
     provision_xks_key(&kms, key_id, "arn:aws:iam::1:role/Creator").await?;
 
     // A second CreateKey for the same id (AWS retries) must succeed and leave the grant intact.
@@ -261,7 +265,7 @@ async fn create_key_is_idempotent_and_repairs_missing_grant() -> KResult<()> {
 
     let ops = kms
         .database
-        .list_user_operations_on_object(key_id, AWS_XKS_SERVICE_USER, false)
+        .list_user_operations_on_object(key_id, &xks_service_user, false)
         .await?;
     assert!(ops.contains(&KmipOperation::Encrypt));
     assert!(ops.contains(&KmipOperation::Decrypt));
@@ -286,6 +290,47 @@ async fn create_key_is_idempotent_and_repairs_missing_grant() -> KResult<()> {
 }
 
 #[tokio::test]
+async fn create_key_rejects_existing_non_xks_symmetric_key() -> KResult<()> {
+    let kms = test_kms().await?;
+    let key_id = "plain-key-create-collision";
+    let default_username = UserId::from(kms.params.default_username.as_str());
+    let xks_service_user = UserId::from(AWS_XKS_SERVICE_USER);
+    create_plain_symmetric_key(&kms, key_id, &default_username).await?;
+
+    let err = create_key(
+        http_req(),
+        metadata_request("arn:aws:iam::1:role/Attacker", "CreateKey"),
+        key_id.to_owned(),
+        &kms,
+    )
+    .await;
+    let Err(err) = err else {
+        panic!("CreateKey must reject collisions with non-XKS symmetric keys");
+    };
+
+    assert!(matches!(
+        err.errorName,
+        super::error::XksErrorName::InternalException
+    ));
+    assert_eq!(
+        err.errorMessage.as_deref(),
+        Some(
+            "Key plain-key-create-collision already exists and is not an AWS XKS key; refusing to grant XKS access"
+        )
+    );
+
+    let ops = kms
+        .database
+        .list_user_operations_on_object(key_id, &xks_service_user, false)
+        .await?;
+    assert!(
+        ops.is_empty(),
+        "the reserved XKS identity must not gain access to a non-XKS key"
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn operator_retains_administrative_control() -> KResult<()> {
     // Regression guard: XKS keys must stay administrable. If the reserved identity owned
     // them, no operator could list, revoke, destroy, or export XKS keys, because the
@@ -294,17 +339,18 @@ async fn operator_retains_administrative_control() -> KResult<()> {
     let key_id = "xks-key-admin-control";
     provision_xks_key(&kms, key_id, "arn:aws:iam::1:role/Creator").await?;
     let operator = kms.params.default_username.clone();
+    let operator_id = UserId::from(operator.clone());
 
     // The operator sees the key among the objects they own.
-    let owned = kms.list_owned_objects(&operator).await?;
+    let owned = kms.list_owned_objects(&operator_id).await?;
     assert!(
         owned.iter().any(|o| o.object_id.to_string() == key_id),
         "operator must still see XKS keys in their owned objects"
     );
 
     // And can perform the full administrative lifecycle on it.
-    kms.revoke(revoke_request(key_id), &operator).await?;
-    kms.destroy(destroy_request(key_id), &operator).await?;
+    kms.revoke(revoke_request(key_id), &operator_id).await?;
+    kms.destroy(destroy_request(key_id), &operator_id).await?;
     Ok(())
 }
 
@@ -315,18 +361,17 @@ async fn xks_identity_cannot_perform_administrative_operations() -> KResult<()> 
     // rejection so the test cannot pass because of an unrelated lifecycle error.
     let kms = test_kms().await?;
     let key_id = "xks-key-least-privilege";
+    let xks_service_user = UserId::from(AWS_XKS_SERVICE_USER);
     provision_xks_key(&kms, key_id, "arn:aws:iam::1:role/Creator").await?;
 
-    let revoked = kms
-        .revoke(revoke_request(key_id), AWS_XKS_SERVICE_USER)
-        .await;
+    let revoked = kms.revoke(revoke_request(key_id), &xks_service_user).await;
     assert!(
         is_permission_error(&revoked),
         "revoke by the XKS identity must be denied for lack of permission, got: {revoked:?}"
     );
 
     let destroyed = kms
-        .destroy(destroy_request(key_id), AWS_XKS_SERVICE_USER)
+        .destroy(destroy_request(key_id), &xks_service_user)
         .await;
     assert!(
         is_permission_error(&destroyed),
@@ -345,7 +390,7 @@ async fn xks_identity_cannot_perform_administrative_operations() -> KResult<()> 
                 key_compression_type: None,
                 key_wrapping_specification: None,
             },
-            AWS_XKS_SERVICE_USER,
+            &xks_service_user,
         )
         .await;
     assert!(
@@ -355,7 +400,7 @@ async fn xks_identity_cannot_perform_administrative_operations() -> KResult<()> 
     );
 
     // The operator (owner) is unaffected and can still administer the key.
-    let operator = kms.params.default_username.clone();
+    let operator = UserId::from(kms.params.default_username.clone());
     kms.revoke(revoke_request(key_id), &operator).await?;
     Ok(())
 }
@@ -419,7 +464,7 @@ async fn xks_cannot_reach_non_xks_admin_key() -> KResult<()> {
     // the reserved identity neither owns it nor holds a grant.
     let kms = test_kms().await?;
     let key_id = "admin-only-key";
-    let default_username = kms.params.default_username.clone();
+    let default_username = UserId::from(kms.params.default_username.as_str());
     create_plain_symmetric_key(&kms, key_id, &default_username).await?;
 
     let result = encrypt_inner(
@@ -438,13 +483,22 @@ async fn xks_cannot_reach_non_xks_admin_key() -> KResult<()> {
 }
 
 #[tokio::test]
-async fn legacy_key_is_migrated_to_reserved_identity() -> KResult<()> {
-    // Model an already-shipped XKS key: owned by `default_username` and tagged `aws-xks`, but
-    // with no grant to the reserved identity. Before migration the reserved identity cannot
-    // use it; after migration it can.
+async fn legacy_key_owned_by_previous_default_user_is_migrated_to_reserved_identity() -> KResult<()>
+{
+    // Model an already-shipped XKS key after an operator rotates `default_username`: the key
+    // is still owned by the previous default owner, carries the `aws-xks` tag, and has no
+    // grant to the reserved identity. Before migration the reserved identity cannot use it;
+    // after migration it can.
     let kms = test_kms().await?;
     let key_id = "legacy-xks-key";
     let default_username = kms.params.default_username.clone();
+    let xks_service_user = UserId::from(AWS_XKS_SERVICE_USER);
+    let previous_default_user = UserId::from("legacy-admin@acme.com");
+    let previous_default_username = "legacy-admin@acme.com";
+    assert_ne!(
+        previous_default_username, default_username,
+        "test setup requires a legacy owner distinct from the current default username"
+    );
 
     let uid = UniqueIdentifier::TextString(key_id.to_owned());
     let mut attributes = Attributes {
@@ -466,7 +520,16 @@ async fn legacy_key_is_migrated_to_reserved_identity() -> KResult<()> {
         attributes,
         protection_storage_masks: None,
     };
-    kms.create(create, &default_username).await?;
+    kms.create(create, &previous_default_user).await?;
+
+    let owner = kms
+        .database
+        .retrieve_object(key_id)
+        .await?
+        .expect("legacy xks key should exist")
+        .owner()
+        .to_owned();
+    assert_eq!(owner, previous_default_username);
 
     // Before migration: the reserved identity has no access.
     let before = encrypt_inner(
@@ -499,7 +562,22 @@ async fn legacy_key_is_migrated_to_reserved_identity() -> KResult<()> {
         &kms,
     )
     .await?;
-    assert_eq!(STANDARD.decode(dec.plaintext).unwrap(), b"data");
+    let ops = kms
+        .database
+        .list_user_operations_on_object(key_id, &xks_service_user, false)
+        .await?;
+    assert_eq!(
+        ops,
+        HashSet::from([
+            KmipOperation::Encrypt,
+            KmipOperation::Decrypt,
+            KmipOperation::GetAttributes,
+        ])
+    );
+    assert_eq!(
+        STANDARD.decode(dec.plaintext).expect("valid base64"),
+        b"data"
+    );
     Ok(())
 }
 

--- a/crate/server/src/routes/aws_xks/tests.rs
+++ b/crate/server/src/routes/aws_xks/tests.rs
@@ -1,0 +1,525 @@
+//! Unit tests for the AWS XKS proxy authorization model (issue #1093).
+//!
+//! These tests exercise the handler *inner* functions directly (bypassing the `SigV4`
+//! middleware, which is validated separately) to assert that:
+//! - XKS operations run as the reserved [`AWS_XKS_SERVICE_USER`] least-privilege identity,
+//!   while the keys stay owned by `default_username` so operators keep administering them;
+//! - any `SigV4`-authenticated caller ARN can use a key (the #1093 regression);
+//! - the XKS endpoints cannot reach arbitrary non-XKS keys owned by `default_username`;
+//! - already-shipped keys are migrated so the reserved identity can operate them.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn
+)]
+
+use std::{collections::HashSet, sync::Arc};
+
+use actix_web::{HttpRequest, test::TestRequest};
+use base64::{Engine, engine::general_purpose::STANDARD};
+use cosmian_kms_server_database::reexport::cosmian_kmip::{
+    kmip_0::kmip_types::{
+        CryptographicUsageMask, ErrorReason, RevocationReason, RevocationReasonCode,
+    },
+    kmip_2_1::{
+        KmipOperation,
+        kmip_attributes::Attributes,
+        kmip_objects::ObjectType,
+        kmip_operations::{Create, Destroy, Get, Revoke},
+        kmip_types::{CryptographicAlgorithm, KeyFormatType, UniqueIdentifier},
+    },
+};
+use time::OffsetDateTime;
+
+use super::{
+    AWS_XKS_SERVICE_USER,
+    encrypt_decrypt::{
+        DecryptRequest, EncryptRequest, EncryptResponse, EncryptionAlgorithm,
+        RequestMetadata as CryptoRequestMetadata, decrypt_inner, encrypt_inner,
+    },
+    key_metadata::{
+        GetKeyMetadataRequest, KeyUsage, RequestMetadata as MetadataRequestMetadata, create_key,
+        get_key_metadata_inner,
+    },
+};
+use crate::{
+    config::ServerParams,
+    core::KMS,
+    error::KmsError,
+    result::KResult,
+    start_kms_server::migrate_aws_xks_key_access,
+    tests::test_utils::{https_clap_config, test_kms},
+};
+
+fn http_req() -> HttpRequest {
+    TestRequest::default().to_http_request()
+}
+
+fn revoke_request(key_id: &str) -> Revoke {
+    Revoke {
+        unique_identifier: Some(UniqueIdentifier::TextString(key_id.to_owned())),
+        revocation_reason: RevocationReason {
+            revocation_reason_code: RevocationReasonCode::CessationOfOperation,
+            revocation_message: None,
+        },
+        compromise_occurrence_date: None,
+        cascade: false,
+    }
+}
+
+fn destroy_request(key_id: &str) -> Destroy {
+    Destroy {
+        unique_identifier: Some(UniqueIdentifier::TextString(key_id.to_owned())),
+        remove: true,
+        cascade: false,
+        expected_object_type: None,
+    }
+}
+
+/// Is this result a rejection caused by missing permissions (as opposed to, say, a key
+/// lifecycle violation)? Used to assert *why* an operation was denied.
+///
+/// Unauthorized access is reported as "not found" on some paths, because the server
+/// deliberately does not disclose the existence of objects the caller cannot access.
+fn is_permission_error<T>(result: &KResult<T>) -> bool {
+    match result {
+        Ok(_) => false,
+        Err(e) => matches!(
+            e,
+            KmsError::Unauthorized(_)
+                | KmsError::ItemNotFound(_)
+                | KmsError::Kmip21Error(
+                    ErrorReason::Permission_Denied
+                        | ErrorReason::Item_Not_Found
+                        | ErrorReason::Object_Not_Found,
+                    _
+                )
+        ),
+    }
+}
+
+fn metadata_request(arn: &str, operation: &str) -> GetKeyMetadataRequest {
+    GetKeyMetadataRequest {
+        requestMetadata: MetadataRequestMetadata {
+            awsPrincipalArn: arn.to_owned(),
+            awsSourceVpc: None,
+            awsSourceVpce: None,
+            kmsOperation: operation.to_owned(),
+            kmsRequestId: "req-metadata".to_owned(),
+        },
+    }
+}
+
+fn crypto_meta(arn: &str, operation: &str) -> CryptoRequestMetadata {
+    CryptoRequestMetadata {
+        awsPrincipalArn: arn.to_owned(),
+        awsSourceVpc: None,
+        awsSourceVpce: None,
+        kmsKeyArn: "arn:aws:kms:us-east-1:123456789012:key/xks-test".to_owned(),
+        kmsOperation: operation.to_owned(),
+        kmsRequestId: "req-crypto".to_owned(),
+        kmsViaService: None,
+    }
+}
+
+fn encrypt_request(arn: &str, plaintext: &[u8]) -> EncryptRequest {
+    EncryptRequest {
+        requestMetadata: crypto_meta(arn, "Encrypt"),
+        plaintext: STANDARD.encode(plaintext),
+        encryptionAlgorithm: EncryptionAlgorithm::AES_GCM,
+        additionalAuthenticatedData: None,
+        ciphertextDataIntegrityValueAlgorithm: None,
+    }
+}
+
+fn decrypt_request(arn: &str, enc: &EncryptResponse) -> DecryptRequest {
+    DecryptRequest {
+        requestMetadata: crypto_meta(arn, "Decrypt"),
+        ciphertext: enc.ciphertext.clone(),
+        ciphertextMetadata: enc.ciphertextMetadata.clone(),
+        encryptionAlgorithm: EncryptionAlgorithm::AES_GCM,
+        additionalAuthenticatedData: None,
+        initializationVector: enc.initializationVector.clone(),
+        authenticationTag: enc.authenticationTag.clone(),
+    }
+}
+
+/// Provision an XKS key through the public `create_key` path with the given caller ARN.
+async fn provision_xks_key(kms: &Arc<KMS>, key_id: &str, creator_arn: &str) -> KResult<()> {
+    create_key(
+        http_req(),
+        metadata_request(creator_arn, "CreateKey"),
+        key_id.to_owned(),
+        kms,
+    )
+    .await
+    .map_err(|e| crate::error::KmsError::ServerError(format!("create_key failed: {e:?}")))?;
+    Ok(())
+}
+
+/// Create an AES-256 symmetric key owned by `owner` **without** the `aws-xks` tag, to model
+/// a non-XKS key that must remain unreachable from the XKS endpoints.
+async fn create_plain_symmetric_key(kms: &Arc<KMS>, key_id: &str, owner: &str) -> KResult<()> {
+    let uid = UniqueIdentifier::TextString(key_id.to_owned());
+    let mut attributes = Attributes {
+        cryptographic_algorithm: Some(CryptographicAlgorithm::AES),
+        cryptographic_length: Some(256),
+        cryptographic_usage_mask: Some(
+            CryptographicUsageMask::Encrypt | CryptographicUsageMask::Decrypt,
+        ),
+        key_format_type: Some(KeyFormatType::TransparentSymmetricKey),
+        object_type: Some(ObjectType::SymmetricKey),
+        unique_identifier: Some(uid.clone()),
+        // Backdate activation so the key is Active (mirrors `create_key`), ensuring any
+        // rejection is due to authorization rather than key state.
+        activation_date: Some(OffsetDateTime::now_utc() - time::Duration::minutes(1)),
+        ..Attributes::default()
+    };
+    attributes.set_tags(&kms.params.vendor_identification, ["not-xks"])?;
+    let create = Create {
+        object_type: ObjectType::SymmetricKey,
+        attributes,
+        protection_storage_masks: None,
+    };
+    kms.create(create, owner).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn create_key_keeps_operator_ownership_and_grants_reserved_identity() -> KResult<()> {
+    let kms = test_kms().await?;
+    let key_id = "xks-key-ownership";
+    provision_xks_key(&kms, key_id, "arn:aws:iam::1:role/Creator").await?;
+
+    // Ownership stays with `default_username` so operators keep full administrative control
+    // (list / revoke / destroy / export) over XKS keys.
+    assert!(
+        kms.database
+            .is_object_owned_by(key_id, &kms.params.default_username)
+            .await?
+    );
+    // The caller ARN gets no rights at all: usage must not be bound to a transient principal.
+    let arn_ops = kms
+        .database
+        .list_user_operations_on_object(key_id, "arn:aws:iam::1:role/Creator", false)
+        .await?;
+    assert!(arn_ops.is_empty(), "caller ARN must not receive any grant");
+
+    // The reserved identity holds exactly the three operations XKS needs — no more.
+    let ops = kms
+        .database
+        .list_user_operations_on_object(key_id, AWS_XKS_SERVICE_USER, false)
+        .await?;
+    assert_eq!(
+        ops,
+        HashSet::from([
+            KmipOperation::Encrypt,
+            KmipOperation::Decrypt,
+            KmipOperation::GetAttributes,
+        ]),
+        "the XKS identity must be a least-privilege delegate"
+    );
+
+    // The `aws-xks` marker tag is set.
+    let tags = kms.database.retrieve_tags(key_id).await?;
+    assert!(tags.contains("aws-xks"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn create_key_succeeds_when_privileged_users_are_configured() -> KResult<()> {
+    // Regression guard: XKS keys must be created under an identity accepted by
+    // `enforce_create_permission`. Creating them under a non-privileged identity would break
+    // `CreateKey` on every deployment that configures `privileged_users`.
+    let mut clap_config = https_clap_config();
+    clap_config.privileged_users = Some(vec!["someone-else@acme.com".to_owned()]);
+    let kms = Arc::new(KMS::instantiate(Arc::new(ServerParams::try_from(clap_config)?)).await?);
+
+    provision_xks_key(&kms, "xks-key-privileged", "arn:aws:iam::1:role/Creator").await?;
+
+    // And the key is immediately usable through the XKS endpoints.
+    let enc = encrypt_inner(
+        http_req(),
+        encrypt_request("arn:aws:iam::1:role/Alice", b"payload"),
+        "xks-key-privileged".to_owned(),
+        &kms,
+    )
+    .await?;
+    assert!(!enc.ciphertext.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn create_key_is_idempotent_and_repairs_missing_grant() -> KResult<()> {
+    let kms = test_kms().await?;
+    let key_id = "xks-key-idempotent";
+    provision_xks_key(&kms, key_id, "arn:aws:iam::1:role/Creator").await?;
+
+    // A second CreateKey for the same id (AWS retries) must succeed and leave the grant intact.
+    provision_xks_key(&kms, key_id, "arn:aws:iam::1:role/Other").await?;
+
+    let ops = kms
+        .database
+        .list_user_operations_on_object(key_id, AWS_XKS_SERVICE_USER, false)
+        .await?;
+    assert!(ops.contains(&KmipOperation::Encrypt));
+    assert!(ops.contains(&KmipOperation::Decrypt));
+
+    // The key is still usable after the repeated call.
+    let enc = encrypt_inner(
+        http_req(),
+        encrypt_request("arn:aws:iam::1:role/Alice", b"still works"),
+        key_id.to_owned(),
+        &kms,
+    )
+    .await?;
+    let dec = decrypt_inner(
+        http_req(),
+        decrypt_request("arn:aws:iam::1:role/Bob", &enc),
+        key_id.to_owned(),
+        &kms,
+    )
+    .await?;
+    assert_eq!(STANDARD.decode(dec.plaintext).unwrap(), b"still works");
+    Ok(())
+}
+
+#[tokio::test]
+async fn operator_retains_administrative_control() -> KResult<()> {
+    // Regression guard: XKS keys must stay administrable. If the reserved identity owned
+    // them, no operator could list, revoke, destroy, or export XKS keys, because the
+    // authorization model grants nothing to non-owners without an explicit grant.
+    let kms = test_kms().await?;
+    let key_id = "xks-key-admin-control";
+    provision_xks_key(&kms, key_id, "arn:aws:iam::1:role/Creator").await?;
+    let operator = kms.params.default_username.clone();
+
+    // The operator sees the key among the objects they own.
+    let owned = kms.list_owned_objects(&operator).await?;
+    assert!(
+        owned.iter().any(|o| o.object_id.to_string() == key_id),
+        "operator must still see XKS keys in their owned objects"
+    );
+
+    // And can perform the full administrative lifecycle on it.
+    kms.revoke(revoke_request(key_id), &operator).await?;
+    kms.destroy(destroy_request(key_id), &operator).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn xks_identity_cannot_perform_administrative_operations() -> KResult<()> {
+    // The reserved identity is a least-privilege delegate: it may encrypt/decrypt but must
+    // never be able to revoke or destroy the key. The assertions check the *reason* for the
+    // rejection so the test cannot pass because of an unrelated lifecycle error.
+    let kms = test_kms().await?;
+    let key_id = "xks-key-least-privilege";
+    provision_xks_key(&kms, key_id, "arn:aws:iam::1:role/Creator").await?;
+
+    let revoked = kms
+        .revoke(revoke_request(key_id), AWS_XKS_SERVICE_USER)
+        .await;
+    assert!(
+        is_permission_error(&revoked),
+        "revoke by the XKS identity must be denied for lack of permission, got: {revoked:?}"
+    );
+
+    let destroyed = kms
+        .destroy(destroy_request(key_id), AWS_XKS_SERVICE_USER)
+        .await;
+    assert!(
+        is_permission_error(&destroyed),
+        "destroy by the XKS identity must be denied for lack of permission, got: {destroyed:?}"
+    );
+
+    // Most importantly, it must not be able to export the key material. The grant covers
+    // `GetAttributes` only; `Get` is deliberately excluded so the XKS endpoints can never be
+    // used to exfiltrate key bytes.
+    let exported = kms
+        .get(
+            Get {
+                unique_identifier: Some(UniqueIdentifier::TextString(key_id.to_owned())),
+                key_format_type: None,
+                key_wrap_type: None,
+                key_compression_type: None,
+                key_wrapping_specification: None,
+            },
+            AWS_XKS_SERVICE_USER,
+        )
+        .await;
+    assert!(
+        is_permission_error(&exported),
+        "the XKS identity must not be able to export key material, got: {:?}",
+        exported.map(|_| "<key material returned>")
+    );
+
+    // The operator (owner) is unaffected and can still administer the key.
+    let operator = kms.params.default_username.clone();
+    kms.revoke(revoke_request(key_id), &operator).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn non_creator_arn_can_encrypt_and_decrypt() -> KResult<()> {
+    // Regression test for issue #1093: key usage must not depend on the caller ARN.
+    let kms = test_kms().await?;
+    let key_id = "xks-key-regression";
+    provision_xks_key(&kms, key_id, "arn:aws:iam::1:role/Creator").await?;
+
+    let plaintext = b"Hello XKS World!";
+    // A different ARN than the creator encrypts.
+    let enc = encrypt_inner(
+        http_req(),
+        encrypt_request("arn:aws:iam::1:role/Alice", plaintext),
+        key_id.to_owned(),
+        &kms,
+    )
+    .await?;
+
+    // Yet another ARN decrypts and recovers the original plaintext.
+    let dec = decrypt_inner(
+        http_req(),
+        decrypt_request("arn:aws:iam::1:role/Bob", &enc),
+        key_id.to_owned(),
+        &kms,
+    )
+    .await?;
+
+    let recovered = STANDARD.decode(dec.plaintext).unwrap();
+    assert_eq!(recovered, plaintext);
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_key_metadata_works_for_any_arn() -> KResult<()> {
+    let kms = test_kms().await?;
+    let key_id = "xks-key-metadata";
+    provision_xks_key(&kms, key_id, "arn:aws:iam::1:role/Creator").await?;
+
+    let md = get_key_metadata_inner(
+        http_req(),
+        metadata_request("arn:aws:iam::1:role/Stranger", "GetKeyMetadata"),
+        key_id.to_owned(),
+        &kms,
+    )
+    .await
+    .expect("get_key_metadata_inner failed");
+
+    assert_eq!(md.keySpec, "AES_256");
+    assert_eq!(md.keyStatus, "ENABLED");
+    assert!(md.keyUsage.contains(&KeyUsage::ENCRYPT));
+    assert!(md.keyUsage.contains(&KeyUsage::DECRYPT));
+    Ok(())
+}
+
+#[tokio::test]
+async fn xks_cannot_reach_non_xks_admin_key() -> KResult<()> {
+    // A non-XKS key owned by `default_username` must not be usable through the XKS endpoint:
+    // the reserved identity neither owns it nor holds a grant.
+    let kms = test_kms().await?;
+    let key_id = "admin-only-key";
+    let default_username = kms.params.default_username.clone();
+    create_plain_symmetric_key(&kms, key_id, &default_username).await?;
+
+    let result = encrypt_inner(
+        http_req(),
+        encrypt_request("arn:aws:iam::1:role/Attacker", b"secret"),
+        key_id.to_owned(),
+        &kms,
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "XKS encrypt must be rejected for a non-XKS admin-owned key"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn legacy_key_is_migrated_to_reserved_identity() -> KResult<()> {
+    // Model an already-shipped XKS key: owned by `default_username` and tagged `aws-xks`, but
+    // with no grant to the reserved identity. Before migration the reserved identity cannot
+    // use it; after migration it can.
+    let kms = test_kms().await?;
+    let key_id = "legacy-xks-key";
+    let default_username = kms.params.default_username.clone();
+
+    let uid = UniqueIdentifier::TextString(key_id.to_owned());
+    let mut attributes = Attributes {
+        cryptographic_algorithm: Some(CryptographicAlgorithm::AES),
+        cryptographic_length: Some(256),
+        cryptographic_usage_mask: Some(
+            CryptographicUsageMask::Encrypt | CryptographicUsageMask::Decrypt,
+        ),
+        key_format_type: Some(KeyFormatType::TransparentSymmetricKey),
+        object_type: Some(ObjectType::SymmetricKey),
+        unique_identifier: Some(uid.clone()),
+        // Backdate activation so the key is Active, matching a real (shipped) XKS key.
+        activation_date: Some(OffsetDateTime::now_utc() - time::Duration::minutes(1)),
+        ..Attributes::default()
+    };
+    attributes.set_tags(&kms.params.vendor_identification, ["aws-xks"])?;
+    let create = Create {
+        object_type: ObjectType::SymmetricKey,
+        attributes,
+        protection_storage_masks: None,
+    };
+    kms.create(create, &default_username).await?;
+
+    // Before migration: the reserved identity has no access.
+    let before = encrypt_inner(
+        http_req(),
+        encrypt_request("arn:aws:iam::1:role/Alice", b"data"),
+        key_id.to_owned(),
+        &kms,
+    )
+    .await;
+    assert!(
+        before.is_err(),
+        "legacy key should be inaccessible pre-migration"
+    );
+
+    // Run the startup migration.
+    migrate_aws_xks_key_access(&kms).await?;
+
+    // After migration: the reserved identity can encrypt and decrypt.
+    let enc = encrypt_inner(
+        http_req(),
+        encrypt_request("arn:aws:iam::1:role/Alice", b"data"),
+        key_id.to_owned(),
+        &kms,
+    )
+    .await?;
+    let dec = decrypt_inner(
+        http_req(),
+        decrypt_request("arn:aws:iam::1:role/Bob", &enc),
+        key_id.to_owned(),
+        &kms,
+    )
+    .await?;
+    assert_eq!(STANDARD.decode(dec.plaintext).unwrap(), b"data");
+    Ok(())
+}
+
+#[tokio::test]
+async fn encrypt_decrypt_round_trip_with_aad() -> KResult<()> {
+    let kms = test_kms().await?;
+    let key_id = "xks-key-aad";
+    provision_xks_key(&kms, key_id, "arn:aws:iam::1:role/Creator").await?;
+
+    let plaintext = b"payload with aad";
+    let aad = STANDARD.encode(b"project=nile");
+
+    let mut enc_req = encrypt_request("arn:aws:iam::1:role/Alice", plaintext);
+    enc_req.additionalAuthenticatedData = Some(aad.clone());
+    let enc = encrypt_inner(http_req(), enc_req, key_id.to_owned(), &kms).await?;
+
+    let mut dec_req = decrypt_request("arn:aws:iam::1:role/Bob", &enc);
+    dec_req.additionalAuthenticatedData = Some(aad);
+    let dec = decrypt_inner(http_req(), dec_req, key_id.to_owned(), &kms).await?;
+
+    assert_eq!(STANDARD.decode(dec.plaintext).unwrap(), plaintext);
+    Ok(())
+}

--- a/crate/server/src/routes/aws_xks/tests.rs
+++ b/crate/server/src/routes/aws_xks/tests.rs
@@ -26,7 +26,7 @@ use cosmian_kms_server_database::reexport::cosmian_kmip::{
         KmipOperation,
         kmip_attributes::Attributes,
         kmip_objects::ObjectType,
-        kmip_operations::{Create, Destroy, Get, Revoke},
+        kmip_operations::{Create, Destroy, Get, GetAttributes, Revoke},
         kmip_types::{CryptographicAlgorithm, KeyFormatType, UniqueIdentifier},
     },
 };
@@ -333,24 +333,57 @@ async fn create_key_rejects_existing_non_xks_symmetric_key() -> KResult<()> {
 #[tokio::test]
 async fn operator_retains_administrative_control() -> KResult<()> {
     // Regression guard: XKS keys must stay administrable. If the reserved identity owned
-    // them, no operator could list, revoke, destroy, or export XKS keys, because the
+    // them, no operator could monitor, revoke, destroy, or export XKS keys, because the
     // authorization model grants nothing to non-owners without an explicit grant.
+    //
+    // This is the identity that a designated Crypto Officer must hold a real credential
+    // for (TLS certificate CN / OIDC subject matching `default_username`) in order to
+    // monitor and manage the lifecycle of XKS keys — AWS never triggers any of this itself
+    // (the XKS proxy spec has no list/rotate/delete endpoint), so it must be reachable
+    // through the normal `ckms`/Web UI surface. See `README.md` and
+    // `documentation/docs/integrations/cloud_providers/aws/xks.md`.
     let kms = test_kms().await?;
     let key_id = "xks-key-admin-control";
     provision_xks_key(&kms, key_id, "arn:aws:iam::1:role/Creator").await?;
     let operator = kms.params.default_username.clone();
     let operator_id = UserId::from(operator.clone());
 
-    // The operator sees the key among the objects they own.
+    // Monitor: the operator sees the key among the objects they own (equivalent to `Locate`
+    // by tag through `ckms`/Web UI) and can read its attributes.
     let owned = kms.list_owned_objects(&operator_id).await?;
     assert!(
         owned.iter().any(|o| o.object_id.to_string() == key_id),
         "operator must still see XKS keys in their owned objects"
     );
+    kms.get_attributes(
+        GetAttributes {
+            unique_identifier: Some(UniqueIdentifier::TextString(key_id.to_owned())),
+            attribute_reference: None,
+        },
+        &operator_id,
+    )
+    .await?;
 
-    // And can perform the full administrative lifecycle on it.
+    // Manage: the operator can perform the full administrative lifecycle on it.
     kms.revoke(revoke_request(key_id), &operator_id).await?;
     kms.destroy(destroy_request(key_id), &operator_id).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn reserved_xks_identity_cannot_be_used_as_the_monitoring_operator() -> KResult<()> {
+    // The Crypto Officer responsible for monitoring/managing XKS keys must never be the
+    // reserved `AWS_XKS_SERVICE_USER` delegate: that identity is intentionally unreachable
+    // through any real credential (TLS/OIDC/SPIRE/UI session — see
+    // `reject_reserved_aws_xks_identity` in `middlewares/mod.rs`), and even if it were
+    // reachable, it only holds Encrypt/Decrypt/GetAttributes, never Revoke/Destroy/Get.
+    use crate::middlewares::reject_reserved_aws_xks_identity;
+
+    assert!(
+        reject_reserved_aws_xks_identity(&UserId::from(AWS_XKS_SERVICE_USER)).is_err(),
+        "the reserved AWS XKS service identity must stay unreachable through any \
+         externally-authenticated path, including for monitoring purposes"
+    );
     Ok(())
 }
 

--- a/crate/server/src/routes/ocsp/handler.rs
+++ b/crate/server/src/routes/ocsp/handler.rs
@@ -32,7 +32,10 @@ use actix_web::{
     HttpRequest, HttpResponse, get, post,
     web::{Bytes, Data, Path},
 };
-use base64::{Engine as _, engine::general_purpose::URL_SAFE};
+use base64::{
+    Engine as _, alphabet,
+    engine::{DecodePaddingMode, GeneralPurpose, GeneralPurposeConfig},
+};
 use cosmian_kms_server_database::reexport::{
     cosmian_kmip::{kmip_0::kmip_types::State, kmip_2_1::kmip_types::LinkType},
     cosmian_kms_crypto::openssl::{
@@ -67,6 +70,22 @@ const CT_OCSP_RESPONSE: &str = "application/ocsp-response";
 /// 4096 is generous headroom over any legitimate lightweight-profile request
 /// while bounding the cost of decoding an attacker-controlled path segment.
 const MAX_OCSP_GET_ENCODED_LEN: usize = 4096;
+
+/// Base64url engine used to decode the `GET /ocsp/{encoded_request}` path
+/// segment.
+///
+/// RFC 6960 Appendix A does not mandate whether the base64url encoding is
+/// padded with `=`, and real-world OCSP clients disagree (e.g. `openssl ocsp`
+/// and this project's own black-box test suite emit unpadded requests, while
+/// other libraries emit padded ones). `DecodePaddingMode::Indifferent`
+/// accepts both forms instead of rejecting well-formed requests with a
+/// spurious 422 depending on the caller's padding choice.
+static OCSP_GET_PATH_ENGINE: GeneralPurpose = GeneralPurpose::new(
+    &alphabet::URL_SAFE,
+    GeneralPurposeConfig::new()
+        .with_encode_padding(false)
+        .with_decode_padding_mode(DecodePaddingMode::Indifferent),
+);
 
 /// Returns `true` if a base64url-encoded GET path segment of the given length
 /// exceeds [`MAX_OCSP_GET_ENCODED_LEN`] and must be rejected before decoding.
@@ -140,9 +159,11 @@ pub(crate) async fn get_ocsp(
         return Ok(build_malformed_request_response());
     }
 
-    let request_der = URL_SAFE.decode(encoded.as_bytes()).map_err(|e| {
-        KmsError::InvalidRequest(format!("Invalid base64url in OCSP GET path: {e}"))
-    })?;
+    let request_der = OCSP_GET_PATH_ENGINE
+        .decode(encoded.as_bytes())
+        .map_err(|e| {
+            KmsError::InvalidRequest(format!("Invalid base64url in OCSP GET path: {e}"))
+        })?;
     info!("GET /ocsp/ ({} bytes)", request_der.len());
     handle_ocsp_request(&kms, &request_der).await
 }

--- a/crate/server/src/routes/ui_auth.rs
+++ b/crate/server/src/routes/ui_auth.rs
@@ -317,7 +317,11 @@ pub(crate) async fn callback(
         return HttpResponse::InternalServerError()
             .json(serde_json::json!({ "error": "Missing email claim in id_token" }));
     };
-    if let Err(error) = reject_reserved_aws_xks_identity(&UserId::from(user_id.as_str())) {
+    let Ok(user_id) = UserId::try_new(user_id.as_str()) else {
+        return HttpResponse::Unauthorized()
+            .json(serde_json::json!({ "error": "Empty email claim in id_token" }));
+    };
+    if let Err(error) = reject_reserved_aws_xks_identity(&user_id) {
         return HttpResponse::Unauthorized()
             .json(serde_json::json!({ "error": format!("Forbidden user identity: {error}") }));
     }
@@ -510,7 +514,12 @@ pub(crate) async fn login_as(
                     );
                 }
             };
-            if let Err(error) = reject_reserved_aws_xks_identity(&UserId::from(user_id.as_str())) {
+            let Ok(user_id) = UserId::try_new(user_id.as_str()) else {
+                return HttpResponse::Unauthorized().json(
+                    serde_json::json!({ "error": "Empty subject claim in Auth Verifier token" }),
+                );
+            };
+            if let Err(error) = reject_reserved_aws_xks_identity(&user_id) {
                 return HttpResponse::Unauthorized().json(
                     serde_json::json!({ "error": format!("Forbidden user identity: {error}") }),
                 );

--- a/crate/server/src/routes/ui_auth.rs
+++ b/crate/server/src/routes/ui_auth.rs
@@ -9,7 +9,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use url::Url;
 
-use crate::config::{AuthVerifierRuntimeConfig, OidcRuntimeConfig};
+use crate::{
+    config::{AuthVerifierRuntimeConfig, OidcRuntimeConfig},
+    middlewares::{UserId, reject_reserved_aws_xks_identity},
+};
 
 fn random_b64url(len_bytes: usize) -> Result<String, ()> {
     let mut buf = vec![0_u8; len_bytes];
@@ -314,6 +317,10 @@ pub(crate) async fn callback(
         return HttpResponse::InternalServerError()
             .json(serde_json::json!({ "error": "Missing email claim in id_token" }));
     };
+    if let Err(error) = reject_reserved_aws_xks_identity(&UserId::from(user_id.as_str())) {
+        return HttpResponse::Unauthorized()
+            .json(serde_json::json!({ "error": format!("Forbidden user identity: {error}") }));
+    }
 
     if session.insert("user_id", &user_id).is_err() {
         return HttpResponse::InternalServerError()
@@ -503,6 +510,11 @@ pub(crate) async fn login_as(
                     );
                 }
             };
+            if let Err(error) = reject_reserved_aws_xks_identity(&UserId::from(user_id.as_str())) {
+                return HttpResponse::Unauthorized().json(
+                    serde_json::json!({ "error": format!("Forbidden user identity: {error}") }),
+                );
+            }
 
             if session.insert("user_id", &user_id).is_err() {
                 return HttpResponse::InternalServerError()

--- a/crate/server/src/start_kms_server.rs
+++ b/crate/server/src/start_kms_server.rs
@@ -8,6 +8,7 @@
 //! - Setting up routes and middleware
 
 use std::{
+    collections::HashSet,
     path::PathBuf,
     sync::{Arc, mpsc},
 };
@@ -23,8 +24,10 @@ use actix_web::{
     middleware::{Condition, DefaultHeaders, from_fn},
     web::{self, Data, JsonConfig, PayloadConfig},
 };
+use cosmian_kms_access::access::Access;
 use cosmian_kms_server_database::reexport::{
     cosmian_kmip::kmip_2_1::{
+        KmipOperation,
         kmip_attributes::Attributes,
         kmip_data_structures::{KeyBlock, KeyMaterial, KeyValue},
         kmip_objects::{Object, ObjectType, PrivateKey, PublicKey},
@@ -64,7 +67,7 @@ use crate::{
     result::{KResult, KResultHelper},
     routes::{
         access,
-        aws_xks::{self},
+        aws_xks::{self, AWS_XKS_SERVICE_USER},
         azure_ekm, cli_archive_download, cli_archive_exists, crl, get_hsm_status, get_server_info,
         get_version,
         google_cse::{self, GoogleCseConfig},
@@ -218,6 +221,83 @@ pub async fn handle_google_cse_rsa_keypair(
     }
 
     info!("RSA Keypair for Google CSE created.");
+
+    Ok(())
+}
+
+/// One-time, idempotent migration that grants the reserved AWS XKS service identity access
+/// to XKS keys created by earlier KMS versions.
+///
+/// Before the fix for issue #1093, XKS keys were created with `default_username` as owner
+/// and their `Encrypt`/`Decrypt` grant bound to the transient caller ARN — so only the
+/// creating principal could use the key. XKS operations now run under the reserved
+/// [`AWS_XKS_SERVICE_USER`] identity, so already-shipped keys (owned by `default_username`
+/// and carrying the `aws-xks` tag) must be granted to that identity. Ownership is
+/// deliberately left untouched: operators keep full administrative control of the keys.
+///
+/// The grant is additive and safe to re-run on every startup: `CreateKey` applies the same
+/// grant for new keys, and re-granting existing permissions is a no-op.
+///
+/// # Errors
+///
+/// Returns a [`KmsError`] if listing tagged objects, checking ownership, or granting access
+/// fails.
+pub(crate) async fn migrate_aws_xks_key_access(kms_server: &Arc<KMS>) -> KResult<()> {
+    let default_username = &kms_server.params.default_username;
+    // Defensive: an operator could have configured `default_username` to the reserved name.
+    // `grant_access` refuses to let an owner grant themselves, and the owner already has
+    // every right, so there is nothing to do.
+    if default_username == AWS_XKS_SERVICE_USER {
+        return Ok(());
+    }
+
+    let required = [
+        KmipOperation::Encrypt,
+        KmipOperation::Decrypt,
+        KmipOperation::GetAttributes,
+    ];
+    let tags = HashSet::from(["aws-xks".to_owned()]);
+    let uids = kms_server.database.list_uids_for_tags(&tags).await?;
+
+    let mut migrated = 0_usize;
+    for uid in uids {
+        // Only keys owned by `default_username` can be granted by it; skip anything else
+        // rather than attempting a grant that would (correctly) be refused.
+        if !kms_server
+            .database
+            .is_object_owned_by(&uid, default_username)
+            .await?
+        {
+            continue;
+        }
+        // Skip keys that already carry the grant so that a steady-state restart performs no
+        // writes and logs nothing.
+        let granted = kms_server
+            .database
+            .list_user_operations_on_object(&uid, AWS_XKS_SERVICE_USER, false)
+            .await?;
+        if required.iter().all(|op| granted.contains(op)) {
+            continue;
+        }
+        kms_server
+            .grant_access(
+                &Access {
+                    unique_identifier: Some(UniqueIdentifier::TextString(uid.clone())),
+                    user_id: AWS_XKS_SERVICE_USER.to_owned(),
+                    operation_types: required.to_vec(),
+                },
+                default_username,
+            )
+            .await?;
+        migrated += 1;
+    }
+
+    if migrated > 0 {
+        info!(
+            "AWS XKS: granted usage on {migrated} pre-existing key(s) to the reserved service \
+             identity `{AWS_XKS_SERVICE_USER}`"
+        );
+    }
 
     Ok(())
 }
@@ -977,6 +1057,11 @@ pub async fn prepare_kms_server(
 
     // Should we enable the AWS XKS Service?
     let enable_aws_xks = kms_server.params.aws_xks_params.is_some();
+    if enable_aws_xks {
+        // Grant the reserved XKS service identity usage on XKS keys created by earlier
+        // versions. See `migrate_aws_xks_key_access`.
+        migrate_aws_xks_key_access(&kms_server).await?;
+    }
 
     // Should we enable the Azure EKM API ?
     let enable_azure_ekm = kms_server.params.azure_ekm.azure_ekm_enable;

--- a/crate/server/src/start_kms_server.rs
+++ b/crate/server/src/start_kms_server.rs
@@ -231,17 +231,19 @@ pub async fn handle_google_cse_rsa_keypair(
 /// Before the fix for issue #1093, XKS keys were created with `default_username` as owner
 /// and their `Encrypt`/`Decrypt` grant bound to the transient caller ARN — so only the
 /// creating principal could use the key. XKS operations now run under the reserved
-/// [`AWS_XKS_SERVICE_USER`] identity, so already-shipped keys (owned by `default_username`
-/// and carrying the `aws-xks` tag) must be granted to that identity. Ownership is
-/// deliberately left untouched: operators keep full administrative control of the keys.
+/// [`AWS_XKS_SERVICE_USER`] identity, so already-shipped keys carrying the `aws-xks` tag
+/// must be granted to that identity. The migration now performs that grant on behalf of
+/// each key's actual owner rather than assuming the current `default_username`, which also
+/// fixes the later limitation where rotating `default_username` stranded legacy XKS keys
+/// without the reserved identity grant. Ownership is deliberately left untouched:
+/// operators keep full administrative control of the keys.
 ///
 /// The grant is additive and safe to re-run on every startup: `CreateKey` applies the same
 /// grant for new keys, and re-granting existing permissions is a no-op.
 ///
 /// # Errors
 ///
-/// Returns a [`KmsError`] if listing tagged objects, checking ownership, or granting access
-/// fails.
+/// Returns a [`KmsError`] if listing tagged objects or granting access fails.
 pub(crate) async fn migrate_aws_xks_key_access(kms_server: &Arc<KMS>) -> KResult<()> {
     let default_username = &kms_server.params.default_username;
     // Defensive: an operator could have configured `default_username` to the reserved name.
@@ -261,20 +263,33 @@ pub(crate) async fn migrate_aws_xks_key_access(kms_server: &Arc<KMS>) -> KResult
 
     let mut migrated = 0_usize;
     for uid in uids {
-        // Only keys owned by `default_username` can be granted by it; skip anything else
-        // rather than attempting a grant that would (correctly) be refused.
-        if !kms_server
-            .database
-            .is_object_owned_by(&uid, default_username)
-            .await?
-        {
+        let owner = match kms_server.database.retrieve_object(&uid).await {
+            Ok(Some(owm)) => owm.owner_id().to_owned(),
+            Ok(None) => {
+                warn!(
+                    "AWS XKS: skipping migration for key `{uid}` because its owner could not be \
+                     determined (object missing)"
+                );
+                continue;
+            }
+            Err(error) => {
+                warn!(
+                    "AWS XKS: skipping migration for key `{uid}` because its owner could not be \
+                     determined: {error:?}"
+                );
+                continue;
+            }
+        };
+
+        if owner == *AWS_XKS_SERVICE_USER {
             continue;
         }
         // Skip keys that already carry the grant so that a steady-state restart performs no
         // writes and logs nothing.
+        let xks_service_user = UserId::from(AWS_XKS_SERVICE_USER);
         let granted = kms_server
             .database
-            .list_user_operations_on_object(&uid, AWS_XKS_SERVICE_USER, false)
+            .list_user_operations_on_object(&uid, &xks_service_user, false)
             .await?;
         if required.iter().all(|op| granted.contains(op)) {
             continue;
@@ -286,7 +301,7 @@ pub(crate) async fn migrate_aws_xks_key_access(kms_server: &Arc<KMS>) -> KResult
                     user_id: AWS_XKS_SERVICE_USER.to_owned(),
                     operation_types: required.to_vec(),
                 },
-                default_username,
+                &owner,
             )
             .await?;
         migrated += 1;
@@ -297,6 +312,33 @@ pub(crate) async fn migrate_aws_xks_key_access(kms_server: &Arc<KMS>) -> KResult
             "AWS XKS: granted usage on {migrated} pre-existing key(s) to the reserved service \
              identity `{AWS_XKS_SERVICE_USER}`"
         );
+    }
+
+    Ok(())
+}
+
+fn validate_aws_xks_reserved_identity_config(server_params: &ServerParams) -> KResult<()> {
+    if server_params.aws_xks_params.is_none() {
+        return Ok(());
+    }
+
+    if server_params.default_username == AWS_XKS_SERVICE_USER {
+        return Err(KmsError::ServerError(format!(
+            "AWS XKS is enabled: `default_username` must not equal the reserved AWS XKS service \
+             identity `{AWS_XKS_SERVICE_USER}`"
+        )));
+    }
+
+    if server_params
+        .crypto_officer
+        .users
+        .iter()
+        .any(|username| username == AWS_XKS_SERVICE_USER)
+    {
+        return Err(KmsError::ServerError(format!(
+            "AWS XKS is enabled: `crypto_officer.users` must not contain the reserved AWS XKS \
+             service identity `{AWS_XKS_SERVICE_USER}`"
+        )));
     }
 
     Ok(())
@@ -1058,6 +1100,7 @@ pub async fn prepare_kms_server(
     // Should we enable the AWS XKS Service?
     let enable_aws_xks = kms_server.params.aws_xks_params.is_some();
     if enable_aws_xks {
+        validate_aws_xks_reserved_identity_config(&kms_server.params)?;
         // Grant the reserved XKS service identity usage on XKS keys created by earlier
         // versions. See `migrate_aws_xks_key_access`.
         migrate_aws_xks_key_access(&kms_server).await?;
@@ -2049,5 +2092,60 @@ mod tests {
                 "Error message must identify the offending URI, got: {msg}"
             );
         }
+    }
+
+    fn sample_aws_xks_params() -> aws_xks::AwsXksParams {
+        aws_xks::AwsXksParams {
+            region: "eu-west-3".to_owned(),
+            service: "kms".to_owned(),
+            sigv4_access_key_id: "access-key".to_owned(),
+            sigv4_secret_access_key: "secret-key".to_owned(),
+        }
+    }
+
+    #[test]
+    fn aws_xks_reserved_identity_rejects_default_username() {
+        let params = ServerParams {
+            aws_xks_params: Some(sample_aws_xks_params()),
+            default_username: AWS_XKS_SERVICE_USER.to_owned(),
+            ..ServerParams::default()
+        };
+
+        let error = validate_aws_xks_reserved_identity_config(&params)
+            .expect_err("reserved default_username must be rejected when AWS XKS is enabled");
+
+        assert!(error.to_string().contains("default_username"));
+    }
+
+    #[test]
+    fn aws_xks_reserved_identity_rejects_crypto_officer_user() {
+        let mut params = ServerParams {
+            aws_xks_params: Some(sample_aws_xks_params()),
+            ..ServerParams::default()
+        };
+        params
+            .crypto_officer
+            .users
+            .push(AWS_XKS_SERVICE_USER.to_owned());
+
+        let error = validate_aws_xks_reserved_identity_config(&params).expect_err(
+            "reserved AWS XKS service identity must be rejected in crypto_officer.users",
+        );
+
+        assert!(error.to_string().contains("crypto_officer.users"));
+    }
+
+    #[test]
+    fn aws_xks_reserved_identity_validation_is_skipped_when_xks_disabled() {
+        let mut params = ServerParams {
+            default_username: AWS_XKS_SERVICE_USER.to_owned(),
+            ..ServerParams::default()
+        };
+        params
+            .crypto_officer
+            .users
+            .push(AWS_XKS_SERVICE_USER.to_owned());
+
+        assert!(validate_aws_xks_reserved_identity_config(&params).is_ok());
     }
 }

--- a/crate/server/src/start_kms_server.rs
+++ b/crate/server/src/start_kms_server.rs
@@ -272,13 +272,7 @@ pub(crate) async fn migrate_aws_xks_key_access(kms_server: &Arc<KMS>) -> KResult
                 );
                 continue;
             }
-            Err(error) => {
-                warn!(
-                    "AWS XKS: skipping migration for key `{uid}` because its owner could not be \
-                     determined: {error:?}"
-                );
-                continue;
-            }
+            Err(error) => return Err(error.into()),
         };
 
         if owner == *AWS_XKS_SERVICE_USER {

--- a/crate/server/src/start_kms_server.rs
+++ b/crate/server/src/start_kms_server.rs
@@ -281,9 +281,13 @@ pub(crate) async fn migrate_aws_xks_key_access(kms_server: &Arc<KMS>) -> KResult
         // Skip keys that already carry the grant so that a steady-state restart performs no
         // writes and logs nothing.
         let xks_service_user = UserId::from(AWS_XKS_SERVICE_USER);
+        // Query direct (non-inherited) permissions only: a wildcard (`*`) grant covering the
+        // required operations must not be mistaken for the durable service-identity grant, or
+        // this migration would skip granting it — later revoking the wildcard would then break
+        // XKS access for keys that were never actually granted to `AWS_XKS_SERVICE_USER`.
         let granted = kms_server
             .database
-            .list_user_operations_on_object(&uid, &xks_service_user, false)
+            .list_user_operations_on_object(&uid, &xks_service_user, true)
             .await?;
         if required.iter().all(|op| granted.contains(op)) {
             continue;
@@ -1096,8 +1100,38 @@ pub async fn prepare_kms_server(
     if enable_aws_xks {
         validate_aws_xks_reserved_identity_config(&kms_server.params)?;
         // Grant the reserved XKS service identity usage on XKS keys created by earlier
-        // versions. See `migrate_aws_xks_key_access`.
-        migrate_aws_xks_key_access(&kms_server).await?;
+        // versions. Run on a dedicated background thread with its own current-thread
+        // runtime instead of blocking HTTP server startup: the migration has no durable
+        // completion marker and scans every tagged key serially, so an installation with
+        // many XKS keys would otherwise incur a repeated, unbounded startup delay on every
+        // restart. A dedicated thread is required because the store traits are `?Send`
+        // (see `PermissionsStore`/`ObjectsStore`), so the migration future cannot be
+        // spawned onto the main multi-threaded runtime. The migration is additive and
+        // idempotent (see `migrate_aws_xks_key_access`), so running it concurrently with
+        // request serving is safe.
+        let migration_kms_server = kms_server.clone();
+        if let Err(error) = std::thread::Builder::new()
+            .name("aws-xks-key-migration".to_owned())
+            .spawn(move || {
+                let runtime = match tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
+                    Ok(runtime) => runtime,
+                    Err(error) => {
+                        error!("AWS XKS: failed to start key access migration runtime: {error}");
+                        return;
+                    }
+                };
+                if let Err(error) =
+                    runtime.block_on(migrate_aws_xks_key_access(&migration_kms_server))
+                {
+                    error!("AWS XKS: pre-existing key access migration failed: {error}");
+                }
+            })
+        {
+            error!("AWS XKS: failed to spawn key access migration thread: {error}");
+        }
     }
 
     // Should we enable the Azure EKM API ?

--- a/crate/server/src/start_kms_server.rs
+++ b/crate/server/src/start_kms_server.rs
@@ -339,6 +339,24 @@ fn validate_aws_xks_reserved_identity_config(server_params: &ServerParams) -> KR
         )));
     }
 
+    // AWS never calls back into the XKS proxy to list, rotate, revoke, or destroy key
+    // material (the XKS proxy API spec only defines GetKeyMetadata/Encrypt/Decrypt/
+    // GetHealthStatus) — lifecycle management of XKS keys is entirely this operator's
+    // responsibility, exercised as the real, credentialed `default_username` identity
+    // (never as the reserved, unreachable-by-design `AWS_XKS_SERVICE_USER`). Warn loudly
+    // when no Crypto Officer is configured, since that is the intended identity for this
+    // responsibility and an empty list very likely means no one can currently reach these
+    // keys through `ckms`/the Web UI.
+    if server_params.crypto_officer.users.is_empty() {
+        warn!(
+            "AWS XKS is enabled but `crypto_officer.users` is empty: no Crypto Officer is \
+             configured to monitor, rotate, revoke, or destroy XKS keys. AWS never triggers \
+             these operations on your behalf — configure a Crypto Officer identity backed by a \
+             real credential (TLS certificate CN / OIDC subject matching `default_username`) so \
+             XKS keys remain manageable. See crate/server/src/routes/aws_xks/README.md."
+        );
+    }
+
     Ok(())
 }
 

--- a/documentation/docs/configuration/log-reference.md
+++ b/documentation/docs/configuration/log-reference.md
@@ -723,6 +723,9 @@ Crate path: `crate/server`
 | `debug` | `OCSP: all serials served from cache` | `src/routes/ocsp/handler.rs` | - | - |
 | `debug` | `OCSP GET request path exceeds MAX_OCSP_GET_ENCODED_LEN` | `src/routes/ocsp/handler.rs` | - | - |
 | `info` | `` AWS XKS: granted usage on {migrated} pre-existing key(s) to the reserved service              identity `{AWS_XKS_SERVICE_USER}` `` | `src/start_kms_server.rs` | `migrated`, `AWS_XKS_SERVICE_USER` | - |
+| `warn` | `` AWS XKS: skipping migration for key `{uid}` because its owner could not be                      determined (object missing) `` | `src/start_kms_server.rs` | `uid` | - |
+| `warn` | `Session: rejecting reserved AWS XKS service identity from stored                              session user_id: {error}` | `src/middlewares/session_auth.rs` | `error` | - |
+| `warn` | `{log_prefix}: rejecting reserved AWS XKS service identity in SPIRE auth:                      {error}` | `src/middlewares/spire_token.rs` | `log_prefix`, `error` | - |
 
 ### `cosmian_kms_server_database`
 

--- a/documentation/docs/configuration/log-reference.md
+++ b/documentation/docs/configuration/log-reference.md
@@ -722,6 +722,7 @@ Crate path: `crate/server`
 | `debug` | `OCSP cache HIT` | `src/routes/ocsp/handler.rs` | - | - |
 | `debug` | `OCSP: all serials served from cache` | `src/routes/ocsp/handler.rs` | - | - |
 | `debug` | `OCSP GET request path exceeds MAX_OCSP_GET_ENCODED_LEN` | `src/routes/ocsp/handler.rs` | - | - |
+| `info` | `` AWS XKS: granted usage on {migrated} pre-existing key(s) to the reserved service              identity `{AWS_XKS_SERVICE_USER}` `` | `src/start_kms_server.rs` | `migrated`, `AWS_XKS_SERVICE_USER` | - |
 
 ### `cosmian_kms_server_database`
 

--- a/documentation/docs/configuration/log-reference.md
+++ b/documentation/docs/configuration/log-reference.md
@@ -726,6 +726,9 @@ Crate path: `crate/server`
 | `warn` | `` AWS XKS: skipping migration for key `{uid}` because its owner could not be                      determined (object missing) `` | `src/start_kms_server.rs` | `uid` | - |
 | `warn` | `Session: rejecting reserved AWS XKS service identity from stored                              session user_id: {error}` | `src/middlewares/session_auth.rs` | `error` | - |
 | `warn` | `{log_prefix}: rejecting reserved AWS XKS service identity in SPIRE auth:                      {error}` | `src/middlewares/spire_token.rs` | `log_prefix`, `error` | - |
+| `error` | `AWS XKS: failed to spawn key access migration thread: {error}` | `src/start_kms_server.rs` | `error` | - |
+| `error` | `AWS XKS: failed to start key access migration runtime: {error}` | `src/start_kms_server.rs` | `error` | - |
+| `error` | `AWS XKS: pre-existing key access migration failed: {error}` | `src/start_kms_server.rs` | `error` | - |
 
 ### `cosmian_kms_server_database`
 

--- a/documentation/docs/configuration/log-reference.md
+++ b/documentation/docs/configuration/log-reference.md
@@ -729,6 +729,7 @@ Crate path: `crate/server`
 | `error` | `AWS XKS: failed to spawn key access migration thread: {error}` | `src/start_kms_server.rs` | `error` | - |
 | `error` | `AWS XKS: failed to start key access migration runtime: {error}` | `src/start_kms_server.rs` | `error` | - |
 | `error` | `AWS XKS: pre-existing key access migration failed: {error}` | `src/start_kms_server.rs` | `error` | - |
+| `warn` | `` AWS XKS is enabled but `crypto_officer.users` is empty: no Crypto Officer is              configured to monitor, rotate, revoke, or destroy XKS keys. AWS never triggers              these operations on your behalf — configure a Crypto Officer identity backed by a              real credential (TLS certificate CN / OIDC subject matching `default_username`) so              XKS keys remain manageable. See crate/server/src/routes/aws_xks/README.md. `` | `src/start_kms_server.rs` | - | - |
 
 ### `cosmian_kms_server_database`
 

--- a/documentation/docs/integrations/cloud_providers/aws/xks.md
+++ b/documentation/docs/integrations/cloud_providers/aws/xks.md
@@ -58,6 +58,26 @@ The HSM is responsible for storing the Master keys and securing the Eviden KMS k
    ![Choose the external key](./2_choose_external_key.png)
    ![Review the key and create it](./7_review.png)
 
-5. Enforce the correct permissions for the key on the Eviden KMS.
-Make sure the user used by AWS has the permissions for `Encrypt`, `Decrypt` and `GetAttributes`. For instance, when using DynamoDB, the user should be called something like `dynamodb.amazonaws.com`, for Salesforce, it is the user configured as part of the setup.
-In doubt, or for testing, grant theses permissions to all users (`*`).
+5. Authorize AWS principals to use the key.
+
+   The KMS authenticates every XKS request from AWS KMS using the shared SigV4 credentials
+   configured above (`aws_xks_sigv4_access_key_id` / `aws_xks_sigv4_secret_access_key`).
+   This signature is the trust boundary, in line with AWS's model where the AWS key policy
+   and IAM are the source of truth for which principals may use the key.
+
+   XKS keys are used internally through a dedicated, reserved KMS service identity, so
+   **any** AWS principal whose request is correctly signed can use the key.
+   You do **not** need to create or maintain a per-principal (per-ARN) permission entry on
+   the KMS for each IAM role, and the numerous or dynamic roles common with AWS SSO or
+   Control Tower work without additional configuration.
+
+   The keys remain owned by the KMS `default_username`, so you keep full administrative
+   control over them (listing, revocation, destruction and export) from the CLI and the Web
+   UI. The XKS service identity itself is granted only `Encrypt`, `Decrypt` and
+   `GetAttributes`, so the XKS endpoints can never revoke, destroy or export key material.
+
+   The `awsPrincipalArn` sent by AWS KMS is recorded in the KMS logs for auditing only and
+   is never used as an authorization gate.
+
+   Keys created by an earlier KMS version are updated automatically when the server starts,
+   so no manual action is required when upgrading.

--- a/documentation/docs/integrations/cloud_providers/aws/xks.md
+++ b/documentation/docs/integrations/cloud_providers/aws/xks.md
@@ -81,3 +81,38 @@ The HSM is responsible for storing the Master keys and securing the Eviden KMS k
 
    Keys created by an earlier KMS version are updated automatically when the server starts,
    so no manual action is required when upgrading.
+
+## Monitoring and lifecycle management
+
+AWS never calls back into the XKS proxy to list, monitor, rotate, revoke, or destroy key
+material — the [XKS proxy API
+spec](https://github.com/aws/aws-kms-xksproxy-api-spec/blob/main/xks_proxy_api_spec.md)
+only defines `GetKeyMetadata`, `Encrypt`, `Decrypt`, and `GetHealthStatus`. Scheduling
+deletion or on-demand rotation of a CMK from the AWS console only changes state on AWS's
+side; it never reaches this KMS. **Lifecycle management of the external key material is
+therefore entirely your operational responsibility.**
+
+**A Crypto Officer must be designated to handle this.** Configure a real, credentialed
+identity (a TLS certificate CN or OIDC subject matching `default_username`) as a Crypto
+Officer (`crypto_officer.users` / `privileged_users`) so that a human operator can, through
+the normal `ckms` CLI or Web UI:
+
+- **List/monitor** XKS keys — `Locate` by the `aws-xks` tag, `GetAttributes`.
+- **Revoke** or **destroy** XKS keys that are no longer needed.
+
+**XKS keys cannot be rotated in place.** The KMS `ReKey` operation always assigns a new
+internal unique identifier, but AWS KMS always calls the XKS proxy back with the *original*
+external key id configured when the CMK was created — it has no mechanism to learn about a
+new one. Attempting `ReKey` (manually or via the auto-rotation scheduler) on an `aws-xks`
+key is therefore rejected with an explicit error. To rotate the cryptographic material
+behind an external key, create a **new** external key (new CMK with a new external key id)
+in AWS KMS, migrate consumers to it, and destroy the old one through this Crypto Officer
+identity once it is no longer in use.
+
+Do this deliberately: an installation with an empty `crypto_officer.users` list has no one
+who can reach these keys this way, and the server logs a startup warning in that case. Never
+attempt to authenticate as the reserved AWS XKS service identity itself — it is intentionally
+unreachable through any normal authentication path (TLS, OIDC, SPIRE, UI session) and is only
+ever used internally to answer SigV4-signed requests from AWS KMS. Granting it a real
+credential would let anyone holding it bypass AWS's SigV4 trust boundary entirely. See
+`crate/server/src/routes/aws_xks/README.md` for the underlying authorization model.

--- a/lychee.toml
+++ b/lychee.toml
@@ -112,6 +112,9 @@ exclude = [
   'swagger\.io',
   # IBM docs — returns 503 Service Unavailable (Guardium CM TDE guide)
   'www\.ibm\.com',
+  # Eviden (Proteccio HSM vendor page) — returns 503 Service Unavailable to
+  # automated crawlers/CI runners
+  'eviden\.com',
 
   # Kubernetes SIG documentation site — resets connections from automated crawlers
   'secrets-store-csi-driver\.sigs\.k8s\.io',


### PR DESCRIPTION
Closes #1093 

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Introduce reserved `AWS_XKS_SERVICE_USER` identity for XKS operations and grants
> - Adds a reserved KMS identity `[aws-xks-service]` used as a least-privilege delegate for all XKS encrypt, decrypt, metadata, and key-creation operations, replacing caller-ARN authorization
> - Keys remain owned by `default_username`; CreateKey grants the reserved identity exactly `Encrypt`, `Decrypt`, and `GetAttributes`, rejects non-XKS symmetric-key ID collisions, and is idempotent
> - Startup migration in [start_kms_server.rs](https://github.com/Cosmian/kms/pull/1107/files#diff-9eb1842b77777da76d4808dff08a4acc7abb176dfb1f7528f047bbedfa85d9ef) finds `aws-xks`-tagged legacy keys and grants the reserved identity its three permissions using each key's actual owner
> - All authentication middlewares (session, mTLS, JWT, SPIRE, OIDC, Auth Verifier) reject the reserved identity as an externally authenticated user; configuration validation fails when the reserved identity is set as `default_username` or a crypto-officer user
> - Behavioral Change: XKS operations no longer authorize using the `awsPrincipalArn` from request metadata; the ARN is now audit-only. Existing XKS keys created under a previous `default_username` receive the reserved-identity grants at next startup. The reserved identity string `[aws-xks-service]` is now prohibited in `default_username` and `crypto_officer.users` when XKS is enabled.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 38908c1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->