### PR TITLE
fix: usernames should not be exposed in OTel metrics

### DIFF
--- a/.mise/scripts/nix.sh
+++ b/.mise/scripts/nix.sh
@@ -39,6 +39,7 @@ usage() {
       otel_export            Run OTEL export tests (requires Docker)
                              Alias: 'otel' (backward-compatible)
       iris                   Run IRIS ↔ KMS mTLS integration tests (requires Docker + IRIS image)
+      cef_interop            Run CEF audit export interoperability test (jc)
       hsm [backend]          Run HSM tests (Linux + macOS for softhsm2)
                              backend: softhsm2 | utimaco | proteccio | all (default)
       ui                     Run UI E2E tests with Playwright (non-FIPS only)
@@ -494,6 +495,9 @@ test_command() {
     iris)
       SCRIPT="$REPO_ROOT/.mise/scripts/test/test_iris.sh"
       ;;
+    cef_interop)
+      SCRIPT="$REPO_ROOT/.mise/scripts/test/test_cef_interop.sh"
+      ;;
     gcp_cmek)
       SCRIPT="$REPO_ROOT/.mise/scripts/test/test_gcp_cmek.sh"
       ;;
@@ -587,7 +591,7 @@ test_command() {
       ;;
     *)
       echo "Error: Unknown test type '$TEST_TYPE'" >&2
-      echo "Valid types: aws_xks, sqlite, mysql, percona, mariadb, psql, redis, google_cse, gcp_cmek, pykmip, openssh, luks, otel_export, iris, jose, hsm [softhsm2|utimaco|proteccio|all], ui, secret_vault, secret_aws, secret_azure, secret_cosmian_kms" >&2
+      echo "Valid types: aws_xks, sqlite, mysql, percona, mariadb, psql, redis, google_cse, gcp_cmek, pykmip, openssh, luks, otel_export, iris, jose, cef_interop, hsm [softhsm2|utimaco|proteccio|all], ui, secret_vault, secret_aws, secret_azure, secret_cosmian_kms" >&2
       usage
       ;;
   esac
@@ -600,8 +604,8 @@ test_command() {
   if [ "$TEST_TYPE" = "wasm" ] || [ "$TEST_TYPE" = "ui" ] || [ "$TEST_TYPE" = "all" ]; then
     export WITH_WASM=1
   fi
-  # For PyKMIP/Synology DSM tests, JOSE interop, and EDB TDE tests, ensure Python tooling is present inside the Nix shell
-  if [ "$TEST_TYPE" = "pykmip" ] || [ "$TEST_TYPE" = "jose" ] || [ "$TEST_TYPE" = "edb_tde" ]; then
+  # For PyKMIP/Synology DSM tests, JOSE interop, CEF interop, and EDB TDE tests, ensure Python tooling is present inside the Nix shell
+  if [ "$TEST_TYPE" = "pykmip" ] || [ "$TEST_TYPE" = "jose" ] || [ "$TEST_TYPE" = "edb_tde" ] || [ "$TEST_TYPE" = "cef_interop" ]; then
     export WITH_PYTHON=1
   fi
   # For OpenSSH PKCS#11 tests, ensure openssh (ssh-keygen) is present on Linux CI

--- a/.mise/scripts/test/cef_interop_helper.py
+++ b/.mise/scripts/test/cef_interop_helper.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""CEF export interoperability helper for KMS audit log testing.
+
+Reads the original JSONL audit event file and the CEF output produced by
+`ckms audit export --format cef` for that same file, then parses each CEF
+line with `jc` (https://github.com/kellyjonbrazil/jc) — an independent,
+widely used, actively maintained CEF parser — and asserts that every field
+round-trips back to the original source-of-truth value.
+
+This validates that `to_cef_line()` (crate/access/src/audit/cef.rs) produces
+CEF that a real third-party parser can correctly ingest, not just that our
+own Rust unit tests agree with themselves.
+
+Usage:
+    cef_interop_helper.py --jsonl <source.jsonl> --cef <cef-output.txt> --kms-version <version>
+
+Requirements: Python 3.9+, jc
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+
+def _expected_severity(result: Any) -> int:
+    """Mirror cef_severity() in crate/access/src/audit/cef.rs."""
+    if result == "Success":
+        return 5
+    if isinstance(result, dict) and "Failure" in result:
+        msg = result["Failure"]
+        if any(needle in msg for needle in ("401", "403", "Unauthorized", "Forbidden")):
+            return 7
+        return 6
+    raise ValueError(f"Unrecognised AuditResult shape: {result!r}")
+
+
+def _check_line(line_no: int, event: dict, cef_line: str) -> None:
+    import jc
+
+    records = jc.parse("cef", cef_line, raw=True)
+    if len(records) != 1:
+        raise AssertionError(
+            f"line {line_no}: expected exactly 1 parsed CEF record, got {len(records)} "
+            f"(possible record injection / line-splitting bug): {cef_line!r}"
+        )
+    cef = records[0]
+
+    def expect(key: str, value: str, label: str) -> None:
+        got = cef.get(key)
+        if got != value:
+            raise AssertionError(
+                f"line {line_no} ({label}): expected {key}={value!r}, got {got!r}"
+            )
+
+    def expect_absent(key: str, label: str) -> None:
+        if key in cef:
+            raise AssertionError(
+                f"line {line_no} ({label}): expected {key} to be absent, got {cef[key]!r}"
+            )
+
+    expect("deviceVendor", "Cosmian", "vendor")
+    expect("deviceProduct", "KMS", "product")
+    expect("deviceEventClassId", event["operation"], "class id")
+    expect("name", event["operation"], "name")
+    expect("agentSeverity", str(_expected_severity(event["result"])), "severity")
+
+    expect("rt", str(int(event["_rt_ms"])), "rt")
+    expect("suser", event["user"], "suser")
+    if event["client_ip"] is not None:
+        expect("src", event["client_ip"], "client ip")
+    else:
+        expect_absent("src", "client ip")
+
+    result = event["result"]
+    if result == "Success":
+        expect("outcome", "Success", "outcome")
+        expect_absent("reason", "reason")
+    else:
+        expect("outcome", "Failure", "outcome")
+        expect("reason", result["Failure"], "failure reason")
+
+    expect("act", event["operation"], "act")
+    expect("cn1", str(event["duration_ms"]), "duration value")
+    expect("cn1Label", "durationMs", "duration label")
+
+    if event["object_uid"] is not None:
+        expect("cs1", event["object_uid"], "object uid")
+        expect("cs1Label", "objectUID", "object uid label")
+    else:
+        expect_absent("cs1", "object uid")
+
+    if event["algorithm"] is not None:
+        expect("cs2", event["algorithm"], "algorithm")
+        expect("cs2Label", "algorithm", "algorithm label")
+    else:
+        expect_absent("cs2", "algorithm")
+
+    expect("cs3", str(event["id"]), "audit id")
+    expect("cs3Label", "auditId", "audit id label")
+
+    expect("cs4", event["timestamp"], "rfc3339 timestamp")
+    expect("cs4Label", "timestamp", "timestamp label")
+
+    if event.get("request_id") is not None:
+        expect("cs5", event["request_id"], "request id")
+        expect("cs5Label", "requestId", "request id label")
+    else:
+        expect_absent("cs5", "request id")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--jsonl", required=True, help="Path to the original AuditEvent JSONL file")
+    parser.add_argument("--cef", required=True, help="Path to the CEF output produced by ckms audit export")
+    args = parser.parse_args()
+
+    with open(args.jsonl, encoding="utf-8") as f:
+        events = [json.loads(line) for line in f if line.strip()]
+    with open(args.cef, encoding="utf-8") as f:
+        cef_lines = [line.rstrip("\n") for line in f if line.strip()]
+
+    if len(events) != len(cef_lines):
+        print(
+            f"FATAL: source has {len(events)} events but CEF output has {len(cef_lines)} lines",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Rust computes rt as unix_timestamp*1000 + millisecond(); derive the same
+    # value here from the RFC3339 timestamp so we don't need a datetime dep.
+    # datetime.fromisoformat() only accepts up to microsecond (6-digit)
+    # fractional seconds, so truncate any nanosecond-precision input first.
+    import datetime
+    import re
+
+    for event in events:
+        ts = re.sub(r"(\.\d{6})\d*Z$", r"\1Z", event["timestamp"])
+        dt = datetime.datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        event["_rt_ms"] = int(dt.timestamp() * 1000)
+
+    failures = 0
+    for i, (event, cef_line) in enumerate(zip(events, cef_lines), start=1):
+        try:
+            _check_line(i, event, cef_line)
+        except AssertionError as e:
+            print(f"FAIL: {e}", file=sys.stderr)
+            failures += 1
+        else:
+            print(f"PASS: line {i} ({event['operation']}, id={event['id']})")
+
+    if failures:
+        print(f"\n{failures}/{len(events)} CEF line(s) failed interop validation.", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"\nAll {len(events)} CEF lines validated OK via jc.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.mise/scripts/test/requirements-cef.txt
+++ b/.mise/scripts/test/requirements-cef.txt
@@ -1,0 +1,12 @@
+# Frozen Python dependency for the CEF export interoperability test suite.
+#
+# jc (https://github.com/kellyjonbrazil/jc) is a widely used, actively
+# maintained CLI/library (8k+ GitHub stars, MIT licence) that ships a
+# dedicated CEF parser conforming to the ArcSight CEF spec. It is used here
+# to independently parse `ckms audit export --format cef` output and verify
+# every field round-trips correctly, as a third party ingesting the export
+# would.
+#
+# Pinned to the latest stable release at the time of writing; no known
+# CVEs/advisories against this package. Revisit the pin on a major bump.
+jc==1.25.7

--- a/.mise/scripts/test/test_cef_interop.sh
+++ b/.mise/scripts/test/test_cef_interop.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# CEF export interoperability test.
+#
+# Validates that `ckms audit export --format cef` produces output that a
+# real, independent, widely used CEF parser (jc: kellyjonbrazil/jc) can
+# correctly ingest — i.e. that the KMS's hand-rolled CEF serialisation
+# (crate/access/src/audit/cef.rs) is genuinely compatible with third-party
+# SIEM/CEF tooling, not just self-consistent with our own Rust unit tests.
+#
+# No live KMS server is involved: the fixture is a real JSONL audit-log
+# artifact previously produced by an actual KMS run, so no server startup or
+# ephemeral port handling is required for this test.
+#
+# Usage:
+#   bash .mise/scripts/nix.sh test cef_interop
+#   bash .mise/scripts/test/test_cef_interop.sh [--variant fips|non-fips]
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+source "${SCRIPT_DIR}/../common.sh"
+source "${SCRIPT_DIR}/../../lib/kms_build.sh"
+
+init_build_env "$@"
+setup_test_logging
+
+HELPER="${SCRIPT_DIR}/cef_interop_helper.py"
+FIXTURE="$(get_repo_root)/test_data/audit/kms-audit-e2e.jsonl"
+KMS_VERSION="test-interop-1.0.0"
+
+VENV_DIR=""
+CEF_OUTPUT=""
+
+cleanup() {
+  [ -n "${VENV_DIR:-}" ] && { rm -rf "${VENV_DIR}" || true; }
+  [ -n "${CEF_OUTPUT:-}" ] && { rm -f "${CEF_OUTPUT}" || true; }
+}
+trap cleanup EXIT
+
+echo "==========================================="
+echo "CEF export interoperability test (jc)"
+echo "==========================================="
+
+if [ ! -f "${FIXTURE}" ]; then
+  echo "ERROR: fixture not found at ${FIXTURE}" >&2
+  exit 1
+fi
+
+# ── Build ckms and export the fixture as CEF ─────────────────────────────────
+
+echo "==> Building ckms CLI..."
+kms_build_cli
+ckms_bin=$(get_ckms_bin)
+
+echo "==> Exporting fixture as CEF (kms-version=${KMS_VERSION})..."
+CEF_OUTPUT="$(mktemp -t cef-export-XXXXXX.txt)"
+"${ckms_bin}" audit export \
+  --path "${FIXTURE}" \
+  --format cef \
+  --kms-version "${KMS_VERSION}" \
+  >"${CEF_OUTPUT}"
+
+fixture_lines=$(grep -c . "${FIXTURE}")
+cef_lines=$(grep -c . "${CEF_OUTPUT}")
+if [ "${fixture_lines}" != "${cef_lines}" ]; then
+  echo "ERROR: fixture has ${fixture_lines} events but CEF output has ${cef_lines} lines" >&2
+  exit 1
+fi
+echo "    Exported ${cef_lines} CEF line(s)."
+
+# ── Python venv setup (jc) ───────────────────────────────────────────────────
+
+echo "==> Setting up Python virtualenv with jc..."
+VENV_DIR="$(mktemp -d -t cef-interop-venv-XXXXXX)"
+python3 -m venv "${VENV_DIR}"
+# shellcheck disable=SC1091
+source "${VENV_DIR}/bin/activate"
+pip install --quiet -r "${SCRIPT_DIR}/requirements-cef.txt"
+echo "    Python venv OK ($(python3 --version), jc $(pip show jc | grep ^Version | awk '{print $2}'))"
+
+# ── Round-trip validation ────────────────────────────────────────────────────
+
+echo ""
+echo "==> Parsing CEF output with jc and validating field-by-field round-trip..."
+python3 "${HELPER}" --jsonl "${FIXTURE}" --cef "${CEF_OUTPUT}"
+
+echo ""
+echo "CEF export interoperability test passed."

--- a/.mise/tasks/test/cef-interop
+++ b/.mise/tasks/test/cef-interop
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#MISE description="Run CEF audit export interoperability test (jc)"
+#USAGE flag "-v --variant <variant>" env="VARIANT" help="FIPS variant" default="fips" {
+#USAGE   choices "fips" "non-fips"
+#USAGE }
+#USAGE flag "-l --link <link>" env="LINK" help="Linkage type" default="static" {
+#USAGE   choices "static" "dynamic"
+#USAGE }
+set -euo pipefail
+source "${MISE_CONFIG_ROOT}/.mise/lib/common.sh"
+source "${MISE_CONFIG_ROOT}/.mise/lib/nix_helpers.sh"
+kms_init_env "${usage_variant:-fips}" "${usage_link:-static}"
+setup_test_logging
+ensure_nix_shell
+
+print_header "Running CEF export interoperability test (${VARIANT_NAME})"
+
+REPO_ROOT="$(get_repo_root)"
+
+# Delegate to the existing CEF interop test script
+bash "${REPO_ROOT}/.mise/scripts/test/test_cef_interop.sh" --variant "$VARIANT" --link "$LINK"
+
+print_success "CEF export interoperability test completed"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,7 +208,7 @@ Use `--features non-fips` to enable all non-approved algorithms.
 - **Unsafe code**: every `unsafe` block requires a `// SAFETY:` comment explaining the invariant that makes it sound.
 - **Clippy**: zero warnings (`cargo clippy-all`). Decision tree for `#[allow(clippy::...)]`: (1) fix it; (2) if unfixable, add an inline comment explaining why; (3) if undecided, report the exact warning to the user.
 - **Tests**: unit tests go in a `#[cfg(test)]` submodule in the same file.
-- **Public API**: all public items require `///` doc comments.
+- **Public API**: all public items that are not trivial require `///` doc comments that explay _why_, _constraints_, _non obvious behaviors_, etc. Comments should not be a paraphrase of the code.
 - **Pre-commit hooks**: must pass before every commit — never use `--no-verify`.
 - **Commit scope**: minimal, focused changes — don't refactor surrounding code alongside a bug fix.
 - **Live DB tests**: `docker compose up -d <service>` before running tests that need a backend (postgres :5432, mysql :3306, redis :6379, etc.).
@@ -252,21 +252,21 @@ Fix every warning. Do not suppress with `#[allow]` unless there is a documented,
 
 Run **`/kms-sync-rules`** — it auto-detects changed files via `git diff` and emits the exact applicable checklist from the table below.
 
-| Task type | Sub-rules |
-|---|---|
-| New/modified KMIP operation | 4.3, 4.10 |
-| New/modified REST endpoint | 4.2, 4.10 |
-| New/modified CLI command/flag | 4.4, 4.15 |
-| New/modified UI feature | 4.1, 4.4, 4.5 (if WASM needed) |
-| Non-FIPS-only feature | 4.8 |
-| Auth method change | 4.9 |
-| Server config/wizard change | 4.6, 4.7 |
-| Cloud provider integration | 4.12 |
-| HSM backend | 4.13 |
-| Documentation/behavior change | 4.14 |
-| Playwright E2E test change | 4.16 |
-| OpenSSL upgrade | 4.17 |
-| `Cargo.lock` or `pnpm-lock.yaml` change | 4.11 |
+| Task type                               | Sub-rules                      |
+| --------------------------------------- | ------------------------------ |
+| New/modified KMIP operation             | 4.3, 4.10                      |
+| New/modified REST endpoint              | 4.2, 4.10                      |
+| New/modified CLI command/flag           | 4.4, 4.15                      |
+| New/modified UI feature                 | 4.1, 4.4, 4.5 (if WASM needed) |
+| Non-FIPS-only feature                   | 4.8                            |
+| Auth method change                      | 4.9                            |
+| Server config/wizard change             | 4.6, 4.7                       |
+| Cloud provider integration              | 4.12                           |
+| HSM backend                             | 4.13                           |
+| Documentation/behavior change           | 4.14                           |
+| Playwright E2E test change              | 4.16                           |
+| OpenSSL upgrade                         | 4.17                           |
+| `Cargo.lock` or `pnpm-lock.yaml` change | 4.11                           |
 
 > **Full sub-rule checklists** (4.1–4.17) are in `.github/skills/kms-sync-rules/SKILL.md`. The `/kms-sync-rules` skill reads your diff and emits only the applicable ones.
 
@@ -451,8 +451,8 @@ RUST_LOG="cosmian_kms_server=trace,cosmian_kms_server_database=trace" \
 Add the failing crate to `RUST_LOG` if the problem originates elsewhere.
 
 - **During debugging**: whenever you add temporary code (a log, a hardcoded value, a
-relaxed auth/CORS/TLS config, a test-only endpoint), mark it immediately with a comment:
-`// TODO: debug — remove before shipping`. This makes residue findable at a glance.
+  relaxed auth/CORS/TLS config, a test-only endpoint), mark it immediately with a comment:
+  `// TODO: debug — remove before shipping`. This makes residue findable at a glance.
 - When working on some feature, run the tests that actually use that feature or (if no direct test) are the most related - Do not run the full test suite to check if a certain new addition is correct.
 
 ### 8.5 GitHub CLI usage

--- a/CHANGELOG/feat_audit_and_siem.md
+++ b/CHANGELOG/feat_audit_and_siem.md
@@ -1,0 +1,85 @@
+## Features
+
+### Audit logging — tamper-evident JSONL event log
+
+Cosmian KMS now writes a cryptographically-chained audit trail of every KMIP
+operation to a local JSONL file.
+
+**Chain design**
+
+Each persisted row carries:
+
+- `id` — monotonically increasing integer (i64, big-endian in the hash)
+- `prev_hash` — SHA-256 of the previous row's canonical bytes (all-zeros for row 0)
+- `row_hash` — SHA-256 of this row's canonical bytes (including `prev_hash`)
+
+Truncating, reordering, or modifying any field in any row breaks the chain and
+is detected by `ckms audit verify`.
+
+**Durability**
+
+Each write is followed by `fsync` (`File::sync_data()`) so events survive an OS
+crash or power failure. A `sync_data()` is also issued when the writer task
+drains on graceful server shutdown, ensuring no in-flight events are lost.
+
+**Startup resilience**
+
+On restart the server reads only the last 64 KiB of the existing log (O(1)
+regardless of file size) to resume the chain. If the last event's `row_hash`
+does not verify, the server refuses to start and reports the corrupted line —
+preventing silent chain continuation from a forged or truncated tail.
+
+**Drop policy under saturation**
+
+The writer task communicates via a bounded channel whose capacity is set by
+`--audit-channel-capacity` / `KMS_AUDIT_CHANNEL_CAPACITY` (default: **4 096**).
+When the channel is full, the enqueue call returns immediately and logs an
+`error!` — the request path is never blocked. Dropped events are not recorded
+in the chain; the compliance log is simply incomplete for that burst. See
+[SECURITY.md](../SECURITY.md) for operational guidance.
+
+### New CLI command: `ckms audit verify`
+
+```
+ckms audit verify --path <audit.jsonl> [--verbose]
+```
+
+Reads the audit file line by line, verifies each event's `row_hash`, and checks
+every `prev_hash` link. Exits non-zero on the first tampered or broken link.
+With `--verbose`, prints each event id, timestamp, operation, and `chain=ok`.
+
+### CEF output format
+
+`AuditEventFull` can be serialised as a
+[Common Event Format (CEF)](https://www.microfocus.com/documentation/arcsight/arcsight-smartconnectors-8.4/cef-implementation-standard/)
+line via `to_cef_line()`. This enables direct ingestion into SIEM systems such
+as ArcSight, Splunk, or QRadar.
+
+### Configuration
+
+| CLI flag                   | Env var                      | Default      | Description                                                                               |
+| -------------------------- | ---------------------------- | ------------ | ----------------------------------------------------------------------------------------- |
+| `--audit-log-path`         | `KMS_AUDIT_LOG_PATH`         | _(disabled)_ | Path to the JSONL audit log file. Audit logging is disabled when unset.                   |
+| `--audit-channel-capacity` | `KMS_AUDIT_CHANNEL_CAPACITY` | `4096`       | In-memory channel capacity. Raise if you see `"AuditFileStore: channel full"` in the log. |
+
+### Security hardening (this session)
+
+Implemented during code review of the initial `file_store.rs`:
+
+- **Durability**: replaced `file.flush()` (no-op on `std::fs::File`) with
+  `file.sync_data()` after every write and on graceful shutdown.
+- **Fail-fast startup**: the audit file is opened in `AuditFileStore::start()`
+  before spawning the writer task; an unwritable path aborts server startup
+  immediately instead of silently disabling audit logging at runtime.
+- **Tail-seek resume**: `resume_chain` seeks to the last 64 KiB instead of
+  reading the entire file — O(1) startup for GB-scale logs.
+- **Tamper detection at startup**: `verify_event()` is called on the last
+  persisted event before trusting its `row_hash` as the chain seed.
+- **Redundant `Arc` removed**: `AuditFileStore::sender` is now
+  `mpsc::Sender<_>` directly (`Sender` is already `Arc`-backed).
+- **Clippy hygiene**: `&PathBuf` → `&Path` in all signatures; `#[allow]`
+  attributes carry inline justifications.
+- **Test coverage**: replaced three `todo!()` stubs with real tests:
+  `enqueue_drops_when_channel_full`, `chain_resumes_on_restart`,
+  `write_failure_does_not_advance_chain`, plus
+  `resume_rejects_tampered_last_line`.

--- a/CHANGELOG/feat_audit_and_siem.md
+++ b/CHANGELOG/feat_audit_and_siem.md
@@ -59,8 +59,19 @@ as ArcSight, Splunk, or QRadar.
 
 | CLI flag                   | Env var                      | Default      | Description                                                                               |
 | -------------------------- | ---------------------------- | ------------ | ----------------------------------------------------------------------------------------- |
-| `--audit-log-path`         | `KMS_AUDIT_LOG_PATH`         | _(disabled)_ | Path to the JSONL audit log file. Audit logging is disabled when unset.                   |
+| `--audit-enable`           | `KMS_AUDIT_ENABLE`           | `false`      | Enable the audit event pipeline.                                                          |
+| `--audit-file-path`        | `KMS_AUDIT_FILE_PATH`        | _(disabled)_ | Path to the JSONL audit log file. Audit logging is disabled when unset.                   |
 | `--audit-channel-capacity` | `KMS_AUDIT_CHANNEL_CAPACITY` | `4096`       | In-memory channel capacity. Raise if you see `"AuditFileStore: channel full"` in the log. |
+
+In `server.toml`, these nest under `[audit]` / `[audit.file]` (not a flat `[audit] path`):
+
+```toml
+[audit]
+enabled = true
+
+[audit.file]
+path = "/var/log/cosmian-kms/audit.jsonl"
+```
 
 ### Security hardening (this session)
 
@@ -83,3 +94,45 @@ Implemented during code review of the initial `file_store.rs`:
   `enqueue_drops_when_channel_full`, `chain_resumes_on_restart`,
   `write_failure_does_not_advance_chain`, plus
   `resume_rejects_tampered_last_line`.
+
+### Per-`BatchItem` audit events with `request_id`
+
+Each HTTP request now receives a UUID v4 `request_id` stamped on every
+`AuditEventDraft` it produces. For batch `RequestMessage` calls the middleware
+fans out one event per `BatchItem` — each carrying its own `operation`,
+`object_uid`, `algorithm`, and per-item `result` parsed from the
+`ResponseMessage` `ResultStatus`/`ResultReason`. All events in a batch share
+the same `request_id`, enabling correlation in SIEM / log-analysis tools.
+
+The field is optional (`#[serde(skip_serializing_if = "Option::is_none")]`) so
+existing audit files without it remain valid and hash-chain-verifiable.
+
+CEF output gains a `cs5=<uuid> cs5Label=requestId` extension field when
+`request_id` is `Some`.
+
+### Drop-detection sentinel (T3)
+
+Previously, events dropped by `try_send` when the channel was full were silently
+lost with only a log-level `error!`. The hash chain stayed valid but the
+compliance log had invisible gaps.
+
+Now `AuditFileStore` tracks a `dropped_count: Arc<AtomicU64>`. On
+`TrySendError::Full` the counter is incremented. Before writing each real
+event the writer loop swaps the counter to zero; if non-zero, a synthetic
+`operation = "audit:eviction"` sentinel event is written into the chain first —
+making drops **detectable** by `ckms audit verify` and any log-scanning tool.
+
+### XFF trust validation (T7)
+
+`X-Forwarded-For` was previously accepted unconditionally, allowing any client
+to spoof its apparent IP in the audit log.
+
+The middleware now consults a configurable trusted-proxy CIDR list. XFF is only
+honoured when the direct TCP peer address falls within a trusted CIDR.
+
+| CLI flag                      | Env var                         | Default  | Description                                    |
+| ----------------------------- | ------------------------------- | -------- | ---------------------------------------------- |
+| `--audit-trusted-proxy-cidrs` | `KMS_AUDIT_TRUSTED_PROXY_CIDRS` | _(none)_ | Comma-separated CIDR ranges of trusted proxies |
+
+Default is an empty list — no behaviour change unless opted in.
+Single IPs can be expressed as `/32` (IPv4) or `/128` (IPv6).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,9 +1414,9 @@ dependencies = [
  "cosmian_kmip",
  "hex",
  "serde",
- "serde_json",
  "sha2 0.10.9",
  "time",
+ "uuid",
 ]
 
 [[package]]
@@ -1706,6 +1706,7 @@ dependencies = [
  "governor",
  "hex",
  "http 1.5.0",
+ "ipnet",
  "jsonwebtoken",
  "native-tls",
  "num-bigint-dig",
@@ -3556,6 +3557,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -7060,6 +7064,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b913a3b5fe84142e269d63cc62b64319ccaf89b748fc31fe025177f767a756c4"
 dependencies = [
  "getrandom 0.2.17",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,11 @@ name = "cosmian_kms_access"
 version = "5.25.0"
 dependencies = [
  "cosmian_kmip",
+ "hex",
  "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "time",
 ]
 
 [[package]]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,46 +1,46 @@
 # Security Policy
 
 - [Security Policy](#security-policy)
-    - [Reporting a Vulnerability](#reporting-a-vulnerability)
-    - [Severity Rating](#severity-rating)
-    - [Known Vulnerabilities](#known-vulnerabilities)
-        - [2026](#2026)
-            - [COSMIAN-2026-019 — RUSTSEC-2026-0173: `proc-macro-error2` soundness issue via `mysql_async`](#cosmian-2026-019--rustsec-2026-0173-proc-macro-error2-soundness-issue-via-mysql_async)
-            - [COSMIAN-2026-018 — Activate operation uses overly permissive authorization check](#cosmian-2026-018--activate-operation-uses-overly-permissive-authorization-check)
-            - [COSMIAN-2026-017 — ReKey / ReKeyKeyPair authorization bypass via raw object retrieval](#cosmian-2026-017--rekey--rekeykeypair-authorization-bypass-via-raw-object-retrieval)
-            - [COSMIAN-2026-016 — Attribute-mutation authorization bypass via incorrect operation type](#cosmian-2026-016--attribute-mutation-authorization-bypass-via-incorrect-operation-type)
-            - [COSMIAN-2026-015 — KEK plaintext leak via `UsageLimits` persist in Decrypt and Sign](#cosmian-2026-015--kek-plaintext-leak-via-usagelimits-persist-in-decrypt-and-sign)
-            - [COSMIAN-2026-014 — Sensitive configuration values exposed in Debug output](#cosmian-2026-014--sensitive-configuration-values-exposed-in-debug-output)
-            - [COSMIAN-2026-013 — Internal error details leaked in HTTP 5xx responses](#cosmian-2026-013--internal-error-details-leaked-in-http-5xx-responses)
-            - [COSMIAN-2026-012 — `/server-info` endpoint accessible without authentication](#cosmian-2026-012--server-info-endpoint-accessible-without-authentication)
-            - [COSMIAN-2026-011 — Non-atomic state transitions enable TOCTOU races](#cosmian-2026-011--non-atomic-state-transitions-enable-toctou-races)
-            - [COSMIAN-2026-010 — Predictable default session cookie salt](#cosmian-2026-010--predictable-default-session-cookie-salt)
-            - [COSMIAN-2026-009 — Google CSE rewrap SSRF via `original_kacls_url`](#cosmian-2026-009--google-cse-rewrap-ssrf-via-original_kacls_url)
-            - [COSMIAN-2026-008 — Unwrap cache not invalidated on key revocation/destruction](#cosmian-2026-008--unwrap-cache-not-invalidated-on-key-revocationdestruction)
-            - [COSMIAN-2026-007 — MS DKE scope missing authentication middleware](#cosmian-2026-007--ms-dke-scope-missing-authentication-middleware)
-            - [COSMIAN-2026-006 — Server crash under concurrent requests due to tracing span misuse](#cosmian-2026-006--server-crash-under-concurrent-requests-due-to-tracing-span-misuse)
-            - [COSMIAN-2026-005 — JWT decoding race condition causing intermittent authentication bypass](#cosmian-2026-005--jwt-decoding-race-condition-causing-intermittent-authentication-bypass)
-            - [COSMIAN-2026-004 — OTLP telemetry exported over plaintext HTTP leaks encryption queries](#cosmian-2026-004--otlp-telemetry-exported-over-plaintext-http-leaks-encryption-queries)
-            - [COSMIAN-2026-003 — KMIP Import `replace_existing` bypasses ownership verification](#cosmian-2026-003--kmip-import-replace_existing-bypasses-ownership-verification)
-            - [COSMIAN-2026-002 — SipHash key hardcoded to zero in unwrap cache](#cosmian-2026-002--siphash-key-hardcoded-to-zero-in-unwrap-cache)
-        - [2025](#2025)
-            - [COSMIAN-2025-003 — glibc CVEs in container base image (CVE-2024-2961, CVE-2024-33600, CVE-2024-33601)](#cosmian-2025-003--glibc-cves-in-container-base-image-cve-2024-2961-cve-2024-33600-cve-2024-33601)
-            - [COSMIAN-2025-012 — Session cookie encryption key randomly regenerated on each restart](#cosmian-2025-012--session-cookie-encryption-key-randomly-regenerated-on-each-restart)
-            - [COSMIAN-2025-011 — RUSTSEC-2023-0071: RSA Marvin Attack timing side-channel](#cosmian-2025-011--rustsec-2023-0071-rsa-marvin-attack-timing-side-channel)
-            - [COSMIAN-2025-004 — OpenSSL 3.x CVEs addressed by upgrade to 3.6.2](#cosmian-2025-004--openssl-3x-cves-addressed-by-upgrade-to-362)
-            - [COSMIAN-2025-010 — JWT authentication token not forwarded to downstream services](#cosmian-2025-010--jwt-authentication-token-not-forwarded-to-downstream-services)
-            - [COSMIAN-2025-009 — HSM unwrap operation bypasses KMS permission checks](#cosmian-2025-009--hsm-unwrap-operation-bypasses-kms-permission-checks)
-            - [COSMIAN-2025-002 — Negative X.509 certificate serial numbers](#cosmian-2025-002--negative-x509-certificate-serial-numbers)
-            - [COSMIAN-2025-008 — Google CSE `privilegedunwrap` endpoint unrestricted access](#cosmian-2025-008--google-cse-privilegedunwrap-endpoint-unrestricted-access)
-            - [COSMIAN-2025-001 — CSE migration key pair race condition](#cosmian-2025-001--cse-migration-key-pair-race-condition)
-            - [COSMIAN-2025-007 — OpenID Connect authentication silently falls back to no-auth on TLS failure](#cosmian-2025-007--openid-connect-authentication-silently-falls-back-to-no-auth-on-tls-failure)
-            - [COSMIAN-2025-006 — Missing PKCE in OAuth2 authentication flow](#cosmian-2025-006--missing-pkce-in-oauth2-authentication-flow)
-            - [COSMIAN-2025-005 — JWT authorization config loop — only first OIDC provider checked](#cosmian-2025-005--jwt-authorization-config-loop--only-first-oidc-provider-checked)
-    - [Summary Table](#summary-table)
-    - [Security Best Practices](#security-best-practices)
-    - [FIPS Compliance](#fips-compliance)
-    - [Security Audits](#security-audits)
-    - [Contact](#contact)
+  - [Reporting a Vulnerability](#reporting-a-vulnerability)
+  - [Severity Rating](#severity-rating)
+  - [Known Vulnerabilities](#known-vulnerabilities)
+    - [2026](#2026)
+      - [COSMIAN-2026-019 — RUSTSEC-2026-0173: `proc-macro-error2` soundness issue via `mysql_async`](#cosmian-2026-019--rustsec-2026-0173-proc-macro-error2-soundness-issue-via-mysql_async)
+      - [COSMIAN-2026-018 — Activate operation uses overly permissive authorization check](#cosmian-2026-018--activate-operation-uses-overly-permissive-authorization-check)
+      - [COSMIAN-2026-017 — ReKey / ReKeyKeyPair authorization bypass via raw object retrieval](#cosmian-2026-017--rekey--rekeykeypair-authorization-bypass-via-raw-object-retrieval)
+      - [COSMIAN-2026-016 — Attribute-mutation authorization bypass via incorrect operation type](#cosmian-2026-016--attribute-mutation-authorization-bypass-via-incorrect-operation-type)
+      - [COSMIAN-2026-015 — KEK plaintext leak via `UsageLimits` persist in Decrypt and Sign](#cosmian-2026-015--kek-plaintext-leak-via-usagelimits-persist-in-decrypt-and-sign)
+      - [COSMIAN-2026-014 — Sensitive configuration values exposed in Debug output](#cosmian-2026-014--sensitive-configuration-values-exposed-in-debug-output)
+      - [COSMIAN-2026-013 — Internal error details leaked in HTTP 5xx responses](#cosmian-2026-013--internal-error-details-leaked-in-http-5xx-responses)
+      - [COSMIAN-2026-012 — `/server-info` endpoint accessible without authentication](#cosmian-2026-012--server-info-endpoint-accessible-without-authentication)
+      - [COSMIAN-2026-011 — Non-atomic state transitions enable TOCTOU races](#cosmian-2026-011--non-atomic-state-transitions-enable-toctou-races)
+      - [COSMIAN-2026-010 — Predictable default session cookie salt](#cosmian-2026-010--predictable-default-session-cookie-salt)
+      - [COSMIAN-2026-009 — Google CSE rewrap SSRF via `original_kacls_url`](#cosmian-2026-009--google-cse-rewrap-ssrf-via-original_kacls_url)
+      - [COSMIAN-2026-008 — Unwrap cache not invalidated on key revocation/destruction](#cosmian-2026-008--unwrap-cache-not-invalidated-on-key-revocationdestruction)
+      - [COSMIAN-2026-007 — MS DKE scope missing authentication middleware](#cosmian-2026-007--ms-dke-scope-missing-authentication-middleware)
+      - [COSMIAN-2026-006 — Server crash under concurrent requests due to tracing span misuse](#cosmian-2026-006--server-crash-under-concurrent-requests-due-to-tracing-span-misuse)
+      - [COSMIAN-2026-005 — JWT decoding race condition causing intermittent authentication bypass](#cosmian-2026-005--jwt-decoding-race-condition-causing-intermittent-authentication-bypass)
+      - [COSMIAN-2026-004 — OTLP telemetry exported over plaintext HTTP leaks encryption queries](#cosmian-2026-004--otlp-telemetry-exported-over-plaintext-http-leaks-encryption-queries)
+      - [COSMIAN-2026-003 — KMIP Import `replace_existing` bypasses ownership verification](#cosmian-2026-003--kmip-import-replace_existing-bypasses-ownership-verification)
+      - [COSMIAN-2026-002 — SipHash key hardcoded to zero in unwrap cache](#cosmian-2026-002--siphash-key-hardcoded-to-zero-in-unwrap-cache)
+    - [2025](#2025)
+      - [COSMIAN-2025-003 — glibc CVEs in container base image (CVE-2024-2961, CVE-2024-33600, CVE-2024-33601)](#cosmian-2025-003--glibc-cves-in-container-base-image-cve-2024-2961-cve-2024-33600-cve-2024-33601)
+      - [COSMIAN-2025-012 — Session cookie encryption key randomly regenerated on each restart](#cosmian-2025-012--session-cookie-encryption-key-randomly-regenerated-on-each-restart)
+      - [COSMIAN-2025-011 — RUSTSEC-2023-0071: RSA Marvin Attack timing side-channel](#cosmian-2025-011--rustsec-2023-0071-rsa-marvin-attack-timing-side-channel)
+      - [COSMIAN-2025-004 — OpenSSL 3.x CVEs addressed by upgrade to 3.6.2](#cosmian-2025-004--openssl-3x-cves-addressed-by-upgrade-to-362)
+      - [COSMIAN-2025-010 — JWT authentication token not forwarded to downstream services](#cosmian-2025-010--jwt-authentication-token-not-forwarded-to-downstream-services)
+      - [COSMIAN-2025-009 — HSM unwrap operation bypasses KMS permission checks](#cosmian-2025-009--hsm-unwrap-operation-bypasses-kms-permission-checks)
+      - [COSMIAN-2025-002 — Negative X.509 certificate serial numbers](#cosmian-2025-002--negative-x509-certificate-serial-numbers)
+      - [COSMIAN-2025-008 — Google CSE `privilegedunwrap` endpoint unrestricted access](#cosmian-2025-008--google-cse-privilegedunwrap-endpoint-unrestricted-access)
+      - [COSMIAN-2025-001 — CSE migration key pair race condition](#cosmian-2025-001--cse-migration-key-pair-race-condition)
+      - [COSMIAN-2025-007 — OpenID Connect authentication silently falls back to no-auth on TLS failure](#cosmian-2025-007--openid-connect-authentication-silently-falls-back-to-no-auth-on-tls-failure)
+      - [COSMIAN-2025-006 — Missing PKCE in OAuth2 authentication flow](#cosmian-2025-006--missing-pkce-in-oauth2-authentication-flow)
+      - [COSMIAN-2025-005 — JWT authorization config loop — only first OIDC provider checked](#cosmian-2025-005--jwt-authorization-config-loop--only-first-oidc-provider-checked)
+  - [Summary Table](#summary-table)
+  - [Security Best Practices](#security-best-practices)
+  - [FIPS Compliance](#fips-compliance)
+  - [Security Audits](#security-audits)
+  - [Contact](#contact)
 
 ---
 
@@ -79,13 +79,13 @@ We take the security of Cosmian KMS seriously. If you discover a security vulner
 
 #### COSMIAN-2026-019 — RUSTSEC-2026-0173: `proc-macro-error2` soundness issue via `mysql_async`
 
-| Field      | Value                                                                                             |
-| ---------- | ------------------------------------------------------------------------------------------------- |
-| Severity   | Low                                                                                               |
-| Published  | 2026                                                                                              |
-| Affected   | from 5.0.0 before 5.23.0 (MySQL/Percona/MariaDB backend only)                                    |
-| Fixed in   | 5.23.0                                                                                            |
-| Found by   | `cargo deny` advisory scanner (RUSTSEC-2026-0173)                                                 |
+| Field      | Value                                                                                                                                          |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Severity   | Low                                                                                                                                            |
+| Published  | 2026                                                                                                                                           |
+| Affected   | from 5.0.0 before 5.23.0 (MySQL/Percona/MariaDB backend only)                                                                                  |
+| Fixed in   | 5.23.0                                                                                                                                         |
+| Found by   | `cargo deny` advisory scanner (RUSTSEC-2026-0173)                                                                                              |
 | References | [RUSTSEC-2026-0173](https://rustsec.org/advisories/RUSTSEC-2026-0173.html), [#fix_RUSTSEC-2026-0173](https://github.com/Cosmian/kms/pull/1011) |
 
 **Summary:** `mysql_async` 0.36 pulled in `mysql-common-derive`, which transitively depended on `proc-macro-error2`. `proc-macro-error2` carries RUSTSEC-2026-0173, a soundness issue in its procedural macro machinery (use of `std::mem::transmute` across incompatible lifetime bounds). The advisory affects compile-time macro expansion, not the runtime KMS binary.
@@ -107,7 +107,7 @@ We take the security of Cosmian KMS seriously. If you discover a security vulner
 | Found by   | Copilot code review (GitHub PR #961)            |
 | References | [#961](https://github.com/Cosmian/kms/pull/961) |
 
-**Summary:** The KMIP `Activate` operation passed `KmipOperation::GetAttributes` as the operation type to `retrieve_object_for_operation`. The permission check for `GetAttributes` grants access to any user holding *any* operation grant on the object. This meant a user with only `Encrypt` permission could activate a `PreActive` key, changing its lifecycle state — a security-relevant state transition that should require explicit authorization.
+**Summary:** The KMIP `Activate` operation passed `KmipOperation::GetAttributes` as the operation type to `retrieve_object_for_operation`. The permission check for `GetAttributes` grants access to any user holding _any_ operation grant on the object. This meant a user with only `Encrypt` permission could activate a `PreActive` key, changing its lifecycle state — a security-relevant state transition that should require explicit authorization.
 
 **Impact:** Privilege escalation: a user with a minimal grant (e.g., encrypt-only) could force-activate a key that was intentionally kept in `PreActive` state (e.g., with a future activation date), bypassing the key lifecycle controls set by the key owner.
 
@@ -145,7 +145,7 @@ We take the security of Cosmian KMS seriously. If you discover a security vulner
 | Found by   | Copilot code review (GitHub PR #959)              |
 | References | [#960](https://github.com/Cosmian/kms/issues/960) |
 
-**Summary:** The `SetAttribute`, `ModifyAttribute`, `AddAttribute`, and `DeleteAttribute` KMIP operations all passed `KmipOperation::GetAttributes` as the operation type to `retrieve_object_for_operation`. That function's permission check uses a relaxed "any-permission" policy for `GetAttributes`, so any user holding *any* grant on an object (e.g., `Encrypt`-only) could mutate its attributes — including security-sensitive attributes such as `CryptographicUsageMask` — without the required `Modify` or full-access grant.
+**Summary:** The `SetAttribute`, `ModifyAttribute`, `AddAttribute`, and `DeleteAttribute` KMIP operations all passed `KmipOperation::GetAttributes` as the operation type to `retrieve_object_for_operation`. That function's permission check uses a relaxed "any-permission" policy for `GetAttributes`, so any user holding _any_ grant on an object (e.g., `Encrypt`-only) could mutate its attributes — including security-sensitive attributes such as `CryptographicUsageMask` — without the required `Modify` or full-access grant.
 
 **Impact:** Privilege escalation: a user with a limited grant (e.g., encrypt-only) could change key attributes, potentially widening the usage mask, altering sensitive metadata, or compromising the key's intended usage restrictions.
 
@@ -651,38 +651,38 @@ We take the security of Cosmian KMS seriously. If you discover a security vulner
 
 ## Summary Table
 
-| ID               | Severity | Affected                | Fixed in | Title                                                         |
-| ---------------- | -------- | ----------------------- | -------- | ------------------------------------------------------------- |
+| ID               | Severity | Affected                | Fixed in | Title                                                               |
+| ---------------- | -------- | ----------------------- | -------- | ------------------------------------------------------------------- |
 | COSMIAN-2026-019 | Low      | 5.0.0 – 5.22.x          | 5.23.0   | RUSTSEC-2026-0173: proc-macro-error2 via mysql_async (compile-time) |
-| COSMIAN-2026-018 | Moderate | 5.0.0 – 5.22.x          | 5.23.0   | Activate uses overly permissive authorization check           |
-| COSMIAN-2026-017 | Critical | 5.0.0 – 5.22.x          | 5.23.0   | ReKey / ReKeyKeyPair authorization bypass                     |
-| COSMIAN-2026-016 | Moderate | 5.0.0 – 5.22.x          | 5.23.0   | Attribute-mutation authorization bypass via incorrect op type |
-| COSMIAN-2026-015 | High     | 5.0.0 – 5.21.x          | 5.22.0   | KEK plaintext leak via UsageLimits persist in Decrypt/Sign    |
-| COSMIAN-2026-014 | Low      | 5.0.0 – 5.21.0          | 5.22.0   | Sensitive config values exposed in Debug output               |
-| COSMIAN-2026-013 | Moderate | 5.0.0 – 5.21.0          | 5.22.0   | Internal error details leaked in HTTP 5xx responses           |
-| COSMIAN-2026-012 | Low      | 5.0.0 – 5.21.0          | 5.22.0   | `/server-info` endpoint accessible without authentication     |
-| COSMIAN-2026-011 | Moderate | 5.0.0 – 5.21.0          | 5.22.0   | Non-atomic state transitions enable TOCTOU races              |
-| COSMIAN-2026-010 | Moderate | 5.15.0 – 5.21.0         | 5.22.0   | Predictable default session cookie salt                       |
-| COSMIAN-2026-009 | High     | 5.0.0 – 5.21.0          | 5.22.0   | Google CSE rewrap SSRF via `original_kacls_url`               |
-| COSMIAN-2026-008 | High     | 5.0.0 – 5.21.0          | 5.22.0   | Unwrap cache not invalidated on key revocation/destruction    |
-| COSMIAN-2026-007 | High     | 5.0.0 – 5.21.0          | 5.22.0   | MS DKE scope missing authentication middleware                |
-| COSMIAN-2026-006 | High     | 5.17.0 – 5.21.0         | 5.22.0   | Server crash via tracing span misuse                          |
-| COSMIAN-2026-005 | High     | 5.17.0 – 5.20.1         | 5.21.0   | JWT race condition / algorithm confusion                      |
-| COSMIAN-2026-004 | Critical | 5.0.0+ (with HTTP OTLP) | 5.22.0   | Plaintext OTLP export leaks encryption query metadata         |
-| COSMIAN-2026-003 | Critical | 5.0.0 – 5.16.2          | 5.17.0   | Import `replace_existing` ownership bypass                    |
-| COSMIAN-2026-002 | Critical | 5.0.0 – 5.16.2          | 5.17.0   | SipHash key hardcoded to zero                                 |
-| COSMIAN-2025-012 | High     | 5.0.0 – 5.14.1          | 5.15.0   | Session cookie key randomly regenerated on restart            |
-| COSMIAN-2025-011 | High     | 5.0.0 – 5.14.1          | 5.15.0   | RUSTSEC-2023-0071: RSA Marvin Attack timing side-channel      |
-| COSMIAN-2025-010 | High     | 5.0.0 – 5.13.0          | 5.14.0   | JWT token not forwarded to downstream services                |
-| COSMIAN-2025-009 | Critical | 5.0.0 – 5.12.0          | 5.13.0   | HSM unwrap bypasses KMS permission checks                     |
-| COSMIAN-2025-008 | Critical | 5.0.0 – 5.7.0           | 5.8.0    | Google CSE `privilegedunwrap` unrestricted access             |
-| COSMIAN-2025-007 | High     | 5.0.0 – 5.6.1           | 5.6.2    | OIDC silently falls back to no-auth on TLS failure            |
-| COSMIAN-2025-006 | High     | 5.0.0 – 5.0.0           | 5.1.0    | Missing PKCE in OAuth2 authentication flow                    |
-| COSMIAN-2025-005 | High     | 5.0.0 – 5.1.0           | 5.1.1    | JWT config loop — only first OIDC provider checked            |
-| COSMIAN-2025-004 | High     | 5.0.0 – 5.14.1          | 5.15.0   | OpenSSL 3.x CVEs (upgrade to 3.6.2)                           |
-| COSMIAN-2025-003 | High     | 5.0.0 – 5.15.0          | 5.16.0   | glibc CVEs in container base image                            |
-| COSMIAN-2025-002 | Moderate | 5.0.0 – 5.12.0          | 5.12.1   | Negative X.509 certificate serial numbers                     |
-| COSMIAN-2025-001 | Moderate | 5.0.0 – 5.7.0           | 5.8.0    | CSE migration key pair race condition                         |
+| COSMIAN-2026-018 | Moderate | 5.0.0 – 5.22.x          | 5.23.0   | Activate uses overly permissive authorization check                 |
+| COSMIAN-2026-017 | Critical | 5.0.0 – 5.22.x          | 5.23.0   | ReKey / ReKeyKeyPair authorization bypass                           |
+| COSMIAN-2026-016 | Moderate | 5.0.0 – 5.22.x          | 5.23.0   | Attribute-mutation authorization bypass via incorrect op type       |
+| COSMIAN-2026-015 | High     | 5.0.0 – 5.21.x          | 5.22.0   | KEK plaintext leak via UsageLimits persist in Decrypt/Sign          |
+| COSMIAN-2026-014 | Low      | 5.0.0 – 5.21.0          | 5.22.0   | Sensitive config values exposed in Debug output                     |
+| COSMIAN-2026-013 | Moderate | 5.0.0 – 5.21.0          | 5.22.0   | Internal error details leaked in HTTP 5xx responses                 |
+| COSMIAN-2026-012 | Low      | 5.0.0 – 5.21.0          | 5.22.0   | `/server-info` endpoint accessible without authentication           |
+| COSMIAN-2026-011 | Moderate | 5.0.0 – 5.21.0          | 5.22.0   | Non-atomic state transitions enable TOCTOU races                    |
+| COSMIAN-2026-010 | Moderate | 5.15.0 – 5.21.0         | 5.22.0   | Predictable default session cookie salt                             |
+| COSMIAN-2026-009 | High     | 5.0.0 – 5.21.0          | 5.22.0   | Google CSE rewrap SSRF via `original_kacls_url`                     |
+| COSMIAN-2026-008 | High     | 5.0.0 – 5.21.0          | 5.22.0   | Unwrap cache not invalidated on key revocation/destruction          |
+| COSMIAN-2026-007 | High     | 5.0.0 – 5.21.0          | 5.22.0   | MS DKE scope missing authentication middleware                      |
+| COSMIAN-2026-006 | High     | 5.17.0 – 5.21.0         | 5.22.0   | Server crash via tracing span misuse                                |
+| COSMIAN-2026-005 | High     | 5.17.0 – 5.20.1         | 5.21.0   | JWT race condition / algorithm confusion                            |
+| COSMIAN-2026-004 | Critical | 5.0.0+ (with HTTP OTLP) | 5.22.0   | Plaintext OTLP export leaks encryption query metadata               |
+| COSMIAN-2026-003 | Critical | 5.0.0 – 5.16.2          | 5.17.0   | Import `replace_existing` ownership bypass                          |
+| COSMIAN-2026-002 | Critical | 5.0.0 – 5.16.2          | 5.17.0   | SipHash key hardcoded to zero                                       |
+| COSMIAN-2025-012 | High     | 5.0.0 – 5.14.1          | 5.15.0   | Session cookie key randomly regenerated on restart                  |
+| COSMIAN-2025-011 | High     | 5.0.0 – 5.14.1          | 5.15.0   | RUSTSEC-2023-0071: RSA Marvin Attack timing side-channel            |
+| COSMIAN-2025-010 | High     | 5.0.0 – 5.13.0          | 5.14.0   | JWT token not forwarded to downstream services                      |
+| COSMIAN-2025-009 | Critical | 5.0.0 – 5.12.0          | 5.13.0   | HSM unwrap bypasses KMS permission checks                           |
+| COSMIAN-2025-008 | Critical | 5.0.0 – 5.7.0           | 5.8.0    | Google CSE `privilegedunwrap` unrestricted access                   |
+| COSMIAN-2025-007 | High     | 5.0.0 – 5.6.1           | 5.6.2    | OIDC silently falls back to no-auth on TLS failure                  |
+| COSMIAN-2025-006 | High     | 5.0.0 – 5.0.0           | 5.1.0    | Missing PKCE in OAuth2 authentication flow                          |
+| COSMIAN-2025-005 | High     | 5.0.0 – 5.1.0           | 5.1.1    | JWT config loop — only first OIDC provider checked                  |
+| COSMIAN-2025-004 | High     | 5.0.0 – 5.14.1          | 5.15.0   | OpenSSL 3.x CVEs (upgrade to 3.6.2)                                 |
+| COSMIAN-2025-003 | High     | 5.0.0 – 5.15.0          | 5.16.0   | glibc CVEs in container base image                                  |
+| COSMIAN-2025-002 | Moderate | 5.0.0 – 5.12.0          | 5.12.1   | Negative X.509 certificate serial numbers                           |
+| COSMIAN-2025-001 | Moderate | 5.0.0 – 5.7.0           | 5.8.0    | CSE migration key pair race condition                               |
 
 ---
 
@@ -696,6 +696,14 @@ When using Cosmian KMS, we recommend:
 4. **Access Control**: Implement proper authentication and authorization mechanisms
 5. **Monitoring**: Enable logging and monitoring for security events
 6. **TLS Everywhere**: Use TLS for all endpoints including OTLP collectors
+7. **Audit log saturation**: The tamper-evident audit log uses a bounded in-memory
+   channel (default capacity: 4 096 events). Under sustained high load, events that
+   cannot be enqueued are dropped and an `error!` is emitted to the server log — the
+   compliance record is incomplete for that burst. To detect saturation, monitor the
+   server log for `"AuditFileStore: channel full"` messages and alert on any
+   occurrence. Tune the capacity with `--audit-channel-capacity` (env:
+   `KMS_AUDIT_CHANNEL_CAPACITY`); reduce request concurrency or raise the capacity
+   to stay within the write throughput of the underlying storage.
 
 ## FIPS Compliance
 

--- a/crate/access/Cargo.toml
+++ b/crate/access/Cargo.toml
@@ -22,4 +22,10 @@ doctest = false
 
 [dependencies]
 cosmian_kmip = { path = "../kmip", version = "5.25.0", default-features = true }
+hex = { workspace = true, features = ["serde"] }
 serde = { workspace = true }
+sha2 = { workspace = true }
+time = { workspace = true, features = ["serde-human-readable"] }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crate/access/Cargo.toml
+++ b/crate/access/Cargo.toml
@@ -25,7 +25,5 @@ cosmian_kmip = { path = "../kmip", version = "5.25.0", default-features = true }
 hex = { workspace = true, features = ["serde"] }
 serde = { workspace = true }
 sha2 = { workspace = true }
+uuid = { workspace = true, features = ["v4", "serde"] }
 time = { workspace = true, features = ["serde-human-readable"] }
-
-[dev-dependencies]
-serde_json = { workspace = true }

--- a/crate/access/src/audit/cef.rs
+++ b/crate/access/src/audit/cef.rs
@@ -1,0 +1,237 @@
+use std::fmt::Write as _;
+
+use time::format_description::well_known::Rfc3339;
+
+use super::event::{AuditEventFull, AuditResult};
+
+// CEF v25 severity levels used by this implementation
+const SEV_SUCCESS: u8 = 5;
+const SEV_AUTH_FAILURE: u8 = 7; // 401 / 403
+const SEV_OTHER_FAILURE: u8 = 6;
+
+/// Serialises `event` as a single CEF v25 line (no trailing newline).
+///
+/// Format:
+/// ```text
+/// CEF:0|Cosmian|KMS|<version>|<operation>|<operation>|<severity>|<extension>
+/// ```
+///
+/// Extension fields produced:
+/// | Key        | Description                          |
+/// |------------|--------------------------------------|
+/// `rt`         | Event timestamp (epoch milliseconds) |
+/// `suser`      | Authenticated user                   |
+/// `src`        | Client IP (omitted if unknown)       |
+/// `outcome`    | "Success" or "Failure"               |
+/// `reason`     | Failure message (omitted on success) |
+/// `act`        | KMIP operation name                  |
+/// `cn1`        | Duration in milliseconds             |
+/// `cn1Label`   | "durationMs"                         |
+/// `cs1`        | Object UID (omitted if unknown)      |
+/// `cs1Label`   | "objectUID" (omitted if cs1 absent)  |
+/// `cs2`        | Algorithm (omitted if unknown)       |
+/// `cs2Label`   | "algorithm" (omitted if cs2 absent)  |
+#[must_use]
+pub fn to_cef_line(event: &AuditEventFull, kms_version: &str) -> String {
+    let severity = cef_severity(&event.result);
+
+    // ── Header fields ────────────────────────────────────────────────────
+    // CEF:Version|Device Vendor|Device Product|Device Version|
+    //     Device Event Class ID|Name|Severity|
+    let header = format!(
+        "CEF:0|Cosmian|KMS|{ver}|{class}|{name}|{sev}|",
+        ver = escape_header(kms_version),
+        class = escape_header(&event.operation),
+        name = escape_header(&event.operation),
+        sev = severity,
+    );
+
+    // ── Extension key=value pairs ────────────────────────────────────────
+    let rt_ms = event.timestamp.unix_timestamp() * 1000 + i64::from(event.timestamp.millisecond());
+
+    let mut ext = format!(
+        "rt={rt} suser={user}",
+        rt = rt_ms,
+        user = escape_ext_value(&event.user),
+    );
+
+    if let Some(ip) = &event.client_ip {
+        let _ = write!(ext, " src={}", escape_ext_value(ip));
+    }
+
+    match &event.result {
+        AuditResult::Success => {
+            ext.push_str(" outcome=Success");
+        }
+        AuditResult::Failure(msg) => {
+            ext.push_str(" outcome=Failure");
+            let _ = write!(ext, " reason={}", escape_ext_value(msg));
+        }
+    }
+
+    let _ = write!(
+        ext,
+        " act={act} cn1={dur} cn1Label=durationMs",
+        act = escape_ext_value(&event.operation),
+        dur = event.duration_ms,
+    );
+
+    if let Some(uid) = &event.object_uid {
+        let _ = write!(ext, " cs1={} cs1Label=objectUID", escape_ext_value(uid));
+    }
+
+    if let Some(alg) = &event.algorithm {
+        let _ = write!(ext, " cs2={} cs2Label=algorithm", escape_ext_value(alg));
+    }
+
+    // Append the event id for easy cross-referencing with the JSONL log
+    let _ = write!(ext, " cs3={} cs3Label=auditId", event.id);
+
+    // Append RFC3339 timestamp as a human-readable reference
+    let ts_str = event
+        .timestamp
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned());
+    let _ = write!(ext, " cs4={} cs4Label=timestamp", escape_ext_value(&ts_str));
+
+    format!("{header}{ext}")
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+fn cef_severity(result: &AuditResult) -> u8 {
+    match result {
+        AuditResult::Success => SEV_SUCCESS,
+        AuditResult::Failure(msg) => {
+            if msg.contains("401")
+                || msg.contains("403")
+                || msg.contains("Unauthorized")
+                || msg.contains("Forbidden")
+            {
+                SEV_AUTH_FAILURE
+            } else {
+                SEV_OTHER_FAILURE
+            }
+        }
+    }
+}
+
+/// Escapes a value for use in the CEF pipe-delimited header.
+/// Escapes `\` → `\\` then `|` → `\|`.
+fn escape_header(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('|', "\\|")
+}
+
+/// Escapes a value for use in a CEF extension field value.
+/// Per CEF v25 spec: `\` → `\\`, then `=` → `\=`, then newlines.
+fn escape_ext_value(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('=', "\\=")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::unseparated_literal_suffix)]
+mod tests {
+    use time::OffsetDateTime;
+
+    use super::super::event::{AuditEventFull, AuditResult};
+    use super::{escape_ext_value, escape_header, to_cef_line};
+    use crate::audit::hash::compute_row_hash;
+
+    fn make_event(result: AuditResult) -> AuditEventFull {
+        let mut ev = AuditEventFull {
+            id: 7,
+            timestamp: OffsetDateTime::from_unix_timestamp(1_700_000_000).unwrap(),
+            operation: "Encrypt".to_owned(),
+            user: "alice@example.com".to_owned(),
+            object_uid: Some("obj-1234".to_owned()),
+            algorithm: Some("AES-256-GCM".to_owned()),
+            client_ip: Some("10.0.1.42".to_owned()),
+            result,
+            duration_ms: 12,
+            prev_hash: [0u8; 32],
+            row_hash: [0u8; 32],
+        };
+        ev.row_hash = compute_row_hash(&ev);
+        ev
+    }
+
+    #[test]
+    fn cef_line_starts_with_header() {
+        let ev = make_event(AuditResult::Success);
+        let line = to_cef_line(&ev, "5.0.0");
+        assert!(line.starts_with("CEF:0|Cosmian|KMS|5.0.0|Encrypt|Encrypt|5|"));
+    }
+
+    #[test]
+    fn cef_line_contains_rt() {
+        let ev = make_event(AuditResult::Success);
+        let line = to_cef_line(&ev, "5.0.0");
+        // 1_700_000_000 * 1000 = 1700000000000
+        assert!(line.contains("rt=1700000000000"));
+    }
+
+    #[test]
+    fn cef_line_success_outcome() {
+        let ev = make_event(AuditResult::Success);
+        let line = to_cef_line(&ev, "5.0.0");
+        assert!(line.contains("outcome=Success"));
+        assert!(!line.contains("reason="));
+    }
+
+    #[test]
+    fn cef_line_failure_outcome() {
+        let ev = make_event(AuditResult::Failure("401 Unauthorized".to_owned()));
+        let line = to_cef_line(&ev, "5.0.0");
+        assert!(line.contains("outcome=Failure"));
+        assert!(line.contains("reason=401 Unauthorized"));
+    }
+
+    #[test]
+    fn cef_failure_401_severity_7() {
+        let ev = make_event(AuditResult::Failure("401 Unauthorized".to_owned()));
+        let line = to_cef_line(&ev, "5.0.0");
+        // header has |7| for auth failures
+        assert!(line.contains("|7|"));
+    }
+
+    #[test]
+    fn cef_other_failure_severity_6() {
+        let ev = make_event(AuditResult::Failure("Internal error".to_owned()));
+        let line = to_cef_line(&ev, "5.0.0");
+        assert!(line.contains("|6|"));
+    }
+
+    #[test]
+    fn cef_line_has_object_uid() {
+        let ev = make_event(AuditResult::Success);
+        let line = to_cef_line(&ev, "5.0.0");
+        assert!(line.contains("cs1=obj-1234"));
+        assert!(line.contains("cs1Label=objectUID"));
+    }
+
+    #[test]
+    fn cef_line_no_object_uid_when_absent() {
+        let mut ev = make_event(AuditResult::Success);
+        ev.object_uid = None;
+        let line = to_cef_line(&ev, "5.0.0");
+        assert!(!line.contains("cs1="));
+    }
+
+    #[test]
+    fn escape_header_pipe() {
+        assert_eq!(escape_header("foo|bar"), "foo\\|bar");
+    }
+
+    #[test]
+    fn escape_ext_value_equals() {
+        assert_eq!(escape_ext_value("key=val"), "key\\=val");
+    }
+
+    #[test]
+    fn escape_ext_value_backslash() {
+        assert_eq!(escape_ext_value("a\\b"), "a\\\\b");
+    }
+}

--- a/crate/access/src/audit/cef.rs
+++ b/crate/access/src/audit/cef.rs
@@ -1,3 +1,5 @@
+// This file is implemented according to the following spec:
+// https://www.microfocus.com/documentation/arcsight/arcsight-smartconnectors-24.2/pdfdoc/cef-implementation-standard/cef-implementation-standard.pdf
 use std::fmt::Write as _;
 
 use time::format_description::well_known::Rfc3339;

--- a/crate/access/src/audit/cef.rs
+++ b/crate/access/src/audit/cef.rs
@@ -46,7 +46,7 @@ pub fn to_cef_line(event: &AuditEventFull, kms_version: &str) -> String {
         sev = severity,
     );
 
-    // ── Extension key=value pairs ────────────────────────────────────────
+    // Extension key=value pairs
     let rt_ms = event.timestamp.unix_timestamp() * 1000 + i64::from(event.timestamp.millisecond());
 
     let mut ext = format!(
@@ -97,7 +97,6 @@ pub fn to_cef_line(event: &AuditEventFull, kms_version: &str) -> String {
     format!("{header}{ext}")
 }
 
-// ── Internal helpers ──────────────────────────────────────────────────────────
 
 fn cef_severity(result: &AuditResult) -> u8 {
     match result {

--- a/crate/access/src/audit/cef.rs
+++ b/crate/access/src/audit/cef.rs
@@ -96,6 +96,10 @@ pub fn to_cef_line(event: &AuditEvent, kms_version: &str) -> String {
         .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned());
     let _ = write!(ext, " cs4={} cs4Label=timestamp", escape_ext_value(&ts_str));
 
+    if let Some(rid) = &event.request_id {
+        let _ = write!(ext, " cs5={} cs5Label=requestId", rid.hyphenated());
+    }
+
     format!("{header}{ext}")
 }
 
@@ -151,6 +155,7 @@ mod tests {
             client_ip: Some("10.0.1.42".to_owned()),
             result,
             duration_ms: 12,
+            request_id: None,
             prev_hash: [0u8; 32],
             row_hash: [0u8; 32],
         };
@@ -233,5 +238,34 @@ mod tests {
     #[test]
     fn escape_ext_value_backslash() {
         assert_eq!(escape_ext_value("a\\b"), "a\\\\b");
+    }
+
+    #[test]
+    fn cef_line_includes_request_id() {
+        use uuid::Uuid;
+        let mut ev = make_event(AuditResult::Success);
+        let rid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        ev.request_id = Some(rid);
+        ev.row_hash = compute_row_hash(&ev);
+        let line = to_cef_line(&ev, "5.0.0");
+        assert!(
+            line.contains("cs5=550e8400-e29b-41d4-a716-446655440000"),
+            "expected cs5 in: {line}"
+        );
+        assert!(
+            line.contains("cs5Label=requestId"),
+            "expected cs5Label in: {line}"
+        );
+    }
+
+    #[test]
+    fn cef_line_omits_request_id_when_none() {
+        let ev = make_event(AuditResult::Success);
+        assert!(ev.request_id.is_none());
+        let line = to_cef_line(&ev, "5.0.0");
+        assert!(
+            !line.contains("cs5"),
+            "cs5 must be absent when request_id is None: {line}"
+        );
     }
 }

--- a/crate/access/src/audit/cef.rs
+++ b/crate/access/src/audit/cef.rs
@@ -2,14 +2,16 @@ use std::fmt::Write as _;
 
 use time::format_description::well_known::Rfc3339;
 
-use super::event::{AuditEventFull, AuditResult};
+use super::event::{AuditEvent, AuditResult};
 
-// CEF v25 severity levels used by this implementation
+// CEF severity levels used by this implementation (CEF spec 0.1, header CEF:0)
 const SEV_SUCCESS: u8 = 5;
 const SEV_AUTH_FAILURE: u8 = 7; // 401 / 403
 const SEV_OTHER_FAILURE: u8 = 6;
 
-/// Serialises `event` as a single CEF v25 line (no trailing newline).
+// Note: no current Rust library currently seems to exist for CEF, hence this implementation is hand-rolled. Tests are pretty heavy.
+
+/// Serialises `event` as a single CEF line (spec 0.1, `CEF:0` header, no trailing newline).
 ///
 /// Format:
 /// ```text
@@ -32,7 +34,7 @@ const SEV_OTHER_FAILURE: u8 = 6;
 /// `cs2`        | Algorithm (omitted if unknown)       |
 /// `cs2Label`   | "algorithm" (omitted if cs2 absent)  |
 #[must_use]
-pub fn to_cef_line(event: &AuditEventFull, kms_version: &str) -> String {
+pub fn to_cef_line(event: &AuditEvent, kms_version: &str) -> String {
     let severity = cef_severity(&event.result);
 
     // ── Header fields ────────────────────────────────────────────────────
@@ -97,7 +99,6 @@ pub fn to_cef_line(event: &AuditEventFull, kms_version: &str) -> String {
     format!("{header}{ext}")
 }
 
-
 fn cef_severity(result: &AuditResult) -> u8 {
     match result {
         AuditResult::Success => SEV_SUCCESS,
@@ -122,7 +123,7 @@ fn escape_header(s: &str) -> String {
 }
 
 /// Escapes a value for use in a CEF extension field value.
-/// Per CEF v25 spec: `\` → `\\`, then `=` → `\=`, then newlines.
+/// Per CEF spec 0.1: `\` → `\\`, then `=` → `\=`, then newlines.
 fn escape_ext_value(s: &str) -> String {
     s.replace('\\', "\\\\")
         .replace('=', "\\=")
@@ -135,12 +136,12 @@ fn escape_ext_value(s: &str) -> String {
 mod tests {
     use time::OffsetDateTime;
 
-    use super::super::event::{AuditEventFull, AuditResult};
+    use super::super::event::{AuditEvent, AuditResult};
     use super::{escape_ext_value, escape_header, to_cef_line};
     use crate::audit::hash::compute_row_hash;
 
-    fn make_event(result: AuditResult) -> AuditEventFull {
-        let mut ev = AuditEventFull {
+    fn make_event(result: AuditResult) -> AuditEvent {
+        let mut ev = AuditEvent {
             id: 7,
             timestamp: OffsetDateTime::from_unix_timestamp(1_700_000_000).unwrap(),
             operation: "Encrypt".to_owned(),

--- a/crate/access/src/audit/cef.rs
+++ b/crate/access/src/audit/cef.rs
@@ -121,9 +121,14 @@ fn cef_severity(result: &AuditResult) -> u8 {
 }
 
 /// Escapes a value for use in the CEF pipe-delimited header.
-/// Escapes `\` → `\\` then `|` → `\|`.
+/// Escapes `\` → `\\`, `|` → `\|`, then newlines — a raw `\n`/`\r` in the
+/// operation name would otherwise let an attacker inject a second, forged
+/// CEF record into the SIEM stream.
 fn escape_header(s: &str) -> String {
-    s.replace('\\', "\\\\").replace('|', "\\|")
+    s.replace('\\', "\\\\")
+        .replace('|', "\\|")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
 }
 
 /// Escapes a value for use in a CEF extension field value.
@@ -266,6 +271,84 @@ mod tests {
         assert!(
             !line.contains("cs5"),
             "cs5 must be absent when request_id is None: {line}"
+        );
+    }
+
+    // ── Injection hardening ─────────────────────────────────────────────
+
+    #[test]
+    fn escape_ext_value_newline_and_cr() {
+        assert_eq!(escape_ext_value("a\nb\rc"), "a\\nb\\rc");
+    }
+
+    #[test]
+    fn escape_ext_value_pipe_is_not_escaped() {
+        // `|` only delimits the CEF header, not extension key=value pairs.
+        assert_eq!(escape_ext_value("a|b"), "a|b");
+    }
+
+    #[test]
+    fn escape_header_newline_and_cr() {
+        assert_eq!(escape_header("a\nb\rc"), "a\\nb\\rc");
+    }
+
+    #[test]
+    fn cef_line_user_with_forged_record_stays_single_line() {
+        // A malicious `user` embedding a newline + fake CEF header must not be
+        // able to inject a second record into the SIEM stream.
+        let mut ev = make_event(AuditResult::Success);
+        ev.user = "evil\nCEF:0|Attacker|Forged|1.0|Fake|Fake|10|".to_owned();
+        ev.row_hash = compute_row_hash(&ev);
+        let line = to_cef_line(&ev, "5.0.0");
+
+        assert!(
+            !line.contains('\n'),
+            "CEF line must not contain a raw newline: {line}"
+        );
+        assert!(
+            !line.contains('\r'),
+            "CEF line must not contain a raw CR: {line}"
+        );
+        // The forged header text must stay embedded inside the escaped `suser`
+        // value, not break out into what a line-oriented parser would treat
+        // as a second record.
+        assert!(
+            line.contains("suser=evil\\nCEF:0|Attacker"),
+            "expected escaped user: {line}"
+        );
+    }
+
+    #[test]
+    fn cef_line_object_uid_with_equals_and_pipe_stays_single_field() {
+        let mut ev = make_event(AuditResult::Success);
+        ev.object_uid = Some("uid=1|extra=field".to_owned());
+        ev.row_hash = compute_row_hash(&ev);
+        let line = to_cef_line(&ev, "5.0.0");
+
+        assert!(
+            line.contains("cs1=uid\\=1|extra\\=field cs1Label=objectUID"),
+            "expected escaped '=' in cs1 value: {line}"
+        );
+    }
+
+    #[test]
+    fn cef_line_operation_with_pipe_does_not_break_header_fields() {
+        let mut ev = make_event(AuditResult::Success);
+        ev.operation = "Fake|Injected|99".to_owned();
+        ev.row_hash = compute_row_hash(&ev);
+        let line = to_cef_line(&ev, "5.0.0");
+
+        // The embedded `|` must be escaped (`\|`), not left as a raw field
+        // separator — otherwise it would shift the severity/extension fields.
+        let expected_header =
+            "CEF:0|Cosmian|KMS|5.0.0|Fake\\|Injected\\|99|Fake\\|Injected\\|99|5|";
+        assert!(
+            line.starts_with(expected_header),
+            "expected escaped pipes in header, got: {line}"
+        );
+        assert!(
+            line[expected_header.len()..].starts_with("rt="),
+            "severity/extension fields must not shift: {line}"
         );
     }
 }

--- a/crate/access/src/audit/event.rs
+++ b/crate/access/src/audit/event.rs
@@ -1,0 +1,115 @@
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+
+/// The finalised, persisted audit event including its hash-chain fields.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuditEventFull {
+    /// Monotonically increasing row counter.
+    pub id: i64,
+    /// Wall-clock timestamp of the KMIP operation (UTC).
+    #[serde(with = "time::serde::rfc3339")]
+    pub timestamp: OffsetDateTime,
+    /// KMIP operation name, e.g. "Encrypt", "Create", "Destroy".
+    pub operation: String,
+    /// Authenticated username / identity, e.g. "alice@example.com".
+    pub user: String,
+    /// KMIP Unique Identifier of the object involved, if any.
+    pub object_uid: Option<String>,
+    /// Cryptographic algorithm associated with the operation, if any.
+    pub algorithm: Option<String>,
+    /// Client IP address as seen by the server, if available.
+    pub client_ip: Option<String>,
+    /// Whether the operation succeeded or the reason it failed.
+    pub result: AuditResult,
+    /// Total server-side processing time in milliseconds.
+    pub duration_ms: u64,
+    /// SHA-256 of the previous row (all-zeros for the first row).
+    #[serde(with = "hex::serde")]
+    pub prev_hash: [u8; 32],
+    /// SHA-256 of the canonical byte representation of this row.
+    #[serde(with = "hex::serde")]
+    pub row_hash: [u8; 32],
+}
+
+/// Outcome of a KMIP operation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum AuditResult {
+    /// The operation completed successfully.
+    Success,
+    /// The operation failed; the inner string contains the reason.
+    Failure(String),
+}
+
+impl AuditResult {
+    /// Returns a stable string representation used in the hash canonical form.
+    #[must_use]
+    pub fn as_canonical_str(&self) -> String {
+        match self {
+            Self::Success => "Success".to_owned(),
+            Self::Failure(msg) => format!("Failure:{msg}"),
+        }
+    }
+
+    /// Returns `true` if the operation succeeded.
+    #[must_use]
+    pub const fn is_success(&self) -> bool {
+        matches!(self, Self::Success)
+    }
+}
+
+/// The subset of audit data available at request time, before the hash chain
+/// fields (`id`, `prev_hash`, `row_hash`) are assigned by the writer task.
+#[derive(Debug, Clone)]
+pub struct AuditEventDraft {
+    /// Wall-clock timestamp of the KMIP operation (UTC).
+    pub timestamp: OffsetDateTime,
+    /// KMIP operation name.
+    pub operation: String,
+    /// Authenticated username / identity.
+    pub user: String,
+    /// KMIP Unique Identifier of the object involved, if any.
+    pub object_uid: Option<String>,
+    /// Cryptographic algorithm, if any.
+    pub algorithm: Option<String>,
+    /// Client IP address as seen by the server, if available.
+    pub client_ip: Option<String>,
+    /// Whether the operation succeeded or failed.
+    pub result: AuditResult,
+    /// Server-side processing time in milliseconds.
+    pub duration_ms: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use time::OffsetDateTime;
+
+    use super::{AuditEventDraft, AuditResult};
+
+    #[test]
+    fn canonical_str_success() {
+        assert_eq!(AuditResult::Success.as_canonical_str(), "Success");
+    }
+
+    #[test]
+    fn canonical_str_failure() {
+        assert_eq!(
+            AuditResult::Failure("401 Unauthorized".to_owned()).as_canonical_str(),
+            "Failure:401 Unauthorized"
+        );
+    }
+
+    #[test]
+    fn draft_creation() {
+        let draft = AuditEventDraft {
+            timestamp: OffsetDateTime::now_utc(),
+            operation: "Encrypt".to_owned(),
+            user: "alice@example.com".to_owned(),
+            object_uid: Some("obj-1234".to_owned()),
+            algorithm: Some("AES-256-GCM".to_owned()),
+            client_ip: Some("127.0.0.1".to_owned()),
+            result: AuditResult::Success,
+            duration_ms: 5,
+        };
+        assert_eq!(draft.operation, "Encrypt");
+    }
+}

--- a/crate/access/src/audit/event.rs
+++ b/crate/access/src/audit/event.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
+use uuid::Uuid;
 
 /// The finalised, persisted audit event including its hash-chain fields.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -16,6 +17,10 @@ pub struct AuditEvent {
     pub client_ip: Option<String>,
     pub result: AuditResult,
     pub duration_ms: u64,
+    /// Shared across all `BatchItem` drafts produced from the same HTTP request.
+    /// `None` only for synthetic events or test fixtures that predate this field.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub request_id: Option<Uuid>,
     /// SHA-256 of the previous row (all-zeros for the first row).
     #[serde(with = "hex::serde")]
     pub prev_hash: [u8; 32],
@@ -62,6 +67,8 @@ pub struct AuditEventDraft {
     pub client_ip: Option<String>,
     pub result: AuditResult,
     pub duration_ms: u64,
+    /// Shared across all `BatchItem` drafts from the same HTTP request.
+    pub request_id: Option<Uuid>,
 }
 
 #[cfg(test)]
@@ -94,6 +101,7 @@ mod tests {
             client_ip: Some("127.0.0.1".to_owned()),
             result: AuditResult::Success,
             duration_ms: 5,
+            request_id: None,
         };
         assert_eq!(draft.operation, "Encrypt");
     }

--- a/crate/access/src/audit/event.rs
+++ b/crate/access/src/audit/event.rs
@@ -3,25 +3,18 @@ use time::OffsetDateTime;
 
 /// The finalised, persisted audit event including its hash-chain fields.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AuditEventFull {
+pub struct AuditEvent {
     /// Monotonically increasing row counter.
     pub id: i64,
     /// Wall-clock timestamp of the KMIP operation (UTC).
     #[serde(with = "time::serde::rfc3339")]
     pub timestamp: OffsetDateTime,
-    /// KMIP operation name, e.g. "Encrypt", "Create", "Destroy".
     pub operation: String,
-    /// Authenticated username / identity, e.g. "alice@example.com".
     pub user: String,
-    /// KMIP Unique Identifier of the object involved, if any.
     pub object_uid: Option<String>,
-    /// Cryptographic algorithm associated with the operation, if any.
     pub algorithm: Option<String>,
-    /// Client IP address as seen by the server, if available.
     pub client_ip: Option<String>,
-    /// Whether the operation succeeded or the reason it failed.
     pub result: AuditResult,
-    /// Total server-side processing time in milliseconds.
     pub duration_ms: u64,
     /// SHA-256 of the previous row (all-zeros for the first row).
     #[serde(with = "hex::serde")]
@@ -61,21 +54,13 @@ impl AuditResult {
 /// fields (`id`, `prev_hash`, `row_hash`) are assigned by the writer task.
 #[derive(Debug, Clone)]
 pub struct AuditEventDraft {
-    /// Wall-clock timestamp of the KMIP operation (UTC).
     pub timestamp: OffsetDateTime,
-    /// KMIP operation name.
     pub operation: String,
-    /// Authenticated username / identity.
     pub user: String,
-    /// KMIP Unique Identifier of the object involved, if any.
     pub object_uid: Option<String>,
-    /// Cryptographic algorithm, if any.
     pub algorithm: Option<String>,
-    /// Client IP address as seen by the server, if available.
     pub client_ip: Option<String>,
-    /// Whether the operation succeeded or failed.
     pub result: AuditResult,
-    /// Server-side processing time in milliseconds.
     pub duration_ms: u64,
 }
 

--- a/crate/access/src/audit/hash.rs
+++ b/crate/access/src/audit/hash.rs
@@ -1,0 +1,179 @@
+use sha2::{Digest, Sha256};
+use time::format_description::well_known::Rfc3339;
+
+use super::event::AuditEventFull;
+
+/// Builds the deterministic, NUL-delimited binary representation of `event`
+/// that is fed into the SHA-256 digest.
+///
+/// Layout (concatenation without length prefixes):
+/// ```text
+/// prev_hash (32 bytes, raw)
+/// || id     (8 bytes, big-endian i64)
+/// || timestamp in RFC 3339 / ISO 8601 (UTF-8 bytes)
+/// || NUL (0x00)
+/// || operation (UTF-8)
+/// || NUL
+/// || user (UTF-8)
+/// || NUL
+/// || object_uid or "" (UTF-8)
+/// || NUL
+/// || algorithm or "" (UTF-8)
+/// || NUL
+/// || client_ip or "" (UTF-8)
+/// || NUL
+/// || result canonical string (UTF-8, e.g. "Success" / "Failure:401 …")
+/// || NUL
+/// || duration_ms (8 bytes, big-endian u64)
+/// ```
+pub(crate) fn canonical_bytes(event: &AuditEventFull) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(256);
+
+    buf.extend_from_slice(&event.prev_hash);
+    buf.extend_from_slice(&event.id.to_be_bytes());
+
+    let ts = event
+        .timestamp
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned());
+    buf.extend_from_slice(ts.as_bytes());
+    buf.push(0x00);
+
+    buf.extend_from_slice(event.operation.as_bytes());
+    buf.push(0x00);
+
+    buf.extend_from_slice(event.user.as_bytes());
+    buf.push(0x00);
+
+    buf.extend_from_slice(event.object_uid.as_deref().unwrap_or("").as_bytes());
+    buf.push(0x00);
+
+    buf.extend_from_slice(event.algorithm.as_deref().unwrap_or("").as_bytes());
+    buf.push(0x00);
+
+    buf.extend_from_slice(event.client_ip.as_deref().unwrap_or("").as_bytes());
+    buf.push(0x00);
+
+    buf.extend_from_slice(event.result.as_canonical_str().as_bytes());
+    buf.push(0x00);
+
+    buf.extend_from_slice(&event.duration_ms.to_be_bytes());
+
+    buf
+}
+
+/// Computes the SHA-256 digest over the canonical byte form of `event`.
+/// The returned hash should be stored as `event.row_hash`.
+#[must_use]
+pub fn compute_row_hash(event: &AuditEventFull) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(canonical_bytes(event));
+    hasher.finalize().into()
+}
+
+/// Returns `true` when `event.row_hash` matches the SHA-256 of its own
+/// canonical bytes.
+#[must_use]
+pub fn verify_event(event: &AuditEventFull) -> bool {
+    let expected = compute_row_hash(event);
+    expected == event.row_hash
+}
+
+/// Verifies that the hash-chain link from `prev` to `current` is intact.
+///
+/// * If `prev` is `None` the row must be the first row
+///   (`current.prev_hash == [0u8; 32]` AND `current.id == 0`).
+/// * Otherwise `current.prev_hash` must equal `prev.row_hash`.
+///
+/// Note: this function does **not** call [`verify_event`]; call that
+/// separately to check the row's own integrity.
+#[must_use]
+pub fn verify_chain_link(current: &AuditEventFull, prev: Option<&AuditEventFull>) -> bool {
+    prev.map_or_else(
+        || current.id == 0 && current.prev_hash == [0_u8; 32],
+        |p| current.prev_hash == p.row_hash,
+    )
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::unseparated_literal_suffix)]
+mod tests {
+    use time::OffsetDateTime;
+
+    use super::super::event::{AuditEventFull, AuditResult};
+    use super::{canonical_bytes, compute_row_hash, verify_chain_link, verify_event};
+
+    fn make_event(id: i64, prev_hash: [u8; 32], result: AuditResult) -> AuditEventFull {
+        let mut ev = AuditEventFull {
+            id,
+            timestamp: OffsetDateTime::from_unix_timestamp(1_700_000_000).unwrap(),
+            operation: "Encrypt".to_owned(),
+            user: "alice@example.com".to_owned(),
+            object_uid: Some("obj-1234".to_owned()),
+            algorithm: Some("AES-256-GCM".to_owned()),
+            client_ip: Some("127.0.0.1".to_owned()),
+            result,
+            duration_ms: 10,
+            prev_hash,
+            row_hash: [0u8; 32],
+        };
+        ev.row_hash = compute_row_hash(&ev);
+        ev
+    }
+
+    #[test]
+    fn canonical_bytes_deterministic() {
+        let ev = make_event(0, [0u8; 32], AuditResult::Success);
+        let b1 = canonical_bytes(&ev);
+        let b2 = canonical_bytes(&ev);
+        assert_eq!(b1, b2);
+    }
+
+    #[test]
+    fn canonical_bytes_differ_on_operation() {
+        let ev1 = make_event(0, [0u8; 32], AuditResult::Success);
+        let mut ev2 = ev1.clone();
+        ev2.operation = "Decrypt".to_owned();
+        assert_ne!(canonical_bytes(&ev1), canonical_bytes(&ev2));
+    }
+
+    #[test]
+    fn verify_event_ok() {
+        let ev = make_event(0, [0u8; 32], AuditResult::Success);
+        assert!(verify_event(&ev));
+    }
+
+    #[test]
+    fn verify_event_detects_tampering() {
+        let mut ev = make_event(0, [0u8; 32], AuditResult::Success);
+        ev.operation = "Destroy".to_owned(); // tamper after hash was set
+        assert!(!verify_event(&ev));
+    }
+
+    #[test]
+    fn chain_first_row() {
+        let ev = make_event(0, [0u8; 32], AuditResult::Success);
+        assert!(verify_chain_link(&ev, None));
+    }
+
+    #[test]
+    fn chain_first_row_wrong_id() {
+        let ev = make_event(1, [0u8; 32], AuditResult::Success);
+        assert!(!verify_chain_link(&ev, None));
+    }
+
+    #[test]
+    fn chain_link_valid() {
+        let row0 = make_event(0, [0u8; 32], AuditResult::Success);
+        let row1 = make_event(1, row0.row_hash, AuditResult::Failure("403".to_owned()));
+        assert!(verify_chain_link(&row1, Some(&row0)));
+    }
+
+    #[test]
+    fn chain_link_broken() {
+        let row0 = make_event(0, [0u8; 32], AuditResult::Success);
+        let mut row1 = make_event(1, row0.row_hash, AuditResult::Success);
+        row1.prev_hash = [0u8; 32]; // break the link
+        assert!(!verify_chain_link(&row1, Some(&row0)));
+    }
+}

--- a/crate/access/src/audit/hash.rs
+++ b/crate/access/src/audit/hash.rs
@@ -25,7 +25,14 @@ use super::event::AuditEvent;
 /// || result canonical string (UTF-8, e.g. "Success" / "Failure:401 …")
 /// || NUL
 /// || duration_ms (8 bytes, big-endian u64)
+/// [optional, only when Some:]
+/// || NUL
+/// || request_id (hyphenated UUID, UTF-8)
 /// ```
+///
+/// The `request_id` segment is appended only when present so that events
+/// written before this field was introduced produce the same bytes as before,
+/// preserving hash-chain verification for existing logs.
 pub(crate) fn canonical_bytes(event: &AuditEvent) -> Vec<u8> {
     let mut buf = Vec::with_capacity(256);
 
@@ -59,6 +66,11 @@ pub(crate) fn canonical_bytes(event: &AuditEvent) -> Vec<u8> {
 
     buf.extend_from_slice(&event.duration_ms.to_be_bytes());
 
+    if let Some(rid) = &event.request_id {
+        buf.push(0x00);
+        buf.extend_from_slice(rid.hyphenated().to_string().as_bytes());
+    }
+
     buf
 }
 
@@ -87,11 +99,6 @@ pub fn verify_event(event: &AuditEvent) -> bool {
 ///
 /// Note: this function does **not** call [`verify_event`]; call that
 /// separately to check the row's own integrity.
-///
-/// TODO: log rotation — when verifying a rotated file that starts from id > 0
-/// the caller must supply the tail hash of the previous file (or the CLI should
-/// expose a `--prev-hash` flag) so the first link is not treated as a fresh
-/// chain start.
 #[must_use]
 pub fn verify_chain_link(current: &AuditEvent, prev: Option<&AuditEvent>) -> bool {
     prev.map_or_else(
@@ -119,6 +126,7 @@ mod tests {
             client_ip: Some("127.0.0.1".to_owned()),
             result,
             duration_ms: 10,
+            request_id: None,
             prev_hash,
             row_hash: [0u8; 32],
         };
@@ -180,5 +188,22 @@ mod tests {
         let mut row1 = make_event(1, row0.row_hash, AuditResult::Success);
         row1.prev_hash = [0u8; 32]; // break the link
         assert!(!verify_chain_link(&row1, Some(&row0)));
+    }
+
+    #[test]
+    fn canonical_bytes_includes_request_id() {
+        use uuid::Uuid;
+        let ev1 = make_event(0, [0u8; 32], AuditResult::Success);
+        let mut ev2 = ev1.clone();
+        ev2.request_id = Some(Uuid::new_v4());
+        assert_ne!(canonical_bytes(&ev1), canonical_bytes(&ev2));
+    }
+
+    #[test]
+    fn existing_event_without_request_id_still_verifies() {
+        // An event with request_id = None must verify — backward compatibility guarantee.
+        let ev = make_event(0, [0u8; 32], AuditResult::Success);
+        assert!(ev.request_id.is_none());
+        assert!(verify_event(&ev));
     }
 }

--- a/crate/access/src/audit/hash.rs
+++ b/crate/access/src/audit/hash.rs
@@ -1,7 +1,7 @@
 use sha2::{Digest, Sha256};
 use time::format_description::well_known::Rfc3339;
 
-use super::event::AuditEventFull;
+use super::event::AuditEvent;
 
 /// Builds the deterministic, NUL-delimited binary representation of `event`
 /// that is fed into the SHA-256 digest.
@@ -26,7 +26,7 @@ use super::event::AuditEventFull;
 /// || NUL
 /// || duration_ms (8 bytes, big-endian u64)
 /// ```
-pub(crate) fn canonical_bytes(event: &AuditEventFull) -> Vec<u8> {
+pub(crate) fn canonical_bytes(event: &AuditEvent) -> Vec<u8> {
     let mut buf = Vec::with_capacity(256);
 
     buf.extend_from_slice(&event.prev_hash);
@@ -65,7 +65,7 @@ pub(crate) fn canonical_bytes(event: &AuditEventFull) -> Vec<u8> {
 /// Computes the SHA-256 digest over the canonical byte form of `event`.
 /// The returned hash should be stored as `event.row_hash`.
 #[must_use]
-pub fn compute_row_hash(event: &AuditEventFull) -> [u8; 32] {
+pub fn compute_row_hash(event: &AuditEvent) -> [u8; 32] {
     let mut hasher = Sha256::new();
     hasher.update(canonical_bytes(event));
     hasher.finalize().into()
@@ -74,7 +74,7 @@ pub fn compute_row_hash(event: &AuditEventFull) -> [u8; 32] {
 /// Returns `true` when `event.row_hash` matches the SHA-256 of its own
 /// canonical bytes.
 #[must_use]
-pub fn verify_event(event: &AuditEventFull) -> bool {
+pub fn verify_event(event: &AuditEvent) -> bool {
     let expected = compute_row_hash(event);
     expected == event.row_hash
 }
@@ -93,7 +93,7 @@ pub fn verify_event(event: &AuditEventFull) -> bool {
 /// expose a `--prev-hash` flag) so the first link is not treated as a fresh
 /// chain start.
 #[must_use]
-pub fn verify_chain_link(current: &AuditEventFull, prev: Option<&AuditEventFull>) -> bool {
+pub fn verify_chain_link(current: &AuditEvent, prev: Option<&AuditEvent>) -> bool {
     prev.map_or_else(
         || current.id == 0 && current.prev_hash == [0_u8; 32],
         |p| current.prev_hash == p.row_hash,
@@ -105,11 +105,11 @@ pub fn verify_chain_link(current: &AuditEventFull, prev: Option<&AuditEventFull>
 mod tests {
     use time::OffsetDateTime;
 
-    use super::super::event::{AuditEventFull, AuditResult};
+    use super::super::event::{AuditEvent, AuditResult};
     use super::{canonical_bytes, compute_row_hash, verify_chain_link, verify_event};
 
-    fn make_event(id: i64, prev_hash: [u8; 32], result: AuditResult) -> AuditEventFull {
-        let mut ev = AuditEventFull {
+    fn make_event(id: i64, prev_hash: [u8; 32], result: AuditResult) -> AuditEvent {
+        let mut ev = AuditEvent {
             id,
             timestamp: OffsetDateTime::from_unix_timestamp(1_700_000_000).unwrap(),
             operation: "Encrypt".to_owned(),

--- a/crate/access/src/audit/hash.rs
+++ b/crate/access/src/audit/hash.rs
@@ -87,6 +87,11 @@ pub fn verify_event(event: &AuditEventFull) -> bool {
 ///
 /// Note: this function does **not** call [`verify_event`]; call that
 /// separately to check the row's own integrity.
+///
+/// TODO: log rotation — when verifying a rotated file that starts from id > 0
+/// the caller must supply the tail hash of the previous file (or the CLI should
+/// expose a `--prev-hash` flag) so the first link is not treated as a fresh
+/// chain start.
 #[must_use]
 pub fn verify_chain_link(current: &AuditEventFull, prev: Option<&AuditEventFull>) -> bool {
     prev.map_or_else(

--- a/crate/access/src/audit/mod.rs
+++ b/crate/access/src/audit/mod.rs
@@ -1,0 +1,7 @@
+mod cef;
+mod event;
+mod hash;
+
+pub use cef::to_cef_line;
+pub use event::{AuditEventDraft, AuditEventFull, AuditResult};
+pub use hash::{compute_row_hash, verify_chain_link, verify_event};

--- a/crate/access/src/audit/mod.rs
+++ b/crate/access/src/audit/mod.rs
@@ -3,5 +3,5 @@ mod event;
 mod hash;
 
 pub use cef::to_cef_line;
-pub use event::{AuditEventDraft, AuditEvent, AuditResult};
+pub use event::{AuditEvent, AuditEventDraft, AuditResult};
 pub use hash::{compute_row_hash, verify_chain_link, verify_event};

--- a/crate/access/src/audit/mod.rs
+++ b/crate/access/src/audit/mod.rs
@@ -3,5 +3,5 @@ mod event;
 mod hash;
 
 pub use cef::to_cef_line;
-pub use event::{AuditEventDraft, AuditEventFull, AuditResult};
+pub use event::{AuditEventDraft, AuditEvent, AuditResult};
 pub use hash::{compute_row_hash, verify_chain_link, verify_event};

--- a/crate/access/src/lib.rs
+++ b/crate/access/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod access;
+pub mod audit;

--- a/crate/clients/ckms/src/commands.rs
+++ b/crate/clients/ckms/src/commands.rs
@@ -169,6 +169,12 @@ pub async fn ckms_main() -> CosmianResult<()> {
     info!("Starting KMS CLI");
     let cli = Cli::parse();
 
+    // Short-circuit: audit commands read the file directly — no server connection
+    // or ckms.toml needed.
+    if let CliCommands::Kms(KmsActions::Audit(audit_action)) = &cli.command {
+        return audit_action.process().map_err(Into::into);
+    }
+
     let mut config = ClientConfig::load(cli.conf_path.clone())?;
 
     // Handle KMS configuration

--- a/crate/clients/clap/src/actions/audit.rs
+++ b/crate/clients/clap/src/actions/audit.rs
@@ -1,0 +1,263 @@
+//! `ckms audit` subcommands — work directly on the JSONL audit file, no KMS
+//! server connection required.
+//!
+//! These commands bypass the normal `ClientConfig::load()` bootstrap so they
+//! can be used offline (e.g. on an isolated audit workstation that has the
+//! audit file but no access to the KMS server).
+//!
+//! Subcommands
+//! ===========
+//! * `export` — reads the file and writes events to stdout (JSON or CEF v25)
+//! * `verify` — validates the SHA-256 hash chain; exits non-zero if broken
+
+use std::{
+    io::{BufRead, BufReader, Write as _},
+    path::PathBuf,
+};
+
+use clap::{Parser, Subcommand, ValueEnum};
+use cosmian_kms_client::reexport::cosmian_kms_access::audit::{
+    AuditEventFull, AuditResult, to_cef_line, verify_chain_link, verify_event,
+};
+
+use crate::error::result::KmsCliResult;
+
+// ── Top-level enum ────────────────────────────────────────────────────────────
+
+/// Commands for managing and inspecting the KMS audit log.
+///
+/// These commands read the audit file directly — no running KMS server is
+/// required.
+#[derive(Subcommand, Debug)]
+pub enum AuditCommands {
+    /// Export audit events to stdout (JSON lines or CEF v25 format).
+    Export(ExportAuditAction),
+    /// Verify the SHA-256 hash chain of the audit file.
+    Verify(VerifyAuditAction),
+}
+
+impl AuditCommands {
+    /// Dispatch to the matching subcommand.
+    ///
+    /// # Errors
+    /// Returns an error if the audit file cannot be read or if I/O fails.
+    pub fn process(&self) -> KmsCliResult<()> {
+        match self {
+            Self::Export(action) => action.run(),
+            Self::Verify(action) => action.run(),
+        }
+    }
+}
+
+// ── Export ────────────────────────────────────────────────────────────────────
+
+/// Output format for `ckms audit export`.
+#[derive(Debug, Clone, Copy, ValueEnum, Default)]
+pub enum ExportFormat {
+    /// Output each event as a JSON object (default — same as the stored format).
+    #[default]
+    Json,
+    /// Output each event as a CEF v25 syslog line.
+    Cef,
+}
+
+/// Export audit events from the JSONL log file to stdout.
+///
+/// Each event is printed on its own line.  Use `--since` to filter by time and
+/// `--format` to choose between JSON (default) and CEF v25 output.
+///
+/// # Examples
+///
+/// ```sh
+/// # Print all events as JSON
+/// ckms audit export --path /data/kms/audit.jsonl
+///
+/// # Print events since 2024-01-01 in CEF format
+/// ckms audit export --path /data/kms/audit.jsonl \
+///     --since 2024-01-01T00:00:00Z --format cef
+/// ```
+#[derive(Parser, Debug)]
+#[clap(verbatim_doc_comment)]
+pub struct ExportAuditAction {
+    /// Path to the JSONL audit log file.
+    #[clap(long, short = 'p', env = "KMS_AUDIT_FILE_PATH")]
+    pub path: PathBuf,
+
+    /// Only export events at or after this RFC 3339 timestamp
+    /// (e.g. `2024-01-15T00:00:00Z`).
+    #[clap(long, env = "KMS_AUDIT_SINCE")]
+    pub since: Option<String>,
+
+    /// Output format: `json` (default) or `cef`.
+    #[clap(long, env = "KMS_AUDIT_FORMAT", default_value = "json")]
+    pub format: ExportFormat,
+
+    /// KMS version string to embed in CEF headers (e.g. "5.0.0").
+    /// Defaults to the current binary version.
+    #[clap(long, default_value = env!("CARGO_PKG_VERSION"))]
+    pub kms_version: String,
+}
+
+impl ExportAuditAction {
+    /// Run the export.
+    ///
+    /// # Errors
+    /// Returns an error if the file cannot be opened or read.
+    pub fn run(&self) -> KmsCliResult<()> {
+        let since = self
+            .since
+            .as_deref()
+            .map(|s| {
+                time::OffsetDateTime::parse(s, &time::format_description::well_known::Rfc3339)
+                    .map_err(|e| {
+                        crate::error::KmsCliError::InvalidRequest(format!(
+                            "--since must be an RFC 3339 timestamp: {e}"
+                        ))
+                    })
+            })
+            .transpose()?;
+
+        let file =
+            std::fs::File::open(&self.path).map_err(crate::error::KmsCliError::IoError)?;
+
+        let reader = BufReader::new(file);
+        let stdout = std::io::stdout();
+        let mut out = stdout.lock();
+
+        for (line_no, line) in reader.lines().enumerate() {
+            let line = line.map_err(crate::error::KmsCliError::IoError)?;
+            if line.trim().is_empty() {
+                continue;
+            }
+
+            let event: AuditEventFull = serde_json::from_str(&line).map_err(|e| {
+                crate::error::KmsCliError::InvalidRequest(format!(
+                    "line {}: malformed audit event: {e}",
+                    line_no + 1
+                ))
+            })?;
+
+            // Apply --since filter
+            if let Some(ts) = since {
+                if event.timestamp < ts {
+                    continue;
+                }
+            }
+
+            let output_line = match self.format {
+                ExportFormat::Json => line,
+                ExportFormat::Cef => to_cef_line(&event, &self.kms_version),
+            };
+
+            writeln!(out, "{output_line}").map_err(crate::error::KmsCliError::IoError)?;
+        }
+
+        Ok(())
+    }
+}
+
+// ── Verify ────────────────────────────────────────────────────────────────────
+
+/// Verify the SHA-256 hash chain of the audit log file.
+///
+/// Checks that:
+/// 1. Each event's `row_hash` matches a freshly computed hash of its fields.
+/// 2. Each event's `prev_hash` matches the `row_hash` of the previous event
+///    (or is all-zeros for the first event).
+///
+/// Exits with code **0** when the chain is intact, or **1** when a broken
+/// link is detected (the ID of the first failing event is printed).
+///
+/// # Example
+///
+/// ```sh
+/// ckms audit verify --path /data/kms/audit.jsonl
+/// ```
+#[derive(Parser, Debug)]
+#[clap(verbatim_doc_comment)]
+pub struct VerifyAuditAction {
+    /// Path to the JSONL audit log file.
+    #[clap(long, short = 'p', env = "KMS_AUDIT_FILE_PATH")]
+    pub path: PathBuf,
+
+    /// Print a summary line for every event even when the chain is valid.
+    #[clap(long, default_value = "false")]
+    pub verbose: bool,
+}
+
+impl VerifyAuditAction {
+    /// Run the verification.
+    ///
+    /// # Errors
+    /// Returns an error if the file cannot be opened or read, or if a broken
+    /// hash-chain link is detected (exit code 1).
+    pub fn run(&self) -> KmsCliResult<()> {
+        let file =
+            std::fs::File::open(&self.path).map_err(crate::error::KmsCliError::IoError)?;
+
+        let reader = BufReader::new(file);
+        let mut prev: Option<AuditEventFull> = None;
+        let mut total: u64 = 0;
+
+        for (line_no, line) in reader.lines().enumerate() {
+            let line = line.map_err(crate::error::KmsCliError::IoError)?;
+            if line.trim().is_empty() {
+                continue;
+            }
+
+            let event: AuditEventFull = serde_json::from_str(&line).map_err(|e| {
+                crate::error::KmsCliError::InvalidRequest(format!(
+                    "line {}: malformed audit event: {e}",
+                    line_no + 1
+                ))
+            })?;
+
+            // 1. Verify the row's own hash
+            if !verify_event(&event) {
+                return Err(crate::error::KmsCliError::InvalidRequest(format!(
+                    "TAMPERED: event id={} (line {}) has an invalid row_hash",
+                    event.id,
+                    line_no + 1
+                )));
+            }
+
+            // 2. Verify the chain link from the previous event
+            if !verify_chain_link(&event, prev.as_ref()) {
+                return Err(crate::error::KmsCliError::InvalidRequest(format!(
+                    "CHAIN BROKEN: event id={} (line {}) prev_hash does not match \
+                     the row_hash of event id={}",
+                    event.id,
+                    line_no + 1,
+                    prev.as_ref().map_or(-1, |p| p.id)
+                )));
+            }
+
+            if self.verbose {
+                let status = match &event.result {
+                    AuditResult::Success => "ok",
+                    AuditResult::Failure(_) => "fail",
+                };
+                eprintln!(
+                    "id={:>6}  {}  {}  {}  chain=ok",
+                    event.id,
+                    event
+                        .timestamp
+                        .format(&time::format_description::well_known::Rfc3339)
+                        .unwrap_or_default(),
+                    event.operation,
+                    status
+                );
+            }
+
+            total += 1;
+            prev = Some(event);
+        }
+
+        writeln!(
+            std::io::stdout().lock(),
+            "Audit chain OK: {total} event{} verified",
+            if total == 1 { "" } else { "s" }
+        )
+        .map_err(crate::error::KmsCliError::IoError)
+    }
+}

--- a/crate/clients/clap/src/actions/audit.rs
+++ b/crate/clients/clap/src/actions/audit.rs
@@ -22,7 +22,6 @@ use cosmian_kms_client::reexport::cosmian_kms_access::audit::{
 
 use crate::error::result::KmsCliResult;
 
-// ── Top-level enum ────────────────────────────────────────────────────────────
 
 /// Commands for managing and inspecting the KMS audit log.
 ///
@@ -49,7 +48,6 @@ impl AuditCommands {
     }
 }
 
-// ── Export ────────────────────────────────────────────────────────────────────
 
 /// Output format for `ckms audit export`.
 #[derive(Debug, Clone, Copy, ValueEnum, Default)]
@@ -117,8 +115,7 @@ impl ExportAuditAction {
             })
             .transpose()?;
 
-        let file =
-            std::fs::File::open(&self.path).map_err(crate::error::KmsCliError::IoError)?;
+        let file = std::fs::File::open(&self.path).map_err(crate::error::KmsCliError::IoError)?;
 
         let reader = BufReader::new(file);
         let stdout = std::io::stdout();
@@ -156,7 +153,6 @@ impl ExportAuditAction {
     }
 }
 
-// ── Verify ────────────────────────────────────────────────────────────────────
 
 /// Verify the SHA-256 hash chain of the audit log file.
 ///
@@ -183,6 +179,9 @@ pub struct VerifyAuditAction {
     /// Print a summary line for every event even when the chain is valid.
     #[clap(long, default_value = "false")]
     pub verbose: bool,
+    // TODO: add a `--prev-hash` option (hex string) so that rotated files
+    //       can be verified by supplying the row_hash of the last event in
+    //       the preceding file segment.
 }
 
 impl VerifyAuditAction {
@@ -192,8 +191,7 @@ impl VerifyAuditAction {
     /// Returns an error if the file cannot be opened or read, or if a broken
     /// hash-chain link is detected (exit code 1).
     pub fn run(&self) -> KmsCliResult<()> {
-        let file =
-            std::fs::File::open(&self.path).map_err(crate::error::KmsCliError::IoError)?;
+        let file = std::fs::File::open(&self.path).map_err(crate::error::KmsCliError::IoError)?;
 
         let reader = BufReader::new(file);
         let mut prev: Option<AuditEventFull> = None;

--- a/crate/clients/clap/src/actions/audit.rs
+++ b/crate/clients/clap/src/actions/audit.rs
@@ -11,17 +11,16 @@
 //! * `verify` — validates the SHA-256 hash chain; exits non-zero if broken
 
 use std::{
-    io::{BufRead, BufReader, Write as _},
+    io::{BufRead, BufReader, Write},
     path::PathBuf,
 };
 
 use clap::{Parser, Subcommand, ValueEnum};
 use cosmian_kms_client::reexport::cosmian_kms_access::audit::{
-    AuditEventFull, AuditResult, to_cef_line, verify_chain_link, verify_event,
+    AuditEvent, AuditResult, to_cef_line, verify_chain_link, verify_event,
 };
 
 use crate::error::result::KmsCliResult;
-
 
 /// Commands for managing and inspecting the KMS audit log.
 ///
@@ -47,7 +46,6 @@ impl AuditCommands {
         }
     }
 }
-
 
 /// Output format for `ckms audit export`.
 #[derive(Debug, Clone, Copy, ValueEnum, Default)]
@@ -97,11 +95,22 @@ pub struct ExportAuditAction {
 }
 
 impl ExportAuditAction {
-    /// Run the export.
+    /// Run the export, writing output to `stdout`.
     ///
     /// # Errors
     /// Returns an error if the file cannot be opened or read.
     pub fn run(&self) -> KmsCliResult<()> {
+        self.run_with_writer(&mut std::io::stdout().lock())
+    }
+
+    /// Run the export, writing output to the provided writer.
+    ///
+    /// For stdout call `run_with_writer(&mut std::io::stdout().lock())`.
+    /// For tests pass `&mut Vec::new()` and inspect the captured bytes.
+    ///
+    /// # Errors
+    /// Returns an error if the file cannot be opened, read, or a line cannot be parsed.
+    pub(crate) fn run_with_writer<W: Write>(&self, out: &mut W) -> KmsCliResult<()> {
         let since = self
             .since
             .as_deref()
@@ -116,10 +125,7 @@ impl ExportAuditAction {
             .transpose()?;
 
         let file = std::fs::File::open(&self.path).map_err(crate::error::KmsCliError::IoError)?;
-
         let reader = BufReader::new(file);
-        let stdout = std::io::stdout();
-        let mut out = stdout.lock();
 
         for (line_no, line) in reader.lines().enumerate() {
             let line = line.map_err(crate::error::KmsCliError::IoError)?;
@@ -127,14 +133,13 @@ impl ExportAuditAction {
                 continue;
             }
 
-            let event: AuditEventFull = serde_json::from_str(&line).map_err(|e| {
+            let event: AuditEvent = serde_json::from_str(&line).map_err(|e| {
                 crate::error::KmsCliError::InvalidRequest(format!(
                     "line {}: malformed audit event: {e}",
                     line_no + 1
                 ))
             })?;
 
-            // Apply --since filter
             if let Some(ts) = since {
                 if event.timestamp < ts {
                     continue;
@@ -152,7 +157,6 @@ impl ExportAuditAction {
         Ok(())
     }
 }
-
 
 /// Verify the SHA-256 hash chain of the audit log file.
 ///
@@ -185,16 +189,28 @@ pub struct VerifyAuditAction {
 }
 
 impl VerifyAuditAction {
-    /// Run the verification.
+    /// Run the verification, printing the summary to `stdout`.
     ///
     /// # Errors
     /// Returns an error if the file cannot be opened or read, or if a broken
     /// hash-chain link is detected (exit code 1).
     pub fn run(&self) -> KmsCliResult<()> {
+        self.run_with_writer(&mut std::io::stdout().lock())
+    }
+
+    /// Run the verification, writing the summary line to the provided writer.
+    ///
+    /// Returns `Err` containing the human-readable diagnosis on the first broken
+    /// link ("TAMPERED: …" or "CHAIN BROKEN: …"), allowing callers to assert on
+    /// the exact error message format.
+    ///
+    /// # Errors
+    /// Returns an error if the file cannot be opened, read, or the chain is broken.
+    pub(crate) fn run_with_writer<W: Write>(&self, out: &mut W) -> KmsCliResult<()> {
         let file = std::fs::File::open(&self.path).map_err(crate::error::KmsCliError::IoError)?;
 
         let reader = BufReader::new(file);
-        let mut prev: Option<AuditEventFull> = None;
+        let mut prev: Option<AuditEvent> = None;
         let mut total: u64 = 0;
 
         for (line_no, line) in reader.lines().enumerate() {
@@ -203,14 +219,13 @@ impl VerifyAuditAction {
                 continue;
             }
 
-            let event: AuditEventFull = serde_json::from_str(&line).map_err(|e| {
+            let event: AuditEvent = serde_json::from_str(&line).map_err(|e| {
                 crate::error::KmsCliError::InvalidRequest(format!(
                     "line {}: malformed audit event: {e}",
                     line_no + 1
                 ))
             })?;
 
-            // 1. Verify the row's own hash
             if !verify_event(&event) {
                 return Err(crate::error::KmsCliError::InvalidRequest(format!(
                     "TAMPERED: event id={} (line {}) has an invalid row_hash",
@@ -219,7 +234,6 @@ impl VerifyAuditAction {
                 )));
             }
 
-            // 2. Verify the chain link from the previous event
             if !verify_chain_link(&event, prev.as_ref()) {
                 return Err(crate::error::KmsCliError::InvalidRequest(format!(
                     "CHAIN BROKEN: event id={} (line {}) prev_hash does not match \
@@ -252,10 +266,237 @@ impl VerifyAuditAction {
         }
 
         writeln!(
-            std::io::stdout().lock(),
+            out,
             "Audit chain OK: {total} event{} verified",
             if total == 1 { "" } else { "s" }
         )
         .map_err(crate::error::KmsCliError::IoError)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use std::{io::Write as _, path::PathBuf};
+
+    use cosmian_kms_client::reexport::cosmian_kms_access::audit::{
+        AuditEvent, AuditResult, compute_row_hash,
+    };
+    use time::OffsetDateTime;
+
+    use super::{ExportAuditAction, ExportFormat, VerifyAuditAction};
+
+    fn temp_path(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "kms_cli_audit_test_{}_{label}.jsonl",
+            std::process::id()
+        ))
+    }
+
+    /// Build a valid N-event hash chain, writing to `path` and returning the events.
+    fn make_chain(n: u64, path: &PathBuf) -> Vec<AuditEvent> {
+        let mut events: Vec<AuditEvent> = Vec::new();
+        let mut file = std::fs::File::create(path).unwrap();
+
+        for i in 0..n {
+            let prev_hash = events.last().map_or([0u8; 32], |e: &AuditEvent| e.row_hash);
+            let mut event = AuditEvent {
+                id: i as i64,
+                timestamp: OffsetDateTime::now_utc(),
+                operation: format!("Op{i}"),
+                user: "test-user".to_owned(),
+                object_uid: Some(format!("uid-{i}")),
+                algorithm: Some("AES-256-GCM".to_owned()),
+                client_ip: Some("127.0.0.1".to_owned()),
+                result: AuditResult::Success,
+                duration_ms: 1,
+                prev_hash,
+                row_hash: [0u8; 32],
+            };
+            event.row_hash = compute_row_hash(&event);
+            writeln!(file, "{}", serde_json::to_string(&event).unwrap()).unwrap();
+            events.push(event);
+        }
+        events
+    }
+
+    fn verify_action(path: PathBuf) -> VerifyAuditAction {
+        VerifyAuditAction {
+            path,
+            verbose: false,
+        }
+    }
+
+    fn export_action(path: PathBuf, format: ExportFormat) -> ExportAuditAction {
+        ExportAuditAction {
+            path,
+            since: None,
+            format,
+            kms_version: "test".to_owned(),
+        }
+    }
+
+    // ── VerifyAuditAction ──────────────────────────────────────────────────────
+
+    #[test]
+    fn verify_ok_reports_n_events_verified() {
+        let path = temp_path("verify_ok");
+        make_chain(3, &path);
+        let mut out = Vec::new();
+        verify_action(path).run_with_writer(&mut out).unwrap();
+        let msg = String::from_utf8(out).unwrap();
+        assert!(msg.contains("Audit chain OK: 3 events verified"), "{msg}");
+    }
+
+    #[test]
+    fn verify_empty_file_is_ok() {
+        let path = temp_path("verify_empty");
+        std::fs::File::create(&path).unwrap();
+        let mut out = Vec::new();
+        verify_action(path).run_with_writer(&mut out).unwrap();
+        let msg = String::from_utf8(out).unwrap();
+        assert!(msg.contains("Audit chain OK: 0 events verified"), "{msg}");
+    }
+
+    #[test]
+    fn verify_detects_tampered_row_hash() {
+        let path = temp_path("verify_tampered");
+        let mut events = make_chain(3, &path);
+
+        // Corrupt event id=1
+        events[1].row_hash[0] ^= 0xff;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(&path)
+            .unwrap();
+        for ev in &events {
+            writeln!(file, "{}", serde_json::to_string(ev).unwrap()).unwrap();
+        }
+
+        let err = verify_action(path)
+            .run_with_writer(&mut Vec::new())
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("TAMPERED") && msg.contains("event id=1"),
+            "{msg}"
+        );
+    }
+
+    #[test]
+    fn verify_detects_broken_chain_link() {
+        let path = temp_path("verify_chain");
+        let mut events = make_chain(3, &path);
+
+        // Break the link: corrupt prev_hash of event id=2 (chain link from id=1)
+        events[2].prev_hash[0] ^= 0xff;
+        // Recompute row_hash so the TAMPERED check passes; only chain check fails
+        events[2].row_hash = compute_row_hash(&events[2]);
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(&path)
+            .unwrap();
+        for ev in &events {
+            writeln!(file, "{}", serde_json::to_string(ev).unwrap()).unwrap();
+        }
+
+        let err = verify_action(path)
+            .run_with_writer(&mut Vec::new())
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("CHAIN BROKEN") && msg.contains("event id=2"),
+            "{msg}"
+        );
+    }
+
+    // ── ExportAuditAction ──────────────────────────────────────────────────────
+
+    #[test]
+    fn export_json_outputs_parseable_lines() {
+        let path = temp_path("export_json");
+        make_chain(3, &path);
+        let mut out = Vec::new();
+        export_action(path, ExportFormat::Json)
+            .run_with_writer(&mut out)
+            .unwrap();
+        let text = String::from_utf8(out).unwrap();
+        let lines: Vec<&str> = text.lines().collect();
+        assert_eq!(lines.len(), 3);
+        for line in &lines {
+            drop(serde_json::from_str::<AuditEvent>(line).unwrap());
+        }
+    }
+
+    #[test]
+    fn export_cef_lines_have_cef_prefix() {
+        let path = temp_path("export_cef");
+        make_chain(3, &path);
+        let mut out = Vec::new();
+        export_action(path, ExportFormat::Cef)
+            .run_with_writer(&mut out)
+            .unwrap();
+        let text = String::from_utf8(out).unwrap();
+        for line in text.lines() {
+            assert!(line.starts_with("CEF:0|"), "{line}");
+        }
+    }
+
+    #[test]
+    fn export_since_filter_drops_earlier_events() {
+        let path = temp_path("export_since");
+        // Build chain with a known timestamp split
+        let before = OffsetDateTime::now_utc();
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let cutoff = OffsetDateTime::now_utc();
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let after = OffsetDateTime::now_utc();
+
+        // Write 3 events: one before, one at cutoff, one after
+        let mut file = std::fs::File::create(&path).unwrap();
+        let timestamps = [before, cutoff, after];
+        let mut prev_hash = [0u8; 32];
+        for (i, ts) in timestamps.iter().enumerate() {
+            let mut ev = AuditEvent {
+                id: i as i64,
+                timestamp: *ts,
+                operation: "Encrypt".to_owned(),
+                user: "u".to_owned(),
+                object_uid: None,
+                algorithm: None,
+                client_ip: None,
+                result: AuditResult::Success,
+                duration_ms: 1,
+                prev_hash,
+                row_hash: [0u8; 32],
+            };
+            ev.row_hash = compute_row_hash(&ev);
+            prev_hash = ev.row_hash;
+            writeln!(file, "{}", serde_json::to_string(&ev).unwrap()).unwrap();
+        }
+
+        let since_str = cutoff
+            .format(&time::format_description::well_known::Rfc3339)
+            .unwrap();
+        let action = ExportAuditAction {
+            path,
+            since: Some(since_str),
+            format: ExportFormat::Json,
+            kms_version: "test".to_owned(),
+        };
+        let mut out = Vec::new();
+        action.run_with_writer(&mut out).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        let lines: Vec<&str> = text.lines().collect();
+        // Events at cutoff and after should appear; event before cutoff should be dropped
+        assert_eq!(
+            lines.len(),
+            2,
+            "expected 2 lines (cutoff + after), got:\n{text}"
+        );
+        let ev0: AuditEvent = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(ev0.id, 1, "first kept event should have id=1 (cutoff)");
     }
 }

--- a/crate/clients/clap/src/actions/audit.rs
+++ b/crate/clients/clap/src/actions/audit.rs
@@ -275,7 +275,7 @@ impl VerifyAuditAction {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
 mod tests {
     use std::{io::Write as _, path::PathBuf};
 
@@ -299,9 +299,11 @@ mod tests {
         let mut file = std::fs::File::create(path).unwrap();
 
         for i in 0..n {
-            let prev_hash = events.last().map_or([0u8; 32], |e: &AuditEvent| e.row_hash);
+            let prev_hash = events
+                .last()
+                .map_or([0_u8; 32], |e: &AuditEvent| e.row_hash);
             let mut event = AuditEvent {
-                id: i as i64,
+                id: i64::try_from(i).unwrap(),
                 timestamp: OffsetDateTime::now_utc(),
                 operation: format!("Op{i}"),
                 user: "test-user".to_owned(),
@@ -310,8 +312,9 @@ mod tests {
                 client_ip: Some("127.0.0.1".to_owned()),
                 result: AuditResult::Success,
                 duration_ms: 1,
+                request_id: None,
                 prev_hash,
-                row_hash: [0u8; 32],
+                row_hash: [0_u8; 32],
             };
             event.row_hash = compute_row_hash(&event);
             writeln!(file, "{}", serde_json::to_string(&event).unwrap()).unwrap();
@@ -457,10 +460,10 @@ mod tests {
         // Write 3 events: one before, one at cutoff, one after
         let mut file = std::fs::File::create(&path).unwrap();
         let timestamps = [before, cutoff, after];
-        let mut prev_hash = [0u8; 32];
+        let mut prev_hash = [0_u8; 32];
         for (i, ts) in timestamps.iter().enumerate() {
             let mut ev = AuditEvent {
-                id: i as i64,
+                id: i64::try_from(i).unwrap(),
                 timestamp: *ts,
                 operation: "Encrypt".to_owned(),
                 user: "u".to_owned(),
@@ -469,8 +472,9 @@ mod tests {
                 client_ip: None,
                 result: AuditResult::Success,
                 duration_ms: 1,
+                request_id: None,
                 prev_hash,
-                row_hash: [0u8; 32],
+                row_hash: [0_u8; 32],
             };
             ev.row_hash = compute_row_hash(&ev);
             prev_hash = ev.row_hash;

--- a/crate/clients/clap/src/actions/kms_actions.rs
+++ b/crate/clients/clap/src/actions/kms_actions.rs
@@ -17,6 +17,7 @@ use crate::{
     actions::{
         access::AccessAction,
         attributes::AttributesCommands,
+        audit::AuditCommands,
         aws::AwsCommands,
         azure::AzureCommands,
         bench::BenchAction,
@@ -88,6 +89,9 @@ pub enum ServerCommands {
 
 #[derive(Subcommand)]
 pub enum KmsActions {
+    #[command(subcommand)]
+    /// Inspect and verify the tamper-evident KMS audit log.
+    Audit(AuditCommands),
     #[command(subcommand)]
     AccessRights(AccessAction),
     #[command(subcommand)]
@@ -161,6 +165,9 @@ impl KmsActions {
         let mut new_config = kms_rest_client.config.clone();
 
         match self {
+            Self::Audit(action) => {
+                action.process()?;
+            }
             Self::AccessRights(action) => Box::pin(action.process(kms_rest_client)).await?,
             Self::Attributes(action) => Box::pin(action.process(kms_rest_client)).await?,
             Self::Aws(action) => Box::pin(action.process(kms_rest_client)).await?,

--- a/crate/clients/clap/src/actions/mod.rs
+++ b/crate/clients/clap/src/actions/mod.rs
@@ -1,5 +1,6 @@
 pub mod access;
 pub mod attributes;
+pub mod audit;
 pub mod aws;
 pub mod azure;
 pub mod bench;

--- a/crate/clients/client_utils/Cargo.toml
+++ b/crate/clients/client_utils/Cargo.toml
@@ -14,7 +14,7 @@ description = "Cosmian KMS Client Utilities - used in WASM and KMS Client"
 workspace = true
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["rlib"] # cdylib causes collisions while not needed
 # doc test linking as a separate binary is extremely slow
 # and is not needed for internal lib
 doctest = false

--- a/crate/kmip/src/ttlv/kmip_ttlv_deserializer/deserializer.rs
+++ b/crate/kmip/src/ttlv/kmip_ttlv_deserializer/deserializer.rs
@@ -125,6 +125,15 @@ impl TtlvDeserializer {
 impl<'de> de::Deserializer<'de> for &mut TtlvDeserializer {
     type Error = TtlvError;
 
+    // TTLV is a binary, non-human-readable format.
+    // Returning false ensures that types like `time::OffsetDateTime` use their
+    // binary serde path (`deserialize_tuple`) rather than the human-readable
+    // path (`deserialize_any` → `visit_i64`), regardless of which `time`
+    // features are enabled workspace-wide.
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+
     // Look at the input data to decide what Serde data model type to
     // deserialize as. Not all data formats are able to support this operation.
     // Formats that support `deserialize_any` are known as self-describing.
@@ -789,22 +798,17 @@ impl<'de> de::Deserializer<'de> for &mut TtlvDeserializer {
             "deserialize_tuple: child index: {}, current :  {:?}",
             self.child_index, self.current
         );
-        // The only reason this is called is to deserialize BigInt
         match &self.fetch_element()?.value {
-            // if the TTLV value is a BigInt, the deserializer is attempting to deserialize the value
-            // by converting the BigInt to u32
+            // BigInt: represent as a sequence of (sign, magnitude) u32 chunks
             TTLValue::BigInteger(bi) => {
                 let seq_access = KmipBigIntDeserializer::instantiate(bi)?;
                 visitor.visit_seq(seq_access)
             }
+            // DateTime: `OffsetDateTime::deserialize` calls `deserialize_tuple(9, …)`
+            // because `is_human_readable()` returns `false` on this deserializer.
+            // The visitor expects `visit_seq` with the 9 components in order:
+            // (year, ordinal, hour, minute, second, nanosecond, offset_h, offset_m, offset_s).
             TTLValue::DateTime(dt) => {
-                // if human_readable is not on the deserializer and the `time` crate (feature serde-human-readable),
-                // `deserialize_tuple` will be called on the deserializer
-                // see <https://github.com/time-rs/time/blob/main/time/src/serde/mod.rs#L320>
-                // The `OffsetDateTime` visitor expects calls to `visit_seq` passing all the elements
-                // og the tuple in order (year, day of year, hour, etc..)
-                // see <https://github.com/time-rs/time/blob/main/time/src/serde/visitor.rs#L80>
-
                 let seq_access = OffsetDateTimeDeserializer::new(&self.current.tag, *dt);
                 visitor.visit_seq(seq_access)
             }

--- a/crate/kmip/src/ttlv/kmip_ttlv_serializer.rs
+++ b/crate/kmip/src/ttlv/kmip_ttlv_serializer.rs
@@ -31,9 +31,10 @@ impl<T> Stack<T>
 where
     T: Debug,
 {
-    pub(crate) const fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
-            elements: Vec::new(),
+            // Pre-allocate for typical KMIP message nesting depth (avoids reallocations)
+            elements: Vec::with_capacity(8),
         }
     }
 
@@ -67,7 +68,7 @@ pub struct TtlvSerializer {
 
 impl TtlvSerializer {
     #[must_use]
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             stack: Stack::new(),
             byte_accumulator: None,

--- a/crate/kmip/src/ttlv/kmip_ttlv_serializer.rs
+++ b/crate/kmip/src/ttlv/kmip_ttlv_serializer.rs
@@ -31,10 +31,9 @@ impl<T> Stack<T>
 where
     T: Debug,
 {
-    pub(crate) fn new() -> Self {
+    pub(crate) const fn new() -> Self {
         Self {
-            // Pre-allocate for typical KMIP message nesting depth (avoids reallocations)
-            elements: Vec::with_capacity(8),
+            elements: Vec::new(),
         }
     }
 
@@ -68,7 +67,7 @@ pub struct TtlvSerializer {
 
 impl TtlvSerializer {
     #[must_use]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             stack: Stack::new(),
             byte_accumulator: None,
@@ -146,6 +145,11 @@ impl<'a> ser::Serializer for &'a mut TtlvSerializer {
     type SerializeTuple = &'a mut TtlvSerializer;
     type SerializeTupleStruct = &'a mut TtlvSerializer;
     type SerializeTupleVariant = &'a mut TtlvSerializer;
+
+    // TTLV is a binary, non-human-readable format.
+    fn is_human_readable(&self) -> bool {
+        false
+    }
 
     #[instrument(level = "trace", skip(self))]
     fn serialize_bool(self, v: bool) -> Result<Self::Ok> {
@@ -528,11 +532,6 @@ impl<'a> ser::Serializer for &'a mut TtlvSerializer {
             &self.current_tag()
         );
         self.serialize_struct(name, len)
-    }
-
-    #[inline]
-    fn is_human_readable(&self) -> bool {
-        true
     }
 }
 

--- a/crate/server/Cargo.toml
+++ b/crate/server/Cargo.toml
@@ -82,6 +82,7 @@ futures = { workspace = true }
 governor = { version = "0.10", features = ["std"] }
 hex = { workspace = true, features = ["serde"] }
 http = { workspace = true }
+ipnet = { version = "2", features = ["serde"] }
 jsonwebtoken = { workspace = true }
 num-bigint-dig = { workspace = true, features = [
   "std",

--- a/crate/server/src/config/command_line/audit_config.rs
+++ b/crate/server/src/config/command_line/audit_config.rs
@@ -1,0 +1,42 @@
+use std::path::PathBuf;
+
+use clap::Args;
+use serde::{Deserialize, Serialize};
+
+/// Configuration for the file-based audit log sub-section.
+#[derive(Debug, Default, Args, Deserialize, Serialize, Clone)]
+#[serde(default)]
+pub struct AuditFileConfig {
+    /// Path to the JSONL audit log file.
+    ///
+    /// When `--audit-enable` is set and this option is omitted, the file
+    /// defaults to `<root-data-path>/audit.jsonl`.
+    #[clap(long, env = "KMS_AUDIT_FILE_PATH", verbatim_doc_comment)]
+    pub audit_file_path: Option<PathBuf>,
+}
+
+/// Configuration for the structured audit event pipeline.
+///
+/// Audit logging is **disabled by default**.  Enable it with `--audit-enable`
+/// or by setting the environment variable `KMS_AUDIT_ENABLE=true`.
+///
+/// When enabled, every KMIP operation (including authentication failures) is
+/// appended as a tamper-evident JSON line to the audit file, and each entry
+/// carries a SHA-256 hash chain so the log can be verified offline with
+/// `ckms audit verify --path <file>`.
+///
+/// Compliance: PCI-DSS Req. 10, HIPAA §164.312(b), NIST SP 800-66r2.
+#[derive(Debug, Default, Args, Deserialize, Serialize, Clone)]
+#[serde(default)]
+pub struct AuditConfig {
+    /// Enable the structured audit event pipeline.
+    ///
+    /// When disabled (the default) no audit file is created and no background
+    /// writer task is spawned.  The value can also be toggled at config-file
+    /// level (`[audit] enable = true`).
+    #[clap(long, env = "KMS_AUDIT_ENABLE", default_value = "false")]
+    pub audit_enable: bool,
+
+    #[clap(flatten)]
+    pub file: AuditFileConfig,
+}

--- a/crate/server/src/config/command_line/audit_config.rs
+++ b/crate/server/src/config/command_line/audit_config.rs
@@ -3,6 +3,13 @@ use std::path::PathBuf;
 use clap::Args;
 use serde::{Deserialize, Serialize};
 
+/// Default capacity of the bounded in-memory channel between request threads and
+/// the audit writer task.
+///
+/// 4 096 events × ~500 B/event ≈ 2 MiB peak.  This absorbs ~4 seconds of
+/// sustained load at 1 000 req/s on `NVMe` storage (one `fsync` ≈ 1 ms).
+pub(crate) const DEFAULT_AUDIT_CHANNEL_CAPACITY: usize = 4_096;
+
 /// Configuration for the file-based audit log sub-section.
 #[derive(Debug, Default, Args, Deserialize, Serialize, Clone)]
 #[serde(default)]
@@ -11,7 +18,11 @@ pub struct AuditFileConfig {
     ///
     /// When `--audit-enable` is set and this option is omitted, the file
     /// defaults to `<root-data-path>/audit.jsonl`.
-    #[clap(long = "audit-file-path", env = "KMS_AUDIT_FILE_PATH", verbatim_doc_comment)]
+    #[clap(
+        long = "audit-file-path",
+        env = "KMS_AUDIT_FILE_PATH",
+        verbatim_doc_comment
+    )]
     #[serde(rename = "path")]
     pub audit_file_path: Option<PathBuf>,
 }
@@ -35,11 +46,38 @@ pub struct AuditConfig {
     /// When disabled (the default) no audit file is created and no background
     /// writer task is spawned.  The value can also be toggled at config-file
     /// level (`[audit] enable = true`).
-    #[clap(long = "audit-enable", env = "KMS_AUDIT_ENABLE", default_value = "false")]
+    #[clap(
+        long = "audit-enable",
+        env = "KMS_AUDIT_ENABLE",
+        default_value = "false"
+    )]
     #[serde(rename = "enabled")]
     pub audit_enable: bool,
 
     #[clap(flatten)]
     #[serde(rename = "file")]
     pub file: AuditFileConfig,
+
+    /// Capacity of the bounded in-memory channel between request threads and the
+    /// audit writer task.
+    ///
+    /// When the channel is full, incoming events are dropped (non-blocking) and
+    /// an `error!` is logged.  Each event is ≈500 B, so the default (4 096 × 500 B
+    /// ≈ 2 MiB) absorbs short bursts without blocking request threads.
+    ///
+    /// Must be ≥ 1.  Raise this value if you see `"AuditFileStore: channel full"`
+    /// in the server log under sustained high load.
+    #[clap(
+        long = "audit-channel-capacity",
+        env = "KMS_AUDIT_CHANNEL_CAPACITY",
+        default_value_t = DEFAULT_AUDIT_CHANNEL_CAPACITY,
+        verbatim_doc_comment
+    )]
+    #[serde(rename = "channel_capacity", default = "default_channel_capacity")]
+    pub audit_channel_capacity: usize,
+}
+
+/// Serde default helper for `AuditConfig::audit_channel_capacity`.
+const fn default_channel_capacity() -> usize {
+    DEFAULT_AUDIT_CHANNEL_CAPACITY
 }

--- a/crate/server/src/config/command_line/audit_config.rs
+++ b/crate/server/src/config/command_line/audit_config.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use clap::Args;
+use ipnet::IpNet;
 use serde::{Deserialize, Serialize};
 
 /// Default capacity of the bounded in-memory channel between request threads and
@@ -75,6 +76,26 @@ pub struct AuditConfig {
     )]
     #[serde(rename = "channel_capacity", default = "default_channel_capacity")]
     pub audit_channel_capacity: usize,
+
+    /// Only set this if the KMS sits behind a reverse proxy or load balancer.
+    ///
+    /// When set, the audit middleware trusts the `X-Forwarded-For` header only if
+    /// the direct TCP peer is one of the proxy addresses listed here, and records
+    /// the header's value as `client_ip` instead. This must be scoped to your
+    /// proxy's own address(es) — trusting it from any peer lets a remote attacker
+    /// forge `client_ip` in the audit trail.
+    ///
+    /// Format: comma-separated IP addresses or CIDR blocks, e.g.
+    /// `"10.0.0.0/8,172.16.0.0/12"`. Single IPs can be expressed as `/32` (IPv4)
+    /// or `/128` (IPv6).
+    #[clap(
+        long = "audit-trusted-proxy-cidrs",
+        env = "KMS_AUDIT_TRUSTED_PROXY_CIDRS",
+        value_delimiter = ',',
+        verbatim_doc_comment
+    )]
+    #[serde(rename = "trusted_proxy_cidrs", default)]
+    pub audit_trusted_proxy_cidrs: Vec<IpNet>,
 }
 
 /// Serde default helper for `AuditConfig::audit_channel_capacity`.

--- a/crate/server/src/config/command_line/audit_config.rs
+++ b/crate/server/src/config/command_line/audit_config.rs
@@ -11,7 +11,8 @@ pub struct AuditFileConfig {
     ///
     /// When `--audit-enable` is set and this option is omitted, the file
     /// defaults to `<root-data-path>/audit.jsonl`.
-    #[clap(long, env = "KMS_AUDIT_FILE_PATH", verbatim_doc_comment)]
+    #[clap(long = "audit-file-path", env = "KMS_AUDIT_FILE_PATH", verbatim_doc_comment)]
+    #[serde(rename = "path")]
     pub audit_file_path: Option<PathBuf>,
 }
 
@@ -34,9 +35,11 @@ pub struct AuditConfig {
     /// When disabled (the default) no audit file is created and no background
     /// writer task is spawned.  The value can also be toggled at config-file
     /// level (`[audit] enable = true`).
-    #[clap(long, env = "KMS_AUDIT_ENABLE", default_value = "false")]
+    #[clap(long = "audit-enable", env = "KMS_AUDIT_ENABLE", default_value = "false")]
+    #[serde(rename = "enabled")]
     pub audit_enable: bool,
 
     #[clap(flatten)]
+    #[serde(rename = "file")]
     pub file: AuditFileConfig,
 }

--- a/crate/server/src/config/command_line/clap_config.rs
+++ b/crate/server/src/config/command_line/clap_config.rs
@@ -76,8 +76,8 @@ impl Default for ClapConfig {
             keyset_warn_depth: 5,
             jwks_endpoint: JwksEndpointConfig::default(),
             secret_backends: SecretBackendConfig::default(),
-            audit: AuditConfig::default(),
             vault: VaultConfig::default(),
+            audit: AuditConfig::default(),
         }
     }
 }
@@ -249,14 +249,14 @@ pub struct ClapConfig {
     #[command(flatten)]
     pub jwks_endpoint: JwksEndpointConfig,
 
-    #[clap(flatten)]
-    #[serde(rename = "audit")]
-    pub audit: AuditConfig,
-
     /// Configuration for the Vault-compatible REST API (`/v1/transit/` and `/v1/<pki_mount>/`).
     #[command(flatten)]
     #[serde(default)]
     pub vault: VaultConfig,
+
+    #[clap(flatten)]
+    #[serde(rename = "audit")]
+    pub audit: AuditConfig,
 }
 
 impl ClapConfig {

--- a/crate/server/src/config/command_line/clap_config.rs
+++ b/crate/server/src/config/command_line/clap_config.rs
@@ -9,9 +9,9 @@ use cosmian_kms_server_database::reexport::cosmian_kmip::kmip_2_1::extra::taggin
 use serde::{Deserialize, Serialize};
 
 use super::{
-    GoogleCseConfig, HsmConfig, HttpConfig, IdpAuthConfig, JwksEndpointConfig, KmipPolicyConfig,
-    MainDBConfig, WorkspaceConfig, logging::LoggingConfig, secret_backends::SecretBackendConfig,
-    ui_config::UiConfig, vault_config::VaultConfig,
+    AuditConfig, GoogleCseConfig, HsmConfig, HttpConfig, IdpAuthConfig, JwksEndpointConfig,
+    KmipPolicyConfig, MainDBConfig, WorkspaceConfig, logging::LoggingConfig,
+    secret_backends::SecretBackendConfig, ui_config::UiConfig, vault_config::VaultConfig,
 };
 use crate::{
     config::{AuthVerifierConfig, AzureEkmConfig, ProxyConfig, SocketServerConfig, TlsConfig},
@@ -76,6 +76,7 @@ impl Default for ClapConfig {
             keyset_warn_depth: 5,
             jwks_endpoint: JwksEndpointConfig::default(),
             secret_backends: SecretBackendConfig::default(),
+            audit: AuditConfig::default(),
             vault: VaultConfig::default(),
         }
     }
@@ -247,6 +248,10 @@ pub struct ClapConfig {
 
     #[command(flatten)]
     pub jwks_endpoint: JwksEndpointConfig,
+
+    #[clap(flatten)]
+    #[serde(rename = "audit")]
+    pub audit: AuditConfig,
 
     /// Configuration for the Vault-compatible REST API (`/v1/transit/` and `/v1/<pki_mount>/`).
     #[command(flatten)]
@@ -738,6 +743,7 @@ impl fmt::Debug for ClapConfig {
         } else {
             x
         };
+        let x = x.field("audit", &self.audit);
 
         x.finish()
     }

--- a/crate/server/src/config/command_line/mod.rs
+++ b/crate/server/src/config/command_line/mod.rs
@@ -1,3 +1,4 @@
+mod audit_config;
 mod auth_verifier_config;
 mod azure_ekm_config;
 mod clap_config;
@@ -17,6 +18,7 @@ mod ui_config;
 mod vault_config;
 mod workspace;
 
+pub use audit_config::{AuditConfig, AuditFileConfig};
 pub use auth_verifier_config::AuthVerifierConfig;
 pub use azure_ekm_config::AzureEkmConfig;
 #[cfg(not(target_os = "windows"))]

--- a/crate/server/src/config/params/server_params.rs
+++ b/crate/server/src/config/params/server_params.rs
@@ -198,6 +198,11 @@ pub struct ServerParams {
     /// disabled (the default).
     pub audit_file_path: Option<std::path::PathBuf>,
 
+    /// Capacity of the bounded in-memory channel between request threads and the
+    /// audit writer task.  Propagated from `--audit-channel-capacity` /
+    /// `KMS_AUDIT_CHANNEL_CAPACITY`.  Must be ≥ 1.
+    pub audit_channel_capacity: usize,
+
     // ── Vault-compatible API ──────────────────────────────────────────────────
     /// When `true`, the Vault-compatible `/v1/transit/` and `/v1/<pki_mount>/` scopes
     /// are registered at startup.  Defaults to `false`.
@@ -452,6 +457,7 @@ impl ServerParams {
             } else {
                 None
             },
+            audit_channel_capacity: conf.audit.audit_channel_capacity,
             // Vault-compatible API — opt-in via config file or CLI flags.
             vault_api_enabled: conf.vault.vault_api_enabled,
             vault_auth_verifier_url: conf
@@ -840,6 +846,7 @@ impl fmt::Debug for ServerParams {
             );
         }
         debug_struct.field("audit_file_path", &self.audit_file_path);
+        debug_struct.field("audit_channel_capacity", &self.audit_channel_capacity);
 
         // Vault API fields
         debug_struct.field("vault_api_enabled", &self.vault_api_enabled);

--- a/crate/server/src/config/params/server_params.rs
+++ b/crate/server/src/config/params/server_params.rs
@@ -193,6 +193,11 @@ pub struct ServerParams {
     /// Configuration for the `GET /.well-known/jwks.json` public-key-discovery endpoint.
     pub jwks_endpoint: JwksEndpointConfig,
 
+    /// When `Some`, tamper-evident JSONL audit logging is enabled and events
+    /// are appended to the file at this path.  `None` means audit logging is
+    /// disabled (the default).
+    pub audit_file_path: Option<std::path::PathBuf>,
+
     // ── Vault-compatible API ──────────────────────────────────────────────────
     /// When `true`, the Vault-compatible `/v1/transit/` and `/v1/<pki_mount>/` scopes
     /// are registered at startup.  Defaults to `false`.
@@ -437,6 +442,16 @@ impl ServerParams {
             },
             keyset_warn_depth: conf.keyset_warn_depth,
             jwks_endpoint: conf.jwks_endpoint,
+            audit_file_path: if conf.audit.audit_enable {
+                let path = conf
+                    .audit
+                    .file
+                    .audit_file_path
+                    .unwrap_or_else(|| conf.workspace.root_data_path.join("audit.jsonl"));
+                Some(path)
+            } else {
+                None
+            },
             // Vault-compatible API — opt-in via config file or CLI flags.
             vault_api_enabled: conf.vault.vault_api_enabled,
             vault_auth_verifier_url: conf
@@ -824,6 +839,7 @@ impl fmt::Debug for ServerParams {
                 &self.jwks_endpoint.jwks_endpoint_enabled,
             );
         }
+        debug_struct.field("audit_file_path", &self.audit_file_path);
 
         // Vault API fields
         debug_struct.field("vault_api_enabled", &self.vault_api_enabled);

--- a/crate/server/src/config/params/server_params.rs
+++ b/crate/server/src/config/params/server_params.rs
@@ -4,6 +4,7 @@ use cosmian_kms_server_database::{
     MainDbParams, reexport::cosmian_kmip::kmip_2_1::kmip_objects::ObjectType,
 };
 use cosmian_logger::{debug, warn};
+use ipnet::IpNet;
 
 use super::{KmipPolicyParams, TlsParams};
 use crate::{
@@ -202,6 +203,10 @@ pub struct ServerParams {
     /// audit writer task.  Propagated from `--audit-channel-capacity` /
     /// `KMS_AUDIT_CHANNEL_CAPACITY`.  Must be ≥ 1.
     pub audit_channel_capacity: usize,
+
+    /// Trusted reverse-proxy CIDR blocks.  `X-Forwarded-For` is only used when
+    /// the direct TCP peer address falls within one of these ranges.
+    pub audit_trusted_proxy_cidrs: Vec<IpNet>,
 
     // ── Vault-compatible API ──────────────────────────────────────────────────
     /// When `true`, the Vault-compatible `/v1/transit/` and `/v1/<pki_mount>/` scopes
@@ -458,6 +463,7 @@ impl ServerParams {
                 None
             },
             audit_channel_capacity: conf.audit.audit_channel_capacity,
+            audit_trusted_proxy_cidrs: conf.audit.audit_trusted_proxy_cidrs,
             // Vault-compatible API — opt-in via config file or CLI flags.
             vault_api_enabled: conf.vault.vault_api_enabled,
             vault_auth_verifier_url: conf
@@ -847,6 +853,7 @@ impl fmt::Debug for ServerParams {
         }
         debug_struct.field("audit_file_path", &self.audit_file_path);
         debug_struct.field("audit_channel_capacity", &self.audit_channel_capacity);
+        debug_struct.field("audit_trusted_proxy_cidrs", &self.audit_trusted_proxy_cidrs);
 
         // Vault API fields
         debug_struct.field("vault_api_enabled", &self.vault_api_enabled);

--- a/crate/server/src/config/params/server_params.rs
+++ b/crate/server/src/config/params/server_params.rs
@@ -194,20 +194,6 @@ pub struct ServerParams {
     /// Configuration for the `GET /.well-known/jwks.json` public-key-discovery endpoint.
     pub jwks_endpoint: JwksEndpointConfig,
 
-    /// When `Some`, tamper-evident JSONL audit logging is enabled and events
-    /// are appended to the file at this path.  `None` means audit logging is
-    /// disabled (the default).
-    pub audit_file_path: Option<std::path::PathBuf>,
-
-    /// Capacity of the bounded in-memory channel between request threads and the
-    /// audit writer task.  Propagated from `--audit-channel-capacity` /
-    /// `KMS_AUDIT_CHANNEL_CAPACITY`.  Must be ≥ 1.
-    pub audit_channel_capacity: usize,
-
-    /// Trusted reverse-proxy CIDR blocks.  `X-Forwarded-For` is only used when
-    /// the direct TCP peer address falls within one of these ranges.
-    pub audit_trusted_proxy_cidrs: Vec<IpNet>,
-
     // ── Vault-compatible API ──────────────────────────────────────────────────
     /// When `true`, the Vault-compatible `/v1/transit/` and `/v1/<pki_mount>/` scopes
     /// are registered at startup.  Defaults to `false`.
@@ -251,6 +237,20 @@ pub struct ServerParams {
     /// When set, the KMS validates bearer tokens issued by the Auth Verifier server.
     /// The `sub` claim is used as the user identity.
     pub auth_verifier_config: Option<AuthVerifierConfig>,
+
+    /// When `Some`, tamper-evident JSONL audit logging is enabled and events
+    /// are appended to the file at this path.  `None` means audit logging is
+    /// disabled (the default).
+    pub audit_file_path: Option<std::path::PathBuf>,
+
+    /// Capacity of the bounded in-memory channel between request threads and the
+    /// audit writer task.  Propagated from `--audit-channel-capacity` /
+    /// `KMS_AUDIT_CHANNEL_CAPACITY`.  Must be ≥ 1.
+    pub audit_channel_capacity: usize,
+
+    /// Trusted reverse-proxy CIDR blocks.  `X-Forwarded-For` is only used when
+    /// the direct TCP peer address falls within one of these ranges.
+    pub audit_trusted_proxy_cidrs: Vec<IpNet>,
 }
 
 /// Represents the server parameters.
@@ -452,18 +452,6 @@ impl ServerParams {
             },
             keyset_warn_depth: conf.keyset_warn_depth,
             jwks_endpoint: conf.jwks_endpoint,
-            audit_file_path: if conf.audit.audit_enable {
-                let path = conf
-                    .audit
-                    .file
-                    .audit_file_path
-                    .unwrap_or_else(|| conf.workspace.root_data_path.join("audit.jsonl"));
-                Some(path)
-            } else {
-                None
-            },
-            audit_channel_capacity: conf.audit.audit_channel_capacity,
-            audit_trusted_proxy_cidrs: conf.audit.audit_trusted_proxy_cidrs,
             // Vault-compatible API — opt-in via config file or CLI flags.
             vault_api_enabled: conf.vault.vault_api_enabled,
             vault_auth_verifier_url: conf
@@ -491,6 +479,18 @@ impl ServerParams {
             } else {
                 None
             },
+            audit_file_path: if conf.audit.audit_enable {
+                let path = conf
+                    .audit
+                    .file
+                    .audit_file_path
+                    .unwrap_or_else(|| conf.workspace.root_data_path.join("audit.jsonl"));
+                Some(path)
+            } else {
+                None
+            },
+            audit_channel_capacity: conf.audit.audit_channel_capacity,
+            audit_trusted_proxy_cidrs: conf.audit.audit_trusted_proxy_cidrs,
         };
 
         debug!("{res:#?}");

--- a/crate/server/src/core/audit/file_store.rs
+++ b/crate/server/src/core/audit/file_store.rs
@@ -1,0 +1,259 @@
+//! Tamper-evident JSONL file backend for audit events.
+//!
+//! Architecture
+//! ============
+//! * `AuditFileStore` is a cheaply cloneable handle (wraps a channel `Sender`).
+//! * A single background tokio task (`writer_loop`) is the **sole owner** of the
+//!   audit file, the monotonic event counter, and the previous-row hash.  This
+//!   design avoids any mutex around the file and guarantees write order under
+//!   concurrent requests.
+//! * The middleware calls `enqueue()` which is a non-blocking `try_send`.  If the
+//!   channel is full (> 1024 buffered events) the draft is silently dropped and a
+//!   warning is logged — we never block the request path.
+//!
+//! Hash chain
+//! ==========
+//! Each persisted row carries:
+//!   `prev_hash` — SHA-256 of the previous row's canonical bytes (all-zeros for row 0)
+//!   `row_hash`  — SHA-256 of this row's canonical bytes (including `prev_hash`)
+//!
+//! Use `ckms audit verify --path <file>` to validate the chain offline.
+
+use std::{
+    io::{BufRead, BufReader, Write},
+    path::PathBuf,
+    sync::Arc,
+};
+
+use cosmian_kms_access::audit::{AuditEventDraft, AuditEventFull, AuditResult, compute_row_hash};
+use cosmian_logger::{debug, warn};
+use time::OffsetDateTime;
+use tokio::sync::mpsc;
+
+use crate::{error::KmsError, result::KResult};
+
+/// Channel capacity.  Events beyond this limit are dropped (non-blocking path).
+const CHANNEL_CAPACITY: usize = 1024;
+
+/// A cheaply cloneable handle to the audit writer task.
+///
+/// Cloning this value is O(1) — it only increments the `Arc` ref-count on the
+/// sender.  All clones share the same underlying channel and therefore the same
+/// writer task.
+#[derive(Clone)]
+pub(crate) struct AuditFileStore {
+    sender: Arc<mpsc::Sender<AuditEventDraft>>,
+}
+
+impl AuditFileStore {
+    /// Initialises the audit file store and spawns the background writer task.
+    ///
+    /// If `path` already contains events the writer task will continue the
+    /// existing chain; the next event ID will be `last_id + 1` and `prev_hash`
+    /// will be taken from the last persisted row.
+    ///
+    /// # Errors
+    /// Returns an error if the audit file cannot be opened or if an existing
+    /// file contains a malformed last line.
+    pub(crate) fn start(path: PathBuf) -> KResult<Self> {
+        // ── Read the tail of an existing log to resume the chain ─────────
+        let (next_id, prev_hash) = Self::resume_chain(&path)?;
+        debug!(
+            "AuditFileStore: resuming at id={next_id}, prev_hash={}",
+            hex::encode(prev_hash)
+        );
+
+        let (tx, rx) = mpsc::channel::<AuditEventDraft>(CHANNEL_CAPACITY);
+
+        // Spawn the sole writer task
+        tokio::spawn(async move {
+            writer_loop(path, next_id, prev_hash, rx).await;
+        });
+
+        Ok(Self {
+            sender: Arc::new(tx),
+        })
+    }
+
+    /// Enqueues a draft event for writing.  Non-blocking: if the channel is
+    /// full the event is silently dropped after logging a warning.
+    pub(crate) fn enqueue(&self, draft: AuditEventDraft) {
+        match self.sender.try_send(draft) {
+            Ok(()) => {}
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                warn!("AuditFileStore: channel full, dropping audit event");
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                warn!("AuditFileStore: writer task has stopped, audit event dropped");
+            }
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────
+
+    /// Reads the last line of `path` (if any) to extract the last `id` and
+    /// `row_hash` so the chain can be continued on restart.
+    fn resume_chain(path: &PathBuf) -> KResult<(i64, [u8; 32])> {
+        if !path.exists() {
+            return Ok((0, [0_u8; 32]));
+        }
+
+        let file = std::fs::File::open(path).map_err(|e| {
+            KmsError::ServerError(format!(
+                "audit: cannot open existing log file {}: {e}",
+                path.display()
+            ))
+        })?;
+
+        let reader = BufReader::new(file);
+        let mut last_line = String::new();
+
+        for line in reader.lines() {
+            let line = line.map_err(|e| {
+                KmsError::ServerError(format!("audit: error reading log file: {e}"))
+            })?;
+            if !line.trim().is_empty() {
+                last_line = line;
+            }
+        }
+
+        if last_line.is_empty() {
+            return Ok((0, [0_u8; 32]));
+        }
+
+        let last_event: AuditEventFull = serde_json::from_str(&last_line).map_err(|e| {
+            KmsError::ServerError(format!(
+                "audit: cannot parse last line of log file: {e}\nLine: {last_line}"
+            ))
+        })?;
+
+        Ok((last_event.id + 1, last_event.row_hash))
+    }
+}
+
+/// The background writer task.  Sole owner of the open file, the id counter,
+/// and `prev_hash`.  Never panics — errors are logged and the loop continues.
+async fn writer_loop(
+    path: PathBuf,
+    mut next_id: i64,
+    mut prev_hash: [u8; 32],
+    mut rx: mpsc::Receiver<AuditEventDraft>,
+) {
+    // Open the file in append mode, creating it if needed.
+    let mut file = match open_append(&path) {
+        Ok(f) => f,
+        Err(e) => {
+            warn!(
+                "AuditFileStore: cannot open {}: {e} — audit logging disabled",
+                path.display()
+            );
+            // Drain the channel so senders are not blocked
+            while rx.recv().await.is_some() {}
+            return;
+        }
+    };
+
+    while let Some(draft) = rx.recv().await {
+        let mut ev = AuditEventFull {
+            id: next_id,
+            timestamp: draft.timestamp,
+            operation: draft.operation,
+            user: draft.user,
+            object_uid: draft.object_uid,
+            algorithm: draft.algorithm,
+            client_ip: draft.client_ip,
+            result: draft.result,
+            duration_ms: draft.duration_ms,
+            prev_hash,
+            row_hash: [0_u8; 32],
+        };
+
+        // Compute the hash only after all fields are set
+        ev.row_hash = compute_row_hash(&ev);
+
+        match write_event(&mut file, &ev) {
+            Ok(()) => {
+                // Advance chain state
+                prev_hash = ev.row_hash;
+                next_id += 1;
+            }
+            Err(e) => {
+                warn!(
+                    "AuditFileStore: failed to write event id={}: {e} — event dropped",
+                    ev.id
+                );
+                // Do NOT advance id or prev_hash — the next event will reuse
+                // the same slot, preserving chain continuity.
+            }
+        }
+    }
+
+    debug!("AuditFileStore: writer loop exited (channel closed)");
+}
+
+/// Opens the audit file for appending, creating parent directories if needed.
+fn open_append(path: &PathBuf) -> std::io::Result<std::fs::File> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+}
+
+/// Serialises `event` as a single JSONL line and flushes to disk.
+fn write_event(file: &mut std::fs::File, event: &AuditEventFull) -> std::io::Result<()> {
+    let mut line = serde_json::to_string(event)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    line.push('\n');
+    file.write_all(line.as_bytes())?;
+    file.flush()
+}
+
+// ── Convenience constructors for the middleware ───────────────────────────────
+
+/// Builds an `AuditEventDraft` for a successful KMIP operation.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn make_success_draft(
+    operation: impl Into<String>,
+    user: impl Into<String>,
+    object_uid: Option<String>,
+    algorithm: Option<String>,
+    client_ip: Option<String>,
+    duration_ms: u64,
+) -> AuditEventDraft {
+    AuditEventDraft {
+        timestamp: OffsetDateTime::now_utc(),
+        operation: operation.into(),
+        user: user.into(),
+        object_uid,
+        algorithm,
+        client_ip,
+        result: AuditResult::Success,
+        duration_ms,
+    }
+}
+
+/// Builds an `AuditEventDraft` for a failed KMIP operation.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn make_failure_draft(
+    operation: impl Into<String>,
+    user: impl Into<String>,
+    object_uid: Option<String>,
+    algorithm: Option<String>,
+    client_ip: Option<String>,
+    duration_ms: u64,
+    reason: impl Into<String>,
+) -> AuditEventDraft {
+    AuditEventDraft {
+        timestamp: OffsetDateTime::now_utc(),
+        operation: operation.into(),
+        user: user.into(),
+        object_uid,
+        algorithm,
+        client_ip,
+        result: AuditResult::Failure(reason.into()),
+        duration_ms,
+    }
+}

--- a/crate/server/src/core/audit/file_store.rs
+++ b/crate/server/src/core/audit/file_store.rs
@@ -8,8 +8,8 @@
 //!   design avoids any mutex around the file and guarantees write order under
 //!   concurrent requests.
 //! * The middleware calls `enqueue()` which is a non-blocking `try_send`.  If the
-//!   channel is full (> 1024 buffered events) the draft is silently dropped and an
-//!   error is logged — we never block the request path.
+//!   channel is full (beyond the configured capacity) the draft is silently dropped
+//!   and an error is logged — we never block the request path.
 //!
 //! Hash chain
 //! ==========
@@ -20,29 +20,32 @@
 //! Use `ckms audit verify --path <file>` to validate the chain offline.
 
 use std::{
-    io::{BufRead, BufReader, Write},
-    path::PathBuf,
-    sync::Arc,
+    io::{BufRead, BufReader, Seek, Write},
+    path::Path,
 };
 
-use cosmian_kms_access::audit::{AuditEventDraft, AuditEventFull, AuditResult, compute_row_hash};
-use cosmian_logger::{debug, error, warn};
+use cosmian_kms_access::audit::{
+    AuditEvent, AuditEventDraft, AuditResult, compute_row_hash, verify_event,
+};
+use cosmian_logger::{debug, error};
 use time::OffsetDateTime;
 use tokio::sync::mpsc;
 
 use crate::{error::KmsError, result::KResult};
 
-/// Channel capacity.  Events beyond this limit are dropped (non-blocking path).
-const CHANNEL_CAPACITY: usize = 1024;
+/// Bytes read from the end of an existing log to locate the last complete event
+/// at startup.  64 KiB comfortably covers many events; a single serialised
+/// `AuditEventFull` is typically <2 KiB.
+const TAIL_WINDOW: u64 = 65_536;
 
 /// A cheaply cloneable handle to the audit writer task.
 ///
-/// Cloning this value is O(1) — it only increments the `Arc` ref-count on the
-/// sender.  All clones share the same underlying channel and therefore the same
-/// writer task.
+/// Cloning this value is O(1) — `tokio::sync::mpsc::Sender` is already backed
+/// by an internal `Arc`.  All clones share the same underlying channel and
+/// therefore the same writer task.
 #[derive(Clone)]
 pub(crate) struct AuditFileStore {
-    sender: Arc<mpsc::Sender<AuditEventDraft>>,
+    sender: mpsc::Sender<AuditEventDraft>,
 }
 
 impl AuditFileStore {
@@ -52,27 +55,42 @@ impl AuditFileStore {
     /// existing chain; the next event ID will be `last_id + 1` and `prev_hash`
     /// will be taken from the last persisted row.
     ///
+    /// `channel_capacity` is the number of events that can be buffered in the
+    /// in-memory channel before new events are dropped.  Must be ≥ 1.
+    ///
     /// # Errors
-    /// Returns an error if the audit file cannot be opened or if an existing
-    /// file contains a malformed last line.
-    pub(crate) fn start(path: PathBuf) -> KResult<Self> {
+    /// Returns an error if `channel_capacity` is 0, the audit file cannot be
+    /// opened, or an existing file contains a malformed last line.
+    pub(crate) fn start(path: &Path, channel_capacity: usize) -> KResult<Self> {
+        if channel_capacity == 0 {
+            return Err(KmsError::ServerError(
+                "audit: channel_capacity must be at least 1".to_owned(),
+            ));
+        }
         // ── Read the tail of an existing log to resume the chain ─────────
-        let (next_id, prev_hash) = Self::resume_chain(&path)?;
+        let (next_id, prev_hash) = Self::resume_chain(path)?;
         debug!(
             "AuditFileStore: resuming at id={next_id}, prev_hash={}",
-            hex::encode(prev_hash)
+            hex::encode(&prev_hash[..8]) // first 8 bytes (16 hex chars) sufficient for diagnostics
         );
 
-        let (tx, rx) = mpsc::channel::<AuditEventDraft>(CHANNEL_CAPACITY);
+        // Open before spawning so an unwritable path aborts startup immediately
+        // instead of silently disabling audit logging at runtime.
+        let file = open_append(path).map_err(|e| {
+            KmsError::ServerError(format!(
+                "audit: cannot open log file {}: {e}",
+                path.display()
+            ))
+        })?;
+
+        let (tx, rx) = mpsc::channel::<AuditEventDraft>(channel_capacity);
 
         // Spawn the sole writer task
         tokio::spawn(async move {
-            writer_loop(path, next_id, prev_hash, rx).await;
+            writer_loop(file, next_id, prev_hash, rx).await;
         });
 
-        Ok(Self {
-            sender: Arc::new(tx),
-        })
+        Ok(Self { sender: tx })
     }
 
     /// Enqueues a draft event for writing.  Non-blocking: if the channel is
@@ -89,24 +107,43 @@ impl AuditFileStore {
         }
     }
 
-
     /// Reads the last line of `path` (if any) to extract the last `id` and
     /// `row_hash` so the chain can be continued on restart.
-    fn resume_chain(path: &PathBuf) -> KResult<(i64, [u8; 32])> {
+    fn resume_chain(path: &Path) -> KResult<(i64, [u8; 32])> {
         if !path.exists() {
             return Ok((0, [0_u8; 32]));
         }
 
-        let file = std::fs::File::open(path).map_err(|e| {
+        let mut file = std::fs::File::open(path).map_err(|e| {
             KmsError::ServerError(format!(
                 "audit: cannot open existing log file {}: {e}",
                 path.display()
             ))
         })?;
 
+        let file_len = file
+            .metadata()
+            .map_err(|e| KmsError::ServerError(format!("audit: cannot stat log file: {e}")))
+            .map(|m| m.len())?;
+
+        if file_len == 0 {
+            return Ok((0, [0_u8; 32]));
+        }
+
+        // Seek to the tail window so startup cost is O(1) regardless of log size.
+        // TAIL_WINDOW is large enough to contain at least one complete event.
+        let seek_pos = file_len.saturating_sub(TAIL_WINDOW);
+        if seek_pos > 0 {
+            file.seek(std::io::SeekFrom::Start(seek_pos))
+                .map_err(|e| KmsError::ServerError(format!("audit: cannot seek log file: {e}")))?;
+        }
+
         let reader = BufReader::new(file);
         let mut last_line = String::new();
 
+        // When seek_pos > 0 the first buffered read may start mid-line (a partial
+        // fragment cut by the seek); taking the LAST non-empty line is correct
+        // regardless because subsequent lines are complete.
         for line in reader.lines() {
             let line = line.map_err(|e| {
                 KmsError::ServerError(format!("audit: error reading log file: {e}"))
@@ -120,40 +157,39 @@ impl AuditFileStore {
             return Ok((0, [0_u8; 32]));
         }
 
-        let last_event: AuditEventFull = serde_json::from_str(&last_line).map_err(|e| {
+        let last_event: AuditEvent = serde_json::from_str(&last_line).map_err(|e| {
             KmsError::ServerError(format!(
                 "audit: cannot parse last line of log file: {e}\nLine: {last_line}"
             ))
         })?;
+
+        // Verify the hash of the last persisted event before trusting it as the
+        // chain seed.  A mismatch signals tampering or a crash-truncated write.
+        if !verify_event(&last_event) {
+            return Err(KmsError::ServerError(format!(
+                "audit: last persisted event (id={}) has an invalid row_hash — \
+                 the log tail may be corrupted or tampered. \
+                 Remove or repair the last line before restarting.",
+                last_event.id
+            )));
+        }
 
         Ok((last_event.id + 1, last_event.row_hash))
     }
 }
 
 /// The background writer task.  Sole owner of the open file, the id counter,
-/// and `prev_hash`.  Never panics — errors are logged and the loop continues.
+/// and `prev_hash`.  Designed not to panic — errors are logged and the loop
+/// continues.  Calls `sync_data()` before exiting so in-flight events are
+/// durable on graceful shutdown.
 async fn writer_loop(
-    path: PathBuf,
+    mut file: std::fs::File,
     mut next_id: i64,
     mut prev_hash: [u8; 32],
     mut rx: mpsc::Receiver<AuditEventDraft>,
 ) {
-    // Open the file in append mode, creating it if needed.
-    let mut file = match open_append(&path) {
-        Ok(f) => f,
-        Err(e) => {
-            warn!(
-                "AuditFileStore: cannot open {}: {e} — audit logging disabled",
-                path.display()
-            );
-            // Drain the channel so senders are not blocked
-            while rx.recv().await.is_some() {}
-            return;
-        }
-    };
-
     while let Some(draft) = rx.recv().await {
-        let mut ev = AuditEventFull {
+        let mut ev = AuditEvent {
             id: next_id,
             timestamp: draft.timestamp,
             operation: draft.operation,
@@ -187,11 +223,16 @@ async fn writer_loop(
         }
     }
 
+    // Channel closed (sender dropped on graceful shutdown): ensure all written
+    // events are durable before the task exits.
+    if let Err(e) = file.sync_data() {
+        error!("AuditFileStore: final sync failed: {e}");
+    }
     debug!("AuditFileStore: writer loop exited (channel closed)");
 }
 
 /// Opens the audit file for appending, creating parent directories if needed.
-fn open_append(path: &PathBuf) -> std::io::Result<std::fs::File> {
+fn open_append(path: &Path) -> std::io::Result<std::fs::File> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
@@ -201,17 +242,22 @@ fn open_append(path: &PathBuf) -> std::io::Result<std::fs::File> {
         .open(path)
 }
 
-/// Serialises `event` as a single JSONL line and flushes to disk.
-fn write_event(file: &mut std::fs::File, event: &AuditEventFull) -> std::io::Result<()> {
-    let mut line = serde_json::to_string(event)
+/// Serialises `event` as a single JSONL line and syncs to storage.
+///
+/// `sync_data()` is called on every write to guarantee durability: without it
+/// data sits in the kernel page cache and is lost on a power failure.  The
+/// tradeoff is one `fsync` per audit event; high-throughput deployments can
+/// reduce cost by batching syncs (every N events or every T ms).
+fn write_event(file: &mut std::fs::File, event: &AuditEvent) -> std::io::Result<()> {
+    serde_json::to_writer(&mut *file, event)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-    line.push('\n');
-    file.write_all(line.as_bytes())?;
-    file.flush()
+    file.write_all(b"\n")?;
+    file.sync_data()
 }
 
-
 /// Builds an `AuditEventDraft` for a successful KMIP operation.
+// Each parameter maps 1-to-1 to an `AuditEventDraft` field; a wrapper struct
+// would not reduce the count and would require updating all call sites.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn make_success_draft(
     timestamp: OffsetDateTime,
@@ -235,6 +281,8 @@ pub(crate) fn make_success_draft(
 }
 
 /// Builds an `AuditEventDraft` for a failed KMIP operation.
+// Each parameter maps 1-to-1 to an `AuditEventDraft` field plus a `reason`
+// string; a wrapper struct would not reduce the count.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn make_failure_draft(
     timestamp: OffsetDateTime,
@@ -261,19 +309,189 @@ pub(crate) fn make_failure_draft(
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    // TODO: add tests for AuditFileStore::start, enqueue capacity behaviour, hash chain resumption
+    use std::{
+        io::BufRead as _,
+        path::{Path, PathBuf},
+    };
+
+    use time::OffsetDateTime;
+
+    use cosmian_kms_access::audit::{AuditEvent, AuditEventDraft, verify_event};
+
+    use super::{AuditFileStore, make_success_draft};
+
+    /// Small channel capacity used in all tests.  Large enough for the ≤5-event
+    /// functional tests; small enough to fill quickly in the saturation test.
+    const TEST_CAPACITY: usize = 16;
+
+    fn temp_path(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "kms_audit_test_{}_{label}.jsonl",
+            std::process::id()
+        ))
+    }
+
+    fn make_draft() -> AuditEventDraft {
+        make_success_draft(
+            OffsetDateTime::now_utc(),
+            "Encrypt",
+            "alice",
+            Some("obj-1".to_owned()),
+            Some("AES-256-GCM".to_owned()),
+            Some("127.0.0.1".to_owned()),
+            5,
+        )
+    }
+
+    fn read_events(path: &Path) -> Vec<AuditEvent> {
+        let file = std::fs::File::open(path).unwrap();
+        std::io::BufReader::new(file)
+            .lines()
+            .filter_map(|l| {
+                let l = l.unwrap();
+                if l.trim().is_empty() {
+                    None
+                } else {
+                    Some(serde_json::from_str::<AuditEvent>(&l).unwrap())
+                }
+            })
+            .collect()
+    }
+
+    fn assert_valid_chain(events: &[AuditEvent]) {
+        for ev in events {
+            assert!(verify_event(ev), "id={} has invalid row_hash", ev.id);
+        }
+        for w in events.windows(2) {
+            if let [prev, curr] = w {
+                assert_eq!(
+                    curr.prev_hash, prev.row_hash,
+                    "chain broken between id={} and id={}",
+                    prev.id, curr.id
+                );
+            }
+        }
+    }
+
+    /// On a current-thread runtime (the default for `#[tokio::test]`) the writer
+    /// task does not run until we yield.  Sending 2× capacity synchronously fills
+    /// the channel; the second half is dropped without blocking or panicking.
     #[tokio::test]
     async fn enqueue_drops_when_channel_full() {
-        todo!("verify enqueue silently drops events when the channel is at capacity")
+        let path = temp_path("capacity");
+        std::fs::remove_file(&path).ok();
+
+        let store = AuditFileStore::start(&path, TEST_CAPACITY).unwrap();
+        for _ in 0..(TEST_CAPACITY * 2) {
+            store.enqueue(make_draft());
+        }
+        drop(store);
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+        let events = read_events(&path);
+        assert!(
+            events.len() <= TEST_CAPACITY,
+            "at most TEST_CAPACITY events can be queued; got {}",
+            events.len()
+        );
+        assert_valid_chain(&events);
+
+        std::fs::remove_file(&path).ok();
     }
 
+    /// Write events across two store lifetimes and verify the chain is seamless.
     #[tokio::test]
     async fn chain_resumes_on_restart() {
-        todo!("verify start() reads the last row_hash from an existing log")
+        let path = temp_path("resume");
+        std::fs::remove_file(&path).ok();
+
+        // Phase 1: write 3 events
+        {
+            let store = AuditFileStore::start(&path, TEST_CAPACITY).unwrap();
+            for _ in 0..3 {
+                store.enqueue(make_draft());
+            }
+        }
+        // Drop closes the channel; yield so the writer drains and exits.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        // Phase 2: resume from the same file, write 2 more
+        {
+            let store = AuditFileStore::start(&path, TEST_CAPACITY).unwrap();
+            for _ in 0..2 {
+                store.enqueue(make_draft());
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        let events = read_events(&path);
+        assert_eq!(events.len(), 5, "expected 5 total events after restart");
+        for (i, ev) in events.iter().enumerate() {
+            assert_eq!(
+                ev.id,
+                i64::try_from(i).unwrap(),
+                "id must be sequential across restart"
+            );
+        }
+        assert_valid_chain(&events);
+
+        std::fs::remove_file(&path).ok();
     }
 
+    /// Verifies that after a sequence of successful writes the ids are strictly
+    /// sequential and all chain links are valid.  The "do not advance on failure"
+    /// invariant is tested indirectly: any id-gap or hash-mismatch would be
+    /// caught by `assert_valid_chain`.  Fault-injection (making the fd unwritable
+    /// mid-run) requires a mock file and is tracked separately.
     #[tokio::test]
     async fn write_failure_does_not_advance_chain() {
-        todo!("verify a write error does not increment id or prev_hash")
+        let path = temp_path("no_advance");
+        std::fs::remove_file(&path).ok();
+
+        let store = AuditFileStore::start(&path, TEST_CAPACITY).unwrap();
+        for _ in 0..5 {
+            store.enqueue(make_draft());
+        }
+        drop(store);
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        let events = read_events(&path);
+        assert_eq!(events.len(), 5);
+        for (i, ev) in events.iter().enumerate() {
+            assert_eq!(ev.id, i64::try_from(i).unwrap(), "id gap at position {i}");
+        }
+        assert_valid_chain(&events);
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// `start()` must refuse to continue from a log whose last event's hash is
+    /// invalid — this catches both tampering and crash-truncated partial writes.
+    #[tokio::test]
+    async fn resume_rejects_tampered_last_line() {
+        let path = temp_path("tampered");
+        std::fs::remove_file(&path).ok();
+
+        // Write 2 valid events
+        {
+            let store = AuditFileStore::start(&path, TEST_CAPACITY).unwrap();
+            store.enqueue(make_draft());
+            store.enqueue(make_draft());
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        // Overwrite the file with the last event's row_hash zeroed out
+        let content = std::fs::read_to_string(&path).unwrap();
+        let mut lines: Vec<String> = content.lines().map(str::to_owned).collect();
+        let mut last_ev: AuditEvent = serde_json::from_str(lines.last().unwrap()).unwrap();
+        last_ev.row_hash = [0_u8; 32];
+        *lines.last_mut().unwrap() = serde_json::to_string(&last_ev).unwrap();
+        std::fs::write(&path, lines.join("\n") + "\n").unwrap();
+
+        // Startup must fail because the last event's hash no longer matches
+        let result = AuditFileStore::start(&path, TEST_CAPACITY);
+        assert!(result.is_err(), "start() must reject a tampered last event");
+
+        std::fs::remove_file(&path).ok();
     }
 }

--- a/crate/server/src/core/audit/file_store.rs
+++ b/crate/server/src/core/audit/file_store.rs
@@ -22,6 +22,10 @@
 use std::{
     io::{BufRead, BufReader, Seek, Write},
     path::Path,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
 };
 
 use cosmian_kms_access::audit::{
@@ -41,11 +45,14 @@ const TAIL_WINDOW: u64 = 65_536;
 /// A cheaply cloneable handle to the audit writer task.
 ///
 /// Cloning this value is O(1) — `tokio::sync::mpsc::Sender` is already backed
-/// by an internal `Arc`.  All clones share the same underlying channel and
-/// therefore the same writer task.
+/// by an internal `Arc`, and `dropped_count` is an `Arc<AtomicU64>`.
+/// All clones share the same underlying channel and writer task.
 #[derive(Clone)]
 pub(crate) struct AuditFileStore {
     sender: mpsc::Sender<AuditEventDraft>,
+    /// Counts events dropped because the channel was full.
+    /// Checked by the writer loop to emit a sentinel event before the next real event.
+    dropped_count: Arc<AtomicU64>,
 }
 
 impl AuditFileStore {
@@ -84,25 +91,40 @@ impl AuditFileStore {
         })?;
 
         let (tx, rx) = mpsc::channel::<AuditEventDraft>(channel_capacity);
+        let dropped_count = Arc::new(AtomicU64::new(0));
+        let dropped_count_for_writer = Arc::clone(&dropped_count);
 
         // Spawn the sole writer task
         tokio::spawn(async move {
-            writer_loop(file, next_id, prev_hash, rx).await;
+            writer_loop(file, next_id, prev_hash, rx, dropped_count_for_writer).await;
         });
 
-        Ok(Self { sender: tx })
+        Ok(Self {
+            sender: tx,
+            dropped_count,
+        })
     }
 
-    /// Enqueues a draft event for writing.  Non-blocking: if the channel is
-    /// full the event is silently dropped after logging a warning.
-    pub(crate) fn enqueue(&self, draft: AuditEventDraft) {
-        match self.sender.try_send(draft) {
-            Ok(()) => {}
-            Err(mpsc::error::TrySendError::Full(_)) => {
-                error!("AuditFileStore: channel full, dropping audit event");
-            }
-            Err(mpsc::error::TrySendError::Closed(_)) => {
-                error!("AuditFileStore: writer task has stopped, audit event dropped");
+    /// Enqueues one or more draft events for writing.  Non-blocking: if the channel is
+    /// full an event is dropped and the `dropped_count` counter is incremented.  The writer
+    /// loop drains that counter before each real event and emits a synthetic
+    /// `operation = "audit:eviction"` sentinel that joins the hash chain — making drops
+    /// detectable by `ckms audit verify` and compliance tools.
+    ///
+    /// **Note**: for batch requests, `try_send` is called per-draft sequentially.
+    /// If the channel fills mid-batch, early drafts are persisted and later ones are
+    /// dropped — the sentinel will account for them on the next successful enqueue.
+    pub(crate) fn enqueue(&self, drafts: impl IntoIterator<Item = AuditEventDraft>) {
+        for draft in drafts {
+            match self.sender.try_send(draft) {
+                Ok(()) => {}
+                Err(mpsc::error::TrySendError::Full(_)) => {
+                    self.dropped_count.fetch_add(1, Ordering::Relaxed);
+                    error!("AuditFileStore: channel full, dropping audit event");
+                }
+                Err(mpsc::error::TrySendError::Closed(_)) => {
+                    error!("AuditFileStore: writer task has stopped, audit event dropped");
+                }
             }
         }
     }
@@ -187,40 +209,16 @@ async fn writer_loop(
     mut next_id: i64,
     mut prev_hash: [u8; 32],
     mut rx: mpsc::Receiver<AuditEventDraft>,
+    dropped_count: Arc<AtomicU64>,
 ) {
     while let Some(draft) = rx.recv().await {
-        let mut ev = AuditEvent {
-            id: next_id,
-            timestamp: draft.timestamp,
-            operation: draft.operation,
-            user: draft.user,
-            object_uid: draft.object_uid,
-            algorithm: draft.algorithm,
-            client_ip: draft.client_ip,
-            result: draft.result,
-            duration_ms: draft.duration_ms,
-            prev_hash,
-            row_hash: [0_u8; 32],
-        };
-
-        // Compute the hash only after all fields are set
-        ev.row_hash = compute_row_hash(&ev);
-
-        match write_event(&mut file, &ev) {
-            Ok(()) => {
-                // Advance chain state
-                prev_hash = ev.row_hash;
-                next_id += 1;
-            }
-            Err(e) => {
-                error!(
-                    "AuditFileStore: failed to write event id={}: {e} — event dropped",
-                    ev.id
-                );
-                // Do NOT advance id or prev_hash — the next event will reuse
-                // the same slot, preserving chain continuity.
-            }
+        // Emit a sentinel before the real event if any drops occurred since the last write.
+        let n_dropped = dropped_count.swap(0, Ordering::Relaxed);
+        if n_dropped > 0 {
+            let sentinel = make_eviction_sentinel(n_dropped);
+            next_id = write_draft_to_chain(&mut file, sentinel, next_id, &mut prev_hash);
         }
+        next_id = write_draft_to_chain(&mut file, draft, next_id, &mut prev_hash);
     }
 
     // Channel closed (sender dropped on graceful shutdown): ensure all written
@@ -229,6 +227,70 @@ async fn writer_loop(
         error!("AuditFileStore: final sync failed: {e}");
     }
     debug!("AuditFileStore: writer loop exited (channel closed)");
+}
+
+/// Finalises and writes a single `AuditEventDraft` into the chain, advancing
+/// `next_id` and `prev_hash` on success.  Returns the new `next_id`.
+fn write_draft_to_chain(
+    file: &mut std::fs::File,
+    draft: AuditEventDraft,
+    next_id: i64,
+    prev_hash: &mut [u8; 32],
+) -> i64 {
+    let mut ev = AuditEvent {
+        id: next_id,
+        timestamp: draft.timestamp,
+        operation: draft.operation,
+        user: draft.user,
+        object_uid: draft.object_uid,
+        algorithm: draft.algorithm,
+        client_ip: draft.client_ip,
+        result: draft.result,
+        duration_ms: draft.duration_ms,
+        request_id: draft.request_id,
+        prev_hash: *prev_hash,
+        row_hash: [0_u8; 32],
+    };
+    ev.row_hash = compute_row_hash(&ev);
+
+    match write_event(file, &ev) {
+        Ok(()) => {
+            *prev_hash = ev.row_hash;
+            next_id.checked_add(1).unwrap_or_else(|| {
+                error!(
+                    "AuditFileStore: id counter overflow at i64::MAX — \
+                     audit logging stopped. Rotate the log file and restart."
+                );
+                next_id
+            })
+        }
+        Err(e) => {
+            error!(
+                "AuditFileStore: failed to write event id={}: {e} — event dropped",
+                ev.id
+            );
+            // Do NOT advance id or prev_hash — the next event will reuse
+            // the same slot, preserving chain continuity.
+            next_id
+        }
+    }
+}
+
+/// Builds a sentinel `AuditEventDraft` that records how many real events were
+/// dropped due to channel saturation.  Joins the hash chain like any real event
+/// — detectable by `ckms audit verify` and compliance tooling.
+fn make_eviction_sentinel(n_dropped: u64) -> AuditEventDraft {
+    AuditEventDraft {
+        timestamp: OffsetDateTime::now_utc(),
+        operation: "audit:eviction".to_owned(),
+        user: "server".to_owned(),
+        object_uid: None,
+        algorithm: None,
+        client_ip: None,
+        result: AuditResult::Failure(format!("{n_dropped} events dropped (channel full)")),
+        duration_ms: 0,
+        request_id: None,
+    }
 }
 
 /// Opens the audit file for appending, creating parent directories if needed.
@@ -277,6 +339,7 @@ pub(crate) fn make_success_draft(
         client_ip,
         result: AuditResult::Success,
         duration_ms,
+        request_id: None,
     }
 }
 
@@ -303,11 +366,12 @@ pub(crate) fn make_failure_draft(
         client_ip,
         result: AuditResult::Failure(reason.into()),
         duration_ms,
+        request_id: None,
     }
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use std::{
         io::BufRead as _,
@@ -383,18 +447,67 @@ mod tests {
 
         let store = AuditFileStore::start(&path, TEST_CAPACITY).unwrap();
         for _ in 0..(TEST_CAPACITY * 2) {
-            store.enqueue(make_draft());
+            store.enqueue(std::iter::once(make_draft()));
         }
         drop(store);
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
         let events = read_events(&path);
+        // TEST_CAPACITY real events fit in the channel; the writer also emits at
+        // most one sentinel for the dropped half, so the total is at most
+        // TEST_CAPACITY + 1.  Crucially, it must be strictly less than
+        // TEST_CAPACITY * 2 (confirming that drops occurred).
         assert!(
-            events.len() <= TEST_CAPACITY,
-            "at most TEST_CAPACITY events can be queued; got {}",
+            events.len() <= TEST_CAPACITY + 1,
+            "at most TEST_CAPACITY + 1 events (real + sentinel); got {}",
+            events.len()
+        );
+        assert!(
+            events.len() < TEST_CAPACITY * 2,
+            "some events must have been dropped; got {} (none dropped?)",
             events.len()
         );
         assert_valid_chain(&events);
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// When the channel fills and a later event is enqueued, the writer emits a
+    /// sentinel `audit:eviction` event in the chain before the next real event.
+    #[tokio::test]
+    async fn sentinel_emitted_after_drops() {
+        let path = temp_path("sentinel");
+        std::fs::remove_file(&path).ok();
+
+        let store = AuditFileStore::start(&path, TEST_CAPACITY).unwrap();
+        // Saturate: send 2× capacity so the second half is dropped.
+        for _ in 0..(TEST_CAPACITY * 2) {
+            store.enqueue(std::iter::once(make_draft()));
+        }
+        // One more real event — the writer will emit the sentinel first.
+        store.enqueue(std::iter::once(make_draft()));
+        drop(store);
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+        let events = read_events(&path);
+        assert_valid_chain(&events);
+
+        let sentinel = events
+            .iter()
+            .find(|e| e.operation == "audit:eviction")
+            .expect("expected an audit:eviction sentinel event");
+        // Sentinel result must be Failure with the drop count.
+        match &sentinel.result {
+            cosmian_kms_access::audit::AuditResult::Failure(msg) => {
+                assert!(
+                    msg.contains("dropped"),
+                    "sentinel reason should mention 'dropped': {msg}"
+                );
+            }
+            cosmian_kms_access::audit::AuditResult::Success => {
+                panic!("expected Failure, got Success")
+            }
+        }
 
         std::fs::remove_file(&path).ok();
     }
@@ -409,7 +522,7 @@ mod tests {
         {
             let store = AuditFileStore::start(&path, TEST_CAPACITY).unwrap();
             for _ in 0..3 {
-                store.enqueue(make_draft());
+                store.enqueue(std::iter::once(make_draft()));
             }
         }
         // Drop closes the channel; yield so the writer drains and exits.
@@ -419,7 +532,7 @@ mod tests {
         {
             let store = AuditFileStore::start(&path, TEST_CAPACITY).unwrap();
             for _ in 0..2 {
-                store.enqueue(make_draft());
+                store.enqueue(std::iter::once(make_draft()));
             }
         }
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
@@ -450,7 +563,7 @@ mod tests {
 
         let store = AuditFileStore::start(&path, TEST_CAPACITY).unwrap();
         for _ in 0..5 {
-            store.enqueue(make_draft());
+            store.enqueue(std::iter::once(make_draft()));
         }
         drop(store);
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
@@ -475,8 +588,8 @@ mod tests {
         // Write 2 valid events
         {
             let store = AuditFileStore::start(&path, TEST_CAPACITY).unwrap();
-            store.enqueue(make_draft());
-            store.enqueue(make_draft());
+            store.enqueue(std::iter::once(make_draft()));
+            store.enqueue(std::iter::once(make_draft()));
         }
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 

--- a/crate/server/src/core/audit/file_store.rs
+++ b/crate/server/src/core/audit/file_store.rs
@@ -33,7 +33,7 @@ use cosmian_kms_access::audit::{
 };
 use cosmian_logger::{debug, error};
 use time::OffsetDateTime;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 
 use crate::{error::KmsError, result::KResult};
 
@@ -42,6 +42,19 @@ use crate::{error::KmsError, result::KResult};
 /// `AuditEventFull` is typically <2 KiB.
 const TAIL_WINDOW: u64 = 65_536;
 
+/// Message sent to the writer task over the channel.
+enum WriterMsg {
+    /// A draft event to persist.
+    Event(AuditEventDraft),
+    /// A synchronization barrier: the writer acknowledges once every message
+    /// enqueued before this one has been written (and, for `File`, `fsync`'d).
+    /// Used by tests to await the writer's progress deterministically instead
+    /// of sleeping. Only the test-only `flush()` constructs it, but the field
+    /// type and writer-loop handler compile unconditionally.
+    #[cfg_attr(not(test), allow(dead_code))]
+    Flush(oneshot::Sender<()>),
+}
+
 /// A cheaply cloneable handle to the audit writer task.
 ///
 /// Cloning this value is O(1) — `tokio::sync::mpsc::Sender` is already backed
@@ -49,7 +62,7 @@ const TAIL_WINDOW: u64 = 65_536;
 /// All clones share the same underlying channel and writer task.
 #[derive(Clone)]
 pub(crate) struct AuditFileStore {
-    sender: mpsc::Sender<AuditEventDraft>,
+    sender: mpsc::Sender<WriterMsg>,
     /// Counts events dropped because the channel was full.
     /// Checked by the writer loop to emit a sentinel event before the next real event.
     dropped_count: Arc<AtomicU64>,
@@ -90,7 +103,7 @@ impl AuditFileStore {
             ))
         })?;
 
-        let (tx, rx) = mpsc::channel::<AuditEventDraft>(channel_capacity);
+        let (tx, rx) = mpsc::channel::<WriterMsg>(channel_capacity);
         let dropped_count = Arc::new(AtomicU64::new(0));
         let dropped_count_for_writer = Arc::clone(&dropped_count);
 
@@ -116,7 +129,7 @@ impl AuditFileStore {
     /// dropped — the sentinel will account for them on the next successful enqueue.
     pub(crate) fn enqueue(&self, drafts: impl IntoIterator<Item = AuditEventDraft>) {
         for draft in drafts {
-            match self.sender.try_send(draft) {
+            match self.sender.try_send(WriterMsg::Event(draft)) {
                 Ok(()) => {}
                 Err(mpsc::error::TrySendError::Full(_)) => {
                     self.dropped_count.fetch_add(1, Ordering::Relaxed);
@@ -126,6 +139,25 @@ impl AuditFileStore {
                     error!("AuditFileStore: writer task has stopped, audit event dropped");
                 }
             }
+        }
+    }
+
+    /// Awaits until every event enqueued before this call has been written by
+    /// the writer task (and, for the real `File` sink, `fsync`'d). Unlike
+    /// `enqueue`, this uses a blocking `send` so the barrier itself is never
+    /// dropped under channel saturation.
+    ///
+    /// Intended for tests and offline tooling that need a deterministic
+    /// drain point instead of a fixed sleep. A no-op if the writer task has
+    /// already stopped.
+    // Only called from test code today; kept as a real (non-cfg-gated) crate API
+    // so `WriterMsg::Flush` stays a normal, always-constructed variant instead of
+    // needing parallel cfg(test)/cfg(not(test)) match arms in the hot writer loop.
+    #[allow(dead_code, reason = "test-only today; a genuine crate API, not dead")]
+    pub(crate) async fn flush(&self) {
+        let (tx, rx) = oneshot::channel();
+        if self.sender.send(WriterMsg::Flush(tx)).await.is_ok() {
+            let _ = rx.await;
         }
     }
 
@@ -200,39 +232,90 @@ impl AuditFileStore {
     }
 }
 
-/// The background writer task.  Sole owner of the open file, the id counter,
-/// and `prev_hash`.  Designed not to panic — errors are logged and the loop
-/// continues.  Calls `sync_data()` before exiting so in-flight events are
-/// durable on graceful shutdown.
-async fn writer_loop(
-    mut file: std::fs::File,
+/// Abstraction over the audit log's underlying writer.
+///
+/// This exists so the fault path (`write_event` failing mid-run) can be
+/// exercised in tests with a mock sink, without touching real files —
+/// production always uses `std::fs::File`.
+trait AuditSink {
+    /// Serialises and durably persists one event.
+    ///
+    /// # Errors
+    /// On failure, the caller must NOT consider the event committed: it does
+    /// not advance the chain's `next_id`/`prev_hash`, so the same slot is
+    /// reused by the next successfully written event.
+    fn write_event(&mut self, event: &AuditEvent) -> std::io::Result<()>;
+
+    /// Called once when the writer loop exits (channel closed). Default is a
+    /// no-op.
+    fn final_sync(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl AuditSink for std::fs::File {
+    /// Serialises `event` as a single JSONL line and syncs to storage.
+    ///
+    /// `sync_data()` is called on every write to guarantee durability: without it
+    /// data sits in the kernel page cache and is lost on a power failure.  The
+    /// tradeoff is one `fsync` per audit event; high-throughput deployments can
+    /// reduce cost by batching syncs (every N events or every T ms).
+    fn write_event(&mut self, event: &AuditEvent) -> std::io::Result<()> {
+        serde_json::to_writer(&mut *self, event)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        self.write_all(b"\n")?;
+        self.sync_data()
+    }
+
+    fn final_sync(&mut self) -> std::io::Result<()> {
+        self.sync_data()
+    }
+}
+
+/// The background writer task.  Sole owner of the sink, the id counter, and
+/// `prev_hash`.  Designed not to panic — errors are logged and the loop
+/// continues.  Calls `final_sync()` before exiting so in-flight events are
+/// durable on graceful shutdown.  Returns the sink so tests can inspect what
+/// was actually persisted.
+async fn writer_loop<S: AuditSink>(
+    mut sink: S,
     mut next_id: i64,
     mut prev_hash: [u8; 32],
-    mut rx: mpsc::Receiver<AuditEventDraft>,
+    mut rx: mpsc::Receiver<WriterMsg>,
     dropped_count: Arc<AtomicU64>,
-) {
-    while let Some(draft) = rx.recv().await {
+) -> S {
+    while let Some(msg) = rx.recv().await {
+        let draft = match msg {
+            WriterMsg::Event(draft) => draft,
+            WriterMsg::Flush(ack) => {
+                // Every prior message has already been written above; simply
+                // acknowledge. Ignore a dropped receiver (caller stopped waiting).
+                let _ = ack.send(());
+                continue;
+            }
+        };
         // Emit a sentinel before the real event if any drops occurred since the last write.
         let n_dropped = dropped_count.swap(0, Ordering::Relaxed);
         if n_dropped > 0 {
             let sentinel = make_eviction_sentinel(n_dropped);
-            next_id = write_draft_to_chain(&mut file, sentinel, next_id, &mut prev_hash);
+            next_id = write_draft_to_chain(&mut sink, sentinel, next_id, &mut prev_hash);
         }
-        next_id = write_draft_to_chain(&mut file, draft, next_id, &mut prev_hash);
+        next_id = write_draft_to_chain(&mut sink, draft, next_id, &mut prev_hash);
     }
 
     // Channel closed (sender dropped on graceful shutdown): ensure all written
     // events are durable before the task exits.
-    if let Err(e) = file.sync_data() {
+    if let Err(e) = sink.final_sync() {
         error!("AuditFileStore: final sync failed: {e}");
     }
     debug!("AuditFileStore: writer loop exited (channel closed)");
+    sink
 }
 
 /// Finalises and writes a single `AuditEventDraft` into the chain, advancing
 /// `next_id` and `prev_hash` on success.  Returns the new `next_id`.
-fn write_draft_to_chain(
-    file: &mut std::fs::File,
+fn write_draft_to_chain<S: AuditSink>(
+    sink: &mut S,
     draft: AuditEventDraft,
     next_id: i64,
     prev_hash: &mut [u8; 32],
@@ -253,7 +336,7 @@ fn write_draft_to_chain(
     };
     ev.row_hash = compute_row_hash(&ev);
 
-    match write_event(file, &ev) {
+    match sink.write_event(&ev) {
         Ok(()) => {
             *prev_hash = ev.row_hash;
             next_id.checked_add(1).unwrap_or_else(|| {
@@ -302,19 +385,6 @@ fn open_append(path: &Path) -> std::io::Result<std::fs::File> {
         .create(true)
         .append(true)
         .open(path)
-}
-
-/// Serialises `event` as a single JSONL line and syncs to storage.
-///
-/// `sync_data()` is called on every write to guarantee durability: without it
-/// data sits in the kernel page cache and is lost on a power failure.  The
-/// tradeoff is one `fsync` per audit event; high-throughput deployments can
-/// reduce cost by batching syncs (every N events or every T ms).
-fn write_event(file: &mut std::fs::File, event: &AuditEvent) -> std::io::Result<()> {
-    serde_json::to_writer(&mut *file, event)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-    file.write_all(b"\n")?;
-    file.sync_data()
 }
 
 /// Builds an `AuditEventDraft` for a successful KMIP operation.
@@ -376,13 +446,15 @@ mod tests {
     use std::{
         io::BufRead as _,
         path::{Path, PathBuf},
+        sync::{Arc, atomic::AtomicU64},
     };
 
     use time::OffsetDateTime;
+    use tokio::sync::mpsc;
 
     use cosmian_kms_access::audit::{AuditEvent, AuditEventDraft, verify_event};
 
-    use super::{AuditFileStore, make_success_draft};
+    use super::{AuditFileStore, AuditSink, WriterMsg, make_success_draft, writer_loop};
 
     /// Small channel capacity used in all tests.  Large enough for the ≤5-event
     /// functional tests; small enough to fill quickly in the saturation test.
@@ -449,11 +521,12 @@ mod tests {
         for _ in 0..(TEST_CAPACITY * 2) {
             store.enqueue(std::iter::once(make_draft()));
         }
+        // Deterministic drain barrier instead of a fixed sleep: once flush()
+        // returns, every event enqueued above has been written (and synced).
+        store.flush().await;
         drop(store);
-        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
         let events = read_events(&path);
-        // TEST_CAPACITY real events fit in the channel; the writer also emits at
         // most one sentinel for the dropped half, so the total is at most
         // TEST_CAPACITY + 1.  Crucially, it must be strictly less than
         // TEST_CAPACITY * 2 (confirming that drops occurred).
@@ -486,8 +559,8 @@ mod tests {
         }
         // One more real event — the writer will emit the sentinel first.
         store.enqueue(std::iter::once(make_draft()));
+        store.flush().await;
         drop(store);
-        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
         let events = read_events(&path);
         assert_valid_chain(&events);
@@ -524,9 +597,8 @@ mod tests {
             for _ in 0..3 {
                 store.enqueue(std::iter::once(make_draft()));
             }
+            store.flush().await;
         }
-        // Drop closes the channel; yield so the writer drains and exits.
-        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
         // Phase 2: resume from the same file, write 2 more
         {
@@ -534,8 +606,8 @@ mod tests {
             for _ in 0..2 {
                 store.enqueue(std::iter::once(make_draft()));
             }
+            store.flush().await;
         }
-        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
         let events = read_events(&path);
         assert_eq!(events.len(), 5, "expected 5 total events after restart");
@@ -552,10 +624,8 @@ mod tests {
     }
 
     /// Verifies that after a sequence of successful writes the ids are strictly
-    /// sequential and all chain links are valid.  The "do not advance on failure"
-    /// invariant is tested indirectly: any id-gap or hash-mismatch would be
-    /// caught by `assert_valid_chain`.  Fault-injection (making the fd unwritable
-    /// mid-run) requires a mock file and is tracked separately.
+    /// sequential and all chain links are valid.  Mid-run write failures are
+    /// covered directly by `faulty_sink_error_does_not_advance_chain_and_reuses_slot`.
     #[tokio::test]
     async fn write_failure_does_not_advance_chain() {
         let path = temp_path("no_advance");
@@ -565,8 +635,8 @@ mod tests {
         for _ in 0..5 {
             store.enqueue(std::iter::once(make_draft()));
         }
+        store.flush().await;
         drop(store);
-        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
         let events = read_events(&path);
         assert_eq!(events.len(), 5);
@@ -590,8 +660,8 @@ mod tests {
             let store = AuditFileStore::start(&path, TEST_CAPACITY).unwrap();
             store.enqueue(std::iter::once(make_draft()));
             store.enqueue(std::iter::once(make_draft()));
+            store.flush().await;
         }
-        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
         // Overwrite the file with the last event's row_hash zeroed out
         let content = std::fs::read_to_string(&path).unwrap();
@@ -606,5 +676,162 @@ mod tests {
         assert!(result.is_err(), "start() must reject a tampered last event");
 
         std::fs::remove_file(&path).ok();
+    }
+
+    // ── Fail-fast startup ────────────────────────────────────────────────
+
+    /// `start()` must abort immediately (not silently disable audit logging)
+    /// when the log path cannot be opened. Using a path that walks *through*
+    /// an existing plain file (instead of relying on filesystem permissions,
+    /// which root ignores) makes this deterministic on every platform/CI user.
+    #[test]
+    fn start_fails_when_path_is_unopenable() {
+        let blocker = temp_path("unopenable_blocker");
+        std::fs::remove_file(&blocker).ok();
+        std::fs::write(&blocker, b"i am a file, not a directory").unwrap();
+        // `blocker` is a file, so treating it as a parent directory must fail.
+        let bogus_path = blocker.join("audit.jsonl");
+
+        let result = AuditFileStore::start(&bogus_path, TEST_CAPACITY);
+        assert!(
+            result.is_err(),
+            "start() must fail when the log file cannot be opened"
+        );
+        let err = result.err().unwrap().to_string();
+        assert!(
+            err.contains("cannot open"),
+            "unexpected error message: {err}"
+        );
+
+        std::fs::remove_file(&blocker).ok();
+    }
+
+    /// A zero channel capacity is rejected before any file I/O or task spawn.
+    #[test]
+    fn start_fails_with_zero_capacity() {
+        let path = temp_path("zero_capacity");
+        std::fs::remove_file(&path).ok();
+
+        let result = AuditFileStore::start(&path, 0);
+        assert!(result.is_err(), "start() must reject channel_capacity == 0");
+        let err = result.err().unwrap().to_string();
+        assert!(
+            err.contains("channel_capacity must be at least 1"),
+            "unexpected error message: {err}"
+        );
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// A last line that isn't valid JSON (e.g. a crash mid-`serde_json::to_writer`,
+    /// before any `\n` was written) must abort startup rather than silently
+    /// resetting the chain from id 0.
+    #[test]
+    fn start_fails_on_malformed_last_line() {
+        let path = temp_path("malformed_last_line");
+        std::fs::remove_file(&path).ok();
+        std::fs::write(&path, b"{not valid json at all\n").unwrap();
+
+        let result = AuditFileStore::start(&path, TEST_CAPACITY);
+        assert!(
+            result.is_err(),
+            "start() must reject a log whose last line is not valid JSON"
+        );
+        let err = result.err().unwrap().to_string();
+        assert!(
+            err.contains("cannot parse last line"),
+            "unexpected error message: {err}"
+        );
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    // ── Fault injection on the write path ────────────────────────────────
+
+    /// A mock `AuditSink` that fails `write_event` for calls whose 0-based
+    /// index satisfies `should_fail`, allowing precise control over exactly
+    /// which write in a sequence fails.
+    struct FaultySink {
+        events: Vec<AuditEvent>,
+        call_count: usize,
+        should_fail: fn(usize) -> bool,
+    }
+
+    impl FaultySink {
+        fn new(should_fail: fn(usize) -> bool) -> Self {
+            Self {
+                events: Vec::new(),
+                call_count: 0,
+                should_fail,
+            }
+        }
+    }
+
+    impl AuditSink for FaultySink {
+        fn write_event(&mut self, event: &AuditEvent) -> std::io::Result<()> {
+            let idx = self.call_count;
+            self.call_count += 1;
+            if (self.should_fail)(idx) {
+                return Err(std::io::Error::other("simulated write failure"));
+            }
+            self.events.push(event.clone());
+            Ok(())
+        }
+    }
+
+    /// A single failed write mid-run must not advance the chain: the failed
+    /// draft is lost, and the next successful write reuses its `id`/`prev_hash`
+    /// slot — proving the "do not advance on failure" invariant that was
+    /// previously only exercised on the happy path.
+    #[tokio::test]
+    async fn faulty_sink_error_does_not_advance_chain_and_reuses_slot() {
+        let (tx, rx) = mpsc::channel::<WriterMsg>(TEST_CAPACITY);
+        let dropped_count = Arc::new(AtomicU64::new(0));
+        // Fail exactly the 3rd write call (0-based index 2).
+        let sink = FaultySink::new(|idx| idx == 2);
+
+        let handle = tokio::spawn(writer_loop(sink, 0, [0_u8; 32], rx, dropped_count));
+
+        for _ in 0..5 {
+            tx.send(WriterMsg::Event(make_draft())).await.unwrap();
+        }
+        drop(tx);
+
+        let sink = handle.await.unwrap();
+        assert_eq!(
+            sink.events.len(),
+            4,
+            "one of the 5 drafts must be lost to the injected write failure"
+        );
+        for (i, ev) in sink.events.iter().enumerate() {
+            assert_eq!(
+                ev.id,
+                i64::try_from(i).unwrap(),
+                "ids must stay contiguous — the failed write's slot must be reused, not skipped"
+            );
+        }
+        assert_valid_chain(&sink.events);
+    }
+
+    /// When every write fails, nothing is persisted and the writer loop still
+    /// exits cleanly (no panic) once the channel closes.
+    #[tokio::test]
+    async fn faulty_sink_all_writes_fail_persists_nothing() {
+        let (tx, rx) = mpsc::channel::<WriterMsg>(TEST_CAPACITY);
+        let dropped_count = Arc::new(AtomicU64::new(0));
+        let sink = FaultySink::new(|_| true);
+
+        let handle = tokio::spawn(writer_loop(sink, 0, [0_u8; 32], rx, dropped_count));
+
+        for _ in 0..3 {
+            tx.send(WriterMsg::Event(make_draft())).await.unwrap();
+        }
+        drop(tx);
+
+        let sink = handle.await.unwrap();
+        assert!(
+            sink.events.is_empty(),
+            "no event should be persisted when every write fails"
+        );
     }
 }

--- a/crate/server/src/core/audit/file_store.rs
+++ b/crate/server/src/core/audit/file_store.rs
@@ -8,8 +8,8 @@
 //!   design avoids any mutex around the file and guarantees write order under
 //!   concurrent requests.
 //! * The middleware calls `enqueue()` which is a non-blocking `try_send`.  If the
-//!   channel is full (> 1024 buffered events) the draft is silently dropped and a
-//!   warning is logged — we never block the request path.
+//!   channel is full (> 1024 buffered events) the draft is silently dropped and an
+//!   error is logged — we never block the request path.
 //!
 //! Hash chain
 //! ==========
@@ -26,7 +26,7 @@ use std::{
 };
 
 use cosmian_kms_access::audit::{AuditEventDraft, AuditEventFull, AuditResult, compute_row_hash};
-use cosmian_logger::{debug, warn};
+use cosmian_logger::{debug, error, warn};
 use time::OffsetDateTime;
 use tokio::sync::mpsc;
 
@@ -81,15 +81,14 @@ impl AuditFileStore {
         match self.sender.try_send(draft) {
             Ok(()) => {}
             Err(mpsc::error::TrySendError::Full(_)) => {
-                warn!("AuditFileStore: channel full, dropping audit event");
+                error!("AuditFileStore: channel full, dropping audit event");
             }
             Err(mpsc::error::TrySendError::Closed(_)) => {
-                warn!("AuditFileStore: writer task has stopped, audit event dropped");
+                error!("AuditFileStore: writer task has stopped, audit event dropped");
             }
         }
     }
 
-    // ── Helpers ───────────────────────────────────────────────────────────
 
     /// Reads the last line of `path` (if any) to extract the last `id` and
     /// `row_hash` so the chain can be continued on restart.
@@ -178,7 +177,7 @@ async fn writer_loop(
                 next_id += 1;
             }
             Err(e) => {
-                warn!(
+                error!(
                     "AuditFileStore: failed to write event id={}: {e} — event dropped",
                     ev.id
                 );
@@ -211,11 +210,11 @@ fn write_event(file: &mut std::fs::File, event: &AuditEventFull) -> std::io::Res
     file.flush()
 }
 
-// ── Convenience constructors for the middleware ───────────────────────────────
 
 /// Builds an `AuditEventDraft` for a successful KMIP operation.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn make_success_draft(
+    timestamp: OffsetDateTime,
     operation: impl Into<String>,
     user: impl Into<String>,
     object_uid: Option<String>,
@@ -224,7 +223,7 @@ pub(crate) fn make_success_draft(
     duration_ms: u64,
 ) -> AuditEventDraft {
     AuditEventDraft {
-        timestamp: OffsetDateTime::now_utc(),
+        timestamp,
         operation: operation.into(),
         user: user.into(),
         object_uid,
@@ -238,6 +237,7 @@ pub(crate) fn make_success_draft(
 /// Builds an `AuditEventDraft` for a failed KMIP operation.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn make_failure_draft(
+    timestamp: OffsetDateTime,
     operation: impl Into<String>,
     user: impl Into<String>,
     object_uid: Option<String>,
@@ -247,7 +247,7 @@ pub(crate) fn make_failure_draft(
     reason: impl Into<String>,
 ) -> AuditEventDraft {
     AuditEventDraft {
-        timestamp: OffsetDateTime::now_utc(),
+        timestamp,
         operation: operation.into(),
         user: user.into(),
         object_uid,
@@ -255,5 +255,25 @@ pub(crate) fn make_failure_draft(
         client_ip,
         result: AuditResult::Failure(reason.into()),
         duration_ms,
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    // TODO: add tests for AuditFileStore::start, enqueue capacity behaviour, hash chain resumption
+    #[tokio::test]
+    async fn enqueue_drops_when_channel_full() {
+        todo!("verify enqueue silently drops events when the channel is at capacity")
+    }
+
+    #[tokio::test]
+    async fn chain_resumes_on_restart() {
+        todo!("verify start() reads the last row_hash from an existing log")
+    }
+
+    #[tokio::test]
+    async fn write_failure_does_not_advance_chain() {
+        todo!("verify a write error does not increment id or prev_hash")
     }
 }

--- a/crate/server/src/core/audit/mod.rs
+++ b/crate/server/src/core/audit/mod.rs
@@ -1,0 +1,3 @@
+mod file_store;
+
+pub(crate) use file_store::{AuditFileStore, make_failure_draft, make_success_draft};

--- a/crate/server/src/core/kms/mod.rs
+++ b/crate/server/src/core/kms/mod.rs
@@ -288,7 +288,7 @@ impl KMS {
     /// Starts the audit file store if audit logging is configured.
     fn create_audit_store(server_params: &ServerParams) -> KResult<Option<AuditFileStore>> {
         if let Some(ref path) = server_params.audit_file_path {
-            let store = AuditFileStore::start(path.clone())?;
+            let store = AuditFileStore::start(path, server_params.audit_channel_capacity)?;
             Ok(Some(store))
         } else {
             Ok(None)

--- a/crate/server/src/core/kms/mod.rs
+++ b/crate/server/src/core/kms/mod.rs
@@ -42,7 +42,7 @@ static GLOBAL_HSMS: OnceCell<Vec<Arc<dyn HSM + Send + Sync>>> = OnceCell::const_
 
 use crate::{
     config::{OpenTelemetryConfig, ServerParams},
-    core::OtelMetrics,
+    core::{OtelMetrics, audit::AuditFileStore},
     error::KmsError,
     kms_bail,
     result::KResult,
@@ -90,6 +90,9 @@ pub struct KMS {
 
     /// OTLP metrics collector (if enabled)
     pub(crate) metrics: Option<Arc<OtelMetrics>>,
+
+    /// Audit file store (if audit logging is enabled)
+    pub(crate) audit_store: Option<AuditFileStore>,
 
     /// Optional HSM instance for PKCS#11 operations.
     /// This is used for KMIP PKCS#11 operations like `C_Initialize`, `C_GetInfo`, `C_Finalize`.
@@ -199,6 +202,7 @@ impl KMS {
             // Keep a reference to the first HSM for PKCS#11 C_Initialize / C_GetInfo operations.
             hsm: hsm_instances.into_iter().next(),
             metrics,
+            audit_store: Self::create_audit_store(&server_params)?,
         })
     }
 
@@ -276,6 +280,16 @@ impl KMS {
                 .build();
 
             Ok(Some(Arc::new(OtelMetrics::new(meter_provider)?)))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Starts the audit file store if audit logging is configured.
+    fn create_audit_store(server_params: &ServerParams) -> KResult<Option<AuditFileStore>> {
+        if let Some(ref path) = server_params.audit_file_path {
+            let store = AuditFileStore::start(path.clone())?;
+            Ok(Some(store))
         } else {
             Ok(None)
         }

--- a/crate/server/src/core/mod.rs
+++ b/crate/server/src/core/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod audit;
 pub(crate) mod certificate;
 #[cfg(feature = "non-fips")]
 pub(crate) mod cover_crypt;

--- a/crate/server/src/core/otel_metrics.rs
+++ b/crate/server/src/core/otel_metrics.rs
@@ -760,6 +760,33 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_per_user_metric_labels() {
+        let (metrics, provider, exporter) = setup_observing_metrics();
+        metrics.record_kmip_operation("Create", "alice");
+        metrics.record_kmip_operation("Get", "bob");
+        provider.force_flush().expect("flush");
+        let mut labels = user_labels(&exporter, "kms.kmip.operations.per_user.total");
+        labels.sort();
+        assert_eq!(labels, vec!["alice".to_owned(), "bob".to_owned()]);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_per_user_cardinality_overflow() {
+        let (metrics, provider, exporter) = setup_observing_metrics();
+        // Fill the tracker to the cardinality cap directly, avoiding the cost
+        // of `MAX_TRACKED_CARDINALITY` real `record_kmip_operation` calls.
+        for i in 0..MAX_TRACKED_CARDINALITY {
+            metrics
+                .active_users_tracker
+                .insert(format!("user{i}"), i64::MAX);
+        }
+        metrics.record_kmip_operation("Create", "new_user");
+        provider.force_flush().expect("flush");
+        let labels = user_labels(&exporter, "kms.kmip.operations.per_user.total");
+        assert_eq!(labels, vec![OVERFLOW_USER_LABEL.to_owned()]);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_permission_recording() {
         let (metrics, provider, exporter) = setup_observing_metrics();
         metrics.record_permission_grant("user1", "read");

--- a/crate/server/src/core/otel_metrics.rs
+++ b/crate/server/src/core/otel_metrics.rs
@@ -20,6 +20,7 @@ use opentelemetry::{
     metrics::{Counter, Gauge, Histogram, Meter, MeterProvider, UpDownCounter},
 };
 use opentelemetry_sdk::metrics::SdkMeterProvider;
+use sha2::{Digest, Sha256};
 
 use crate::{error::KmsError, result::KResult};
 
@@ -37,6 +38,11 @@ pub(crate) const MAX_TRACKED_CARDINALITY: usize = 10_000;
 
 /// Sentinel label value emitted when the cardinality cap is reached.
 const OVERFLOW_USER_LABEL: &str = "__overflow__";
+
+/// Number of hex characters kept from the SHA-256 digest used for the `user`
+/// metric label (64 bits — negligible collision risk at `MAX_TRACKED_CARDINALITY`
+/// scale, short enough to stay readable in dashboards).
+const USER_LABEL_HASH_HEX_LEN: usize = 16;
 
 /// One-liner builder for an OpenTelemetry metric instrument.
 /// Usage: `metric!(meter, u64_counter, "name", "description", "unit")`
@@ -344,7 +350,11 @@ impl OtelMetrics {
         })
     }
 
-    /// Record a KMIP operation
+    /// Record a KMIP operation.
+    ///
+    /// `user` is only ever used to update the in-process active-user tracker
+    /// and, hashed, as the `kms.kmip.operations.per_user.total` label — see
+    /// [`Self::bounded_user_label`].
     pub fn record_kmip_operation(&self, operation: &str, user: &str) {
         self.kmip_operations_total
             .add(1, &[KeyValue::new("operation", operation.to_owned())]);
@@ -367,7 +377,11 @@ impl OtelMetrics {
         );
     }
 
-    /// Record a permission grant
+    /// Record a permission grant.
+    ///
+    /// `user` is only ever used, hashed, as the
+    /// `kms.permissions.granted.per_user.total` label — see
+    /// [`Self::bounded_user_label`].
     pub fn record_permission_grant(&self, user: &str, permission_type: &str) {
         let effective_user = self.bounded_user_label(user);
         self.permissions_granted_per_user.add(
@@ -380,18 +394,32 @@ impl OtelMetrics {
         self.permissions_granted_total.add(1, &[]);
     }
 
-    /// Returns the user label to use for per-user metrics.
+    /// Returns the `user` label to use for per-user metrics.
     ///
-    /// Returns the real user string if the cardinality cap has not been reached,
-    /// or `"__overflow__"` when it has.
+    /// The raw username is never exported: this returns a non-reversible,
+    /// truncated SHA-256 hash of the user identity if the cardinality cap has
+    /// not been reached, or the literal `"__overflow__"` sentinel when it has.
+    /// Real user identity is recorded only in the audit log
+    /// (`middlewares/audit.rs`), never in OTEL metrics.
     fn bounded_user_label(&self, user: &str) -> String {
         if self.active_users_tracker.contains_key(user)
             || self.active_users_tracker.len() < MAX_TRACKED_CARDINALITY
         {
-            user.to_owned()
+            Self::hash_user(user)
         } else {
             OVERFLOW_USER_LABEL.to_owned()
         }
+    }
+
+    /// Hashes a user identity into a short, non-reversible hex digest suitable
+    /// for use as a metric label (per OTEL's `user.hash` semantic convention).
+    fn hash_user(user: &str) -> String {
+        let digest = Sha256::digest(user.as_bytes());
+        let full_hex = hex::encode(digest);
+        full_hex
+            .get(..USER_LABEL_HASH_HEX_LEN)
+            .unwrap_or(&full_hex)
+            .to_owned()
     }
 
     /// Update active user tracking.
@@ -757,6 +785,17 @@ mod tests {
         metrics.record_kmip_operation("Create", "user2");
         provider.force_flush().expect("flush");
         assert_eq!(last_counter_u64(&exporter, "kms.kmip.operations.total"), 3);
+
+        let labels = user_labels(&exporter, "kms.kmip.operations.per_user.total");
+        assert!(!labels.is_empty());
+        assert!(
+            labels.iter().all(|l| l != "user1" && l != "user2"),
+            "raw username must never appear in the `user` metric label: {labels:?}"
+        );
+        assert!(
+            labels.iter().all(|l| l.len() == USER_LABEL_HASH_HEX_LEN),
+            "expected {USER_LABEL_HASH_HEX_LEN}-hex-char hash labels: {labels:?}"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -796,6 +835,43 @@ mod tests {
         assert_eq!(
             last_counter_u64(&exporter, "kms.permissions.granted.total"),
             3
+        );
+
+        let labels = user_labels(&exporter, "kms.permissions.granted.per_user.total");
+        assert!(!labels.is_empty());
+        assert!(
+            labels.iter().all(|l| l != "user1" && l != "user2"),
+            "raw username must never appear in the `user` metric label: {labels:?}"
+        );
+    }
+
+    #[test]
+    fn test_user_label_hash_is_deterministic() {
+        assert_eq!(
+            OtelMetrics::hash_user("alice@example.com"),
+            OtelMetrics::hash_user("alice@example.com")
+        );
+        assert_ne!(
+            OtelMetrics::hash_user("alice@example.com"),
+            OtelMetrics::hash_user("bob@example.com")
+        );
+        assert_eq!(
+            OtelMetrics::hash_user("alice@example.com").len(),
+            USER_LABEL_HASH_HEX_LEN
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_user_label_overflow_stays_literal_sentinel() {
+        let (metrics, provider, exporter) = setup_observing_metrics();
+        for i in 0..=MAX_TRACKED_CARDINALITY {
+            metrics.record_kmip_operation("Create", &format!("user{i}"));
+        }
+        provider.force_flush().expect("flush");
+        let labels = user_labels(&exporter, "kms.kmip.operations.per_user.total");
+        assert!(
+            labels.iter().any(|l| l == OVERFLOW_USER_LABEL),
+            "expected literal overflow sentinel once cardinality cap is exceeded: {labels:?}"
         );
     }
 

--- a/crate/server/src/core/otel_metrics.rs
+++ b/crate/server/src/core/otel_metrics.rs
@@ -634,13 +634,12 @@ mod tests {
 
     use super::*;
 
-    // ── No-op provider — cheap, used only where value assertions aren't needed ──
-
+    // No-op provider — cheap, used only where value assertions aren't needed
     fn create_test_meter_provider() -> SdkMeterProvider {
         SdkMeterProvider::builder().build()
     }
 
-    // ── Observing setup: real exporter, values assertable after force_flush() ──
+    // Observing setup: real exporter, values assertable after force_flush()
 
     fn setup_observing_metrics() -> (OtelMetrics, SdkMeterProvider, InMemoryMetricExporter) {
         let exporter = InMemoryMetricExporter::default();
@@ -650,8 +649,6 @@ mod tests {
         let metrics = OtelMetrics::new(provider).expect("metrics init");
         (metrics, provider_ref, exporter)
     }
-
-    // ── Value-reading helpers ─────────────────────────────────────────────────
 
     /// Sum of all data-point values for a u64 counter metric in the last exported batch.
     fn last_counter_u64(exporter: &InMemoryMetricExporter, name: &str) -> u64 {
@@ -705,6 +702,33 @@ mod tests {
             }
         }
         0
+    }
+
+    /// Collects every `user` attribute value recorded for a `u64` counter metric
+    /// across all data points in the last exported batch.
+    fn user_labels(exporter: &InMemoryMetricExporter, name: &str) -> Vec<String> {
+        let batches = exporter.get_finished_metrics().unwrap_or_default();
+        let Some(last) = batches.last() else {
+            return vec![];
+        };
+        let mut labels = vec![];
+        for sm in last.scope_metrics() {
+            for metric in sm.metrics() {
+                if metric.name() != name {
+                    continue;
+                }
+                if let AggregatedMetrics::U64(MetricData::Sum(sum)) = metric.data() {
+                    for dp in sum.data_points() {
+                        for kv in dp.attributes() {
+                            if kv.key.as_str() == "user" {
+                                labels.push(kv.value.to_string());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        labels
     }
 
     // ── Smoke tests (construction + no-panic; no value assertions needed) ─────

--- a/crate/server/src/core/otel_metrics.rs
+++ b/crate/server/src/core/otel_metrics.rs
@@ -799,33 +799,6 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_per_user_metric_labels() {
-        let (metrics, provider, exporter) = setup_observing_metrics();
-        metrics.record_kmip_operation("Create", "alice");
-        metrics.record_kmip_operation("Get", "bob");
-        provider.force_flush().expect("flush");
-        let mut labels = user_labels(&exporter, "kms.kmip.operations.per_user.total");
-        labels.sort();
-        assert_eq!(labels, vec!["alice".to_owned(), "bob".to_owned()]);
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_per_user_cardinality_overflow() {
-        let (metrics, provider, exporter) = setup_observing_metrics();
-        // Fill the tracker to the cardinality cap directly, avoiding the cost
-        // of `MAX_TRACKED_CARDINALITY` real `record_kmip_operation` calls.
-        for i in 0..MAX_TRACKED_CARDINALITY {
-            metrics
-                .active_users_tracker
-                .insert(format!("user{i}"), i64::MAX);
-        }
-        metrics.record_kmip_operation("Create", "new_user");
-        provider.force_flush().expect("flush");
-        let labels = user_labels(&exporter, "kms.kmip.operations.per_user.total");
-        assert_eq!(labels, vec![OVERFLOW_USER_LABEL.to_owned()]);
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_permission_recording() {
         let (metrics, provider, exporter) = setup_observing_metrics();
         metrics.record_permission_grant("user1", "read");
@@ -864,9 +837,18 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_user_label_overflow_stays_literal_sentinel() {
         let (metrics, provider, exporter) = setup_observing_metrics();
-        for i in 0..=MAX_TRACKED_CARDINALITY {
-            metrics.record_kmip_operation("Create", &format!("user{i}"));
+        // Fill the tracker to the cap directly instead of issuing
+        // `MAX_TRACKED_CARDINALITY` real `record_kmip_operation` calls: that
+        // many distinct `user` attribute values would also trip the OTel SDK's
+        // own default per-instrument cardinality limit (2000), which merges
+        // everything past it into an attribute-less SDK overflow point —
+        // masking our own `"__overflow__"` sentinel before it can be observed.
+        for i in 0..MAX_TRACKED_CARDINALITY {
+            metrics
+                .active_users_tracker
+                .insert(format!("user{i}"), i64::MAX);
         }
+        metrics.record_kmip_operation("Create", "new_user");
         provider.force_flush().expect("flush");
         let labels = user_labels(&exporter, "kms.kmip.operations.per_user.total");
         assert!(

--- a/crate/server/src/main.rs
+++ b/crate/server/src/main.rs
@@ -476,13 +476,6 @@ jwks_endpoint_enabled = false
 jwks_endpoint_max_keys = 50
 jwks_endpoint_auto_tag = true
 
-[audit]
-enabled = false
-channel_capacity = 0
-trusted_proxy_cidrs = []
-
-[audit.file]
-
 [vault]
 vault_api_enabled = false
 vault_auth_verifier_accept_invalid_certs = false
@@ -490,6 +483,13 @@ vault_transit_mount = ""
 vault_pki_mount = ""
 vault_pki_ca_key_label = ""
 vault_token_cache_ttl_secs = 0
+
+[audit]
+enabled = false
+channel_capacity = 0
+trusted_proxy_cidrs = []
+
+[audit.file]
 "#;
 
         assert_eq!(toml_string.trim(), toml::to_string(&config).unwrap().trim());

--- a/crate/server/src/main.rs
+++ b/crate/server/src/main.rs
@@ -371,9 +371,7 @@ mod tests {
             secret_backends: cosmian_kms_server::config::SecretBackendConfig::default(),
             auth_verifier: cosmian_kms_server::config::AuthVerifierConfig::default(),
             print_default_config: false,
-            auto_rotation_check_interval_secs: 0,
-            keyset_warn_depth: 5,
-            vault: cosmian_kms_server::config::VaultConfig::default(),
+            ..ClapConfig::default()
         };
 
         let toml_string = r#"

--- a/crate/server/src/main.rs
+++ b/crate/server/src/main.rs
@@ -476,6 +476,13 @@ jwks_endpoint_enabled = false
 jwks_endpoint_max_keys = 50
 jwks_endpoint_auto_tag = true
 
+[audit]
+enabled = false
+channel_capacity = 0
+trusted_proxy_cidrs = []
+
+[audit.file]
+
 [vault]
 vault_api_enabled = false
 vault_auth_verifier_accept_invalid_certs = false

--- a/crate/server/src/middlewares/audit.rs
+++ b/crate/server/src/middlewares/audit.rs
@@ -1,0 +1,221 @@
+//! Audit middleware — intercepts every KMIP request and enqueues an
+//! `AuditEventDraft` to the background writer task after the inner service
+//! has produced its response.
+//!
+//! Design decisions
+//! ================
+//! * When `store` is `None` (audit disabled) the middleware is a transparent
+//!   pass-through: no overhead beyond a single `Option` check.
+//! * The middleware is registered **just before** `.wrap(cors)` so it runs
+//!   *inside* CORS but *outside* all authentication middlewares.  This means:
+//!   - 401 responses from `EnsureAuth`, `JwtAuth`, `TlsAuth` are audited.
+//!   - CORS `OPTIONS` preflight requests are **not** audited (they bypass the
+//!     audit wrapper because CORS handles them first).
+//! * Operation name extraction: the path `/kmip/2_1` → "KMIP", enterprise
+//!   paths `/google_cse/…` → `"GoogleCSE"`, etc.
+//! * User identity: read from `AuthenticatedUser` in request extensions.  If
+//!   absent (401 path) we record `"<unauthenticated>"`.
+//! * Duration: measured as wall-clock elapsed from the moment the inner
+//!   service `Future` is polled to completion.
+
+use std::{
+    pin::Pin,
+    rc::Rc,
+    task::{Context, Poll},
+    time::Instant,
+};
+
+use actix_web::{
+    Error, HttpMessage,
+    body::{BoxBody, EitherBody},
+    dev::{Service, ServiceRequest, ServiceResponse, Transform},
+};
+use cosmian_kms_access::audit::AuditEventDraft;
+use futures::{
+    Future,
+    future::{Ready, ok},
+};
+use time::OffsetDateTime;
+
+use crate::{
+    core::audit::{AuditFileStore, make_failure_draft, make_success_draft},
+    middlewares::AuthenticatedUser,
+};
+
+const UNAUTHENTICATED: &str = "<unauthenticated>";
+
+/// Factory struct — cheaply cloneable (wraps an `Option<AuditFileStore>` where
+/// the store itself is already an `Arc` under the hood).
+#[derive(Clone)]
+pub(crate) struct AuditMiddleware {
+    store: Option<AuditFileStore>,
+}
+
+impl AuditMiddleware {
+    /// Creates a new `AuditMiddleware`.
+    ///
+    /// When `store` is `None` the middleware is a no-op pass-through.
+    #[must_use]
+    pub(crate) const fn new(store: Option<AuditFileStore>) -> Self {
+        Self { store }
+    }
+}
+
+impl<S, B> Transform<S, ServiceRequest> for AuditMiddleware
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    S::Future: 'static,
+    B: 'static,
+{
+    type Error = Error;
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+    type InitError = ();
+    type Response = ServiceResponse<EitherBody<B, BoxBody>>;
+    type Transform = AuditService<S>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        ok(AuditService {
+            service: Rc::new(service),
+            store: self.store.clone(),
+        })
+    }
+}
+
+pub(crate) struct AuditService<S> {
+    service: Rc<S>,
+    store: Option<AuditFileStore>,
+}
+
+impl<S, B> Service<ServiceRequest> for AuditService<S>
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    S::Future: 'static,
+    B: 'static,
+{
+    type Error = Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>>>>;
+    type Response = ServiceResponse<EitherBody<B, BoxBody>>;
+
+    fn poll_ready(&self, ctx: &mut Context) -> Poll<Result<(), Self::Error>> {
+        self.service.poll_ready(ctx)
+    }
+
+    fn call(&self, req: ServiceRequest) -> Self::Future {
+        // ── Fast path: audit disabled ─────────────────────────────────────
+        let store = match &self.store {
+            None => {
+                let svc = self.service.clone();
+                return Box::pin(async move {
+                    let res = svc.call(req).await?;
+                    Ok(res.map_into_left_body())
+                });
+            }
+            Some(s) => s.clone(),
+        };
+
+        // ── Capture per-request context ───────────────────────────────────
+        let operation = extract_operation(req.path());
+        let client_ip = extract_client_ip(&req);
+
+        // Read user identity before the request is consumed; may be absent
+        // (no auth configured, or auth will fail downstream).
+        let user = req
+            .extensions()
+            .get::<AuthenticatedUser>()
+            .map_or_else(|| UNAUTHENTICATED.to_owned(), |u| u.username.clone());
+
+        let start = Instant::now();
+        let timestamp = OffsetDateTime::now_utc();
+        let svc = self.service.clone();
+
+        Box::pin(async move {
+            let res = svc.call(req).await?;
+
+            let duration_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+            let status = res.status();
+
+            // Re-read user after authentication middlewares may have injected it
+            // into the response extensions (actix propagates req extensions to resp).
+            let final_user = res
+                .request()
+                .extensions()
+                .get::<AuthenticatedUser>()
+                .map_or(user, |u| u.username.clone());
+
+            let draft: AuditEventDraft = if status.is_success() || status.is_redirection() {
+                make_success_draft(
+                    operation,
+                    final_user,
+                    None, // object_uid resolved post-deserialization — not available here
+                    None, // algorithm — same
+                    client_ip,
+                    duration_ms,
+                )
+            } else {
+                let reason = format!(
+                    "{} {}",
+                    status.as_u16(),
+                    status.canonical_reason().unwrap_or("Unknown")
+                );
+                make_failure_draft(
+                    operation,
+                    final_user,
+                    None,
+                    None,
+                    client_ip,
+                    duration_ms,
+                    reason,
+                )
+            };
+
+            // Override the timestamp with the one captured before the inner call
+            // so the recorded time reflects request arrival, not response completion.
+            let draft = AuditEventDraft { timestamp, ..draft };
+
+            store.enqueue(draft);
+
+            Ok(res.map_into_left_body())
+        })
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Derives a human-readable operation name from the HTTP path.
+fn extract_operation(path: &str) -> String {
+    if path.contains("/kmip/") {
+        "KMIP".to_owned()
+    } else if path.contains("/google_cse") {
+        "GoogleCSE".to_owned()
+    } else if path.contains("/ms_dke") {
+        "MsDKE".to_owned()
+    } else if path.contains("/azure_ekm") {
+        "AzureEKM".to_owned()
+    } else if path.contains("/aws_xks") {
+        "AwsXKS".to_owned()
+    } else {
+        // strip leading slash and use first segment
+        path.trim_start_matches('/')
+            .split('/')
+            .next()
+            .unwrap_or("Unknown")
+            .to_owned()
+    }
+}
+
+/// Extracts the client IP from the `X-Forwarded-For` header or the peer address.
+fn extract_client_ip(req: &ServiceRequest) -> Option<String> {
+    // Prefer `X-Forwarded-For` (set by load balancers / reverse proxies)
+    if let Some(xff) = req.headers().get("x-forwarded-for") {
+        if let Ok(val) = xff.to_str() {
+            // XFF may contain a comma-separated list; take the first (client) entry
+            if let Some(ip) = val.split(',').next() {
+                let ip = ip.trim();
+                if !ip.is_empty() {
+                    return Some(ip.to_owned());
+                }
+            }
+        }
+    }
+    req.peer_addr().map(|addr| addr.ip().to_string())
+}

--- a/crate/server/src/middlewares/audit.rs
+++ b/crate/server/src/middlewares/audit.rs
@@ -12,9 +12,12 @@
 //!   - CORS `OPTIONS` preflight requests are **not** audited (they bypass the
 //!     audit wrapper because CORS handles them first).
 //! * Operation name extraction: the path `/kmip/2_1` → "KMIP", enterprise
-//!   paths `/google_cse/…` → `"GoogleCSE"`, etc.
+//!   paths `/google_cse/…` → `"GoogleCSE"`, etc.  For KMIP requests the
+//!   route handler injects a `KmipOperationName` extension with the exact
+//!   operation (e.g. `"Encrypt"`, `"Create"`), which overrides the coarse
+//!   path-derived name.
 //! * User identity: read from `AuthenticatedUser` in request extensions.  If
-//!   absent (401 path) we record `"<unauthenticated>"`.
+//!   absent (401 path) we record `"unauthenticated"`.
 //! * Duration: measured as wall-clock elapsed from the moment the inner
 //!   service `Future` is polled to completion.
 
@@ -39,13 +42,11 @@ use time::OffsetDateTime;
 
 use crate::{
     core::audit::{AuditFileStore, make_failure_draft, make_success_draft},
-    middlewares::AuthenticatedUser,
+    middlewares::{AuthenticatedUser, KmipOperationName},
 };
 
-const UNAUTHENTICATED: &str = "<unauthenticated>";
+const UNAUTHENTICATED: &str = "unauthenticated";
 
-/// Factory struct — cheaply cloneable (wraps an `Option<AuditFileStore>` where
-/// the store itself is already an `Arc` under the hood).
 #[derive(Clone)]
 pub(crate) struct AuditMiddleware {
     store: Option<AuditFileStore>,
@@ -101,7 +102,7 @@ where
     }
 
     fn call(&self, req: ServiceRequest) -> Self::Future {
-        // ── Fast path: audit disabled ─────────────────────────────────────
+        // Fast path: audit disabled
         let store = match &self.store {
             None => {
                 let svc = self.service.clone();
@@ -113,7 +114,7 @@ where
             Some(s) => s.clone(),
         };
 
-        // ── Capture per-request context ───────────────────────────────────
+        // Capture per-request context
         let operation = extract_operation(req.path());
         let client_ip = extract_client_ip(&req);
 
@@ -142,9 +143,18 @@ where
                 .get::<AuthenticatedUser>()
                 .map_or(user, |u| u.username.clone());
 
+            // Prefer the exact KMIP operation name injected by the route handler
+            // (e.g. "Encrypt", "Create"); fall back to path-derived coarse name.
+            let final_operation = res
+                .request()
+                .extensions()
+                .get::<KmipOperationName>()
+                .map_or(operation, |k| k.0.clone());
+
             let draft: AuditEventDraft = if status.is_success() || status.is_redirection() {
                 make_success_draft(
-                    operation,
+                    timestamp,
+                    final_operation,
                     final_user,
                     None, // object_uid resolved post-deserialization — not available here
                     None, // algorithm — same
@@ -158,7 +168,8 @@ where
                     status.canonical_reason().unwrap_or("Unknown")
                 );
                 make_failure_draft(
-                    operation,
+                    timestamp,
+                    final_operation,
                     final_user,
                     None,
                     None,
@@ -168,10 +179,6 @@ where
                 )
             };
 
-            // Override the timestamp with the one captured before the inner call
-            // so the recorded time reflects request arrival, not response completion.
-            let draft = AuditEventDraft { timestamp, ..draft };
-
             store.enqueue(draft);
 
             Ok(res.map_into_left_body())
@@ -179,32 +186,24 @@ where
     }
 }
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-/// Derives a human-readable operation name from the HTTP path.
+/// Derives an operation name from the HTTP path by taking the first path segment.
+///
+/// For KMIP requests the route handler injects a `KmipOperationName` extension with
+/// the exact operation name — this function only provides the fallback used when no
+/// extension is present (non-KMIP paths, or failures before dispatch).
 fn extract_operation(path: &str) -> String {
-    if path.contains("/kmip/") {
-        "KMIP".to_owned()
-    } else if path.contains("/google_cse") {
-        "GoogleCSE".to_owned()
-    } else if path.contains("/ms_dke") {
-        "MsDKE".to_owned()
-    } else if path.contains("/azure_ekm") {
-        "AzureEKM".to_owned()
-    } else if path.contains("/aws_xks") {
-        "AwsXKS".to_owned()
+    let segment = path.trim_start_matches('/').split('/').next().unwrap_or("");
+    if segment.is_empty() {
+        "unknown".to_owned()
     } else {
-        // strip leading slash and use first segment
-        path.trim_start_matches('/')
-            .split('/')
-            .next()
-            .unwrap_or("Unknown")
-            .to_owned()
+        segment.to_owned()
     }
 }
 
 /// Extracts the client IP from the `X-Forwarded-For` header or the peer address.
 fn extract_client_ip(req: &ServiceRequest) -> Option<String> {
+    // TODO: XFF header can be spoofed by clients when there is no trusted reverse
+    //       proxy in front of the KMS; validate against an IP allowlist in production.
     // Prefer `X-Forwarded-For` (set by load balancers / reverse proxies)
     if let Some(xff) = req.headers().get("x-forwarded-for") {
         if let Ok(val) = xff.to_str() {
@@ -218,4 +217,22 @@ fn extract_client_ip(req: &ServiceRequest) -> Option<String> {
         }
     }
     req.peer_addr().map(|addr| addr.ip().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn operation_extraction_from_paths() {
+        assert_eq!(extract_operation("/kmip/2_1"), "kmip");
+        assert_eq!(extract_operation("/google_cse/digest"), "google_cse");
+        assert_eq!(extract_operation("/ms_dke/version"), "ms_dke");
+        assert_eq!(extract_operation("/azure_ekm/keys"), "azure_ekm");
+        assert_eq!(extract_operation("/aws_xks/healthcheck"), "aws_xks");
+        assert_eq!(extract_operation("/health"), "health");
+        assert_eq!(extract_operation("/v1/crypto/encrypt"), "v1");
+        assert_eq!(extract_operation("/"), "unknown");
+        assert_eq!(extract_operation(""), "unknown");
+    }
 }

--- a/crate/server/src/middlewares/audit.rs
+++ b/crate/server/src/middlewares/audit.rs
@@ -21,6 +21,24 @@
 //! * Duration: measured as wall-clock elapsed from the moment the inner
 //!   service `Future` is polled to completion.
 
+/// KMIP-specific operation name injected by the KMIP route handlers
+/// so the audit middleware records the exact operation ("Encrypt", "Create", …)
+/// instead of the coarse path-derived grouping ("KMIP").
+#[derive(Debug, Clone)]
+pub(crate) struct KmipOperationName(pub String);
+
+/// KMIP object UID injected by the KMIP route handler for audit purposes.
+/// For Create/CreateKeyPair this is the server-generated UID from the response TTLV.
+/// For object-bearing ops (Encrypt, Decrypt, Get, Destroy, …) it is the
+/// `UniqueIdentifier` from the request TTLV.
+#[derive(Debug, Clone)]
+pub(crate) struct KmipObjectUid(pub String);
+
+/// KMIP cryptographic algorithm (e.g. `"AES"`, `"RSA"`) injected by the KMIP
+/// route handler for audit purposes.
+#[derive(Debug, Clone)]
+pub(crate) struct KmipAlgorithm(pub String);
+
 use std::{
     pin::Pin,
     rc::Rc,
@@ -42,7 +60,7 @@ use time::OffsetDateTime;
 
 use crate::{
     core::audit::{AuditFileStore, make_failure_draft, make_success_draft},
-    middlewares::{AuthenticatedUser, KmipOperationName},
+    middlewares::AuthenticatedUser,
 };
 
 const UNAUTHENTICATED: &str = "unauthenticated";
@@ -102,7 +120,6 @@ where
     }
 
     fn call(&self, req: ServiceRequest) -> Self::Future {
-        // Fast path: audit disabled
         let store = match &self.store {
             None => {
                 let svc = self.service.clone();
@@ -114,12 +131,9 @@ where
             Some(s) => s.clone(),
         };
 
-        // Capture per-request context
         let operation = extract_operation(req.path());
         let client_ip = extract_client_ip(&req);
 
-        // Read user identity before the request is consumed; may be absent
-        // (no auth configured, or auth will fail downstream).
         let user = req
             .extensions()
             .get::<AuthenticatedUser>()
@@ -135,29 +149,37 @@ where
             let duration_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
             let status = res.status();
 
-            // Re-read user after authentication middlewares may have injected it
-            // into the response extensions (actix propagates req extensions to resp).
             let final_user = res
                 .request()
                 .extensions()
                 .get::<AuthenticatedUser>()
                 .map_or(user, |u| u.username.clone());
 
-            // Prefer the exact KMIP operation name injected by the route handler
-            // (e.g. "Encrypt", "Create"); fall back to path-derived coarse name.
             let final_operation = res
                 .request()
                 .extensions()
                 .get::<KmipOperationName>()
                 .map_or(operation, |k| k.0.clone());
 
+            let object_uid = res
+                .request()
+                .extensions()
+                .get::<KmipObjectUid>()
+                .map(|k| k.0.clone());
+
+            let algorithm = res
+                .request()
+                .extensions()
+                .get::<KmipAlgorithm>()
+                .map(|k| k.0.clone());
+
             let draft: AuditEventDraft = if status.is_success() || status.is_redirection() {
                 make_success_draft(
                     timestamp,
                     final_operation,
                     final_user,
-                    None, // object_uid resolved post-deserialization — not available here
-                    None, // algorithm — same
+                    object_uid,
+                    algorithm,
                     client_ip,
                     duration_ms,
                 )
@@ -171,8 +193,8 @@ where
                     timestamp,
                     final_operation,
                     final_user,
-                    None,
-                    None,
+                    object_uid,
+                    algorithm,
                     client_ip,
                     duration_ms,
                     reason,
@@ -204,10 +226,8 @@ fn extract_operation(path: &str) -> String {
 fn extract_client_ip(req: &ServiceRequest) -> Option<String> {
     // TODO: XFF header can be spoofed by clients when there is no trusted reverse
     //       proxy in front of the KMS; validate against an IP allowlist in production.
-    // Prefer `X-Forwarded-For` (set by load balancers / reverse proxies)
     if let Some(xff) = req.headers().get("x-forwarded-for") {
         if let Ok(val) = xff.to_str() {
-            // XFF may contain a comma-separated list; take the first (client) entry
             if let Some(ip) = val.split(',').next() {
                 let ip = ip.trim();
                 if !ip.is_empty() {
@@ -234,5 +254,93 @@ mod tests {
         assert_eq!(extract_operation("/v1/crypto/encrypt"), "v1");
         assert_eq!(extract_operation("/"), "unknown");
         assert_eq!(extract_operation(""), "unknown");
+    }
+
+    #[test]
+    fn make_success_draft_all_attributes() {
+        use crate::core::audit::make_success_draft;
+        use cosmian_kms_access::audit::AuditResult;
+        use time::OffsetDateTime;
+
+        let ts = OffsetDateTime::now_utc();
+
+        let draft = make_success_draft(
+            ts,
+            "Encrypt",
+            "alice",
+            Some("key-42".to_owned()),
+            Some("AES-256".to_owned()),
+            Some("192.168.1.1".to_owned()),
+            42,
+        );
+        assert_eq!(draft.timestamp, ts);
+        assert_eq!(draft.operation, "Encrypt");
+        assert_eq!(draft.user, "alice");
+        assert_eq!(draft.object_uid.as_deref(), Some("key-42"));
+        assert_eq!(draft.algorithm.as_deref(), Some("AES-256"));
+        assert_eq!(draft.client_ip.as_deref(), Some("192.168.1.1"));
+        assert_eq!(draft.duration_ms, 42);
+        assert!(matches!(draft.result, AuditResult::Success));
+
+        let draft = make_success_draft(ts, "Get", "bob", None, None, None, 7);
+        assert_eq!(draft.operation, "Get");
+        assert_eq!(draft.user, "bob");
+        assert!(draft.object_uid.is_none());
+        assert!(draft.algorithm.is_none());
+        assert!(draft.client_ip.is_none());
+        assert_eq!(draft.duration_ms, 7);
+        assert!(matches!(draft.result, AuditResult::Success));
+    }
+
+    #[test]
+    fn make_failure_draft_all_attributes() {
+        use crate::core::audit::make_failure_draft;
+        use cosmian_kms_access::audit::AuditResult;
+        use time::OffsetDateTime;
+
+        let ts = OffsetDateTime::now_utc();
+
+        let draft = make_failure_draft(
+            ts,
+            "Decrypt",
+            "charlie",
+            Some("obj-99".to_owned()),
+            Some("RSA-3072".to_owned()),
+            Some("10.0.0.5".to_owned()),
+            123,
+            "403 Forbidden",
+        );
+        assert_eq!(draft.timestamp, ts);
+        assert_eq!(draft.operation, "Decrypt");
+        assert_eq!(draft.user, "charlie");
+        assert_eq!(draft.object_uid.as_deref(), Some("obj-99"));
+        assert_eq!(draft.algorithm.as_deref(), Some("RSA-3072"));
+        assert_eq!(draft.client_ip.as_deref(), Some("10.0.0.5"));
+        assert_eq!(draft.duration_ms, 123);
+        assert!(matches!(
+            &draft.result,
+            AuditResult::Failure(reason) if reason == "403 Forbidden"
+        ));
+
+        let draft = make_failure_draft(
+            ts,
+            "Create",
+            "dave",
+            None,
+            None,
+            None,
+            15,
+            "401 Unauthorized",
+        );
+        assert_eq!(draft.operation, "Create");
+        assert_eq!(draft.user, "dave");
+        assert!(draft.object_uid.is_none());
+        assert!(draft.algorithm.is_none());
+        assert!(draft.client_ip.is_none());
+        assert_eq!(draft.duration_ms, 15);
+        assert!(matches!(
+            &draft.result,
+            AuditResult::Failure(reason) if reason == "401 Unauthorized"
+        ));
     }
 }

--- a/crate/server/src/middlewares/audit.rs
+++ b/crate/server/src/middlewares/audit.rs
@@ -39,6 +39,23 @@ pub(crate) struct KmipObjectUid(pub String);
 #[derive(Debug, Clone)]
 pub(crate) struct KmipAlgorithm(pub String);
 
+/// Per-BatchItem audit context extracted from a `RequestMessage` TTLV.
+/// Injected by the KMIP route handler for batch requests.
+#[derive(Debug, Clone)]
+pub(crate) struct BatchItemAuditContext {
+    pub operation: String,
+    pub object_uid: Option<String>,
+    pub algorithm: Option<String>,
+    /// Per-item result backfilled from the `ResponseMessage` after dispatch.
+    pub result: Option<cosmian_kms_access::audit::AuditResult>,
+}
+
+/// Container for per-`BatchItem` audit contexts extracted from a `RequestMessage`.
+/// Injected into request extensions by `inject_audit_request`; consumed by the
+/// audit middleware to fan out one `AuditEventDraft` per item.
+#[derive(Debug, Clone)]
+pub(crate) struct KmipBatchOperations(pub Vec<BatchItemAuditContext>);
+
 use std::{
     pin::Pin,
     rc::Rc,
@@ -51,12 +68,14 @@ use actix_web::{
     body::{BoxBody, EitherBody},
     dev::{Service, ServiceRequest, ServiceResponse, Transform},
 };
-use cosmian_kms_access::audit::AuditEventDraft;
+use cosmian_kms_access::audit::{AuditEventDraft, AuditResult};
 use futures::{
     Future,
     future::{Ready, ok},
 };
+use ipnet::IpNet;
 use time::OffsetDateTime;
+use uuid::Uuid;
 
 use crate::{
     core::audit::{AuditFileStore, make_failure_draft, make_success_draft},
@@ -68,15 +87,22 @@ const UNAUTHENTICATED: &str = "unauthenticated";
 #[derive(Clone)]
 pub(crate) struct AuditMiddleware {
     store: Option<AuditFileStore>,
+    /// Only used when parsing `X-Forwarded-For`. Empty means always use peer address.
+    trusted_proxies: Vec<IpNet>,
 }
 
 impl AuditMiddleware {
     /// Creates a new `AuditMiddleware`.
     ///
     /// When `store` is `None` the middleware is a no-op pass-through.
+    /// `trusted_proxies` is the list of CIDR ranges whose `X-Forwarded-For` headers
+    /// are trusted; an empty list disables XFF processing entirely.
     #[must_use]
-    pub(crate) const fn new(store: Option<AuditFileStore>) -> Self {
-        Self { store }
+    pub(crate) const fn new(store: Option<AuditFileStore>, trusted_proxies: Vec<IpNet>) -> Self {
+        Self {
+            store,
+            trusted_proxies,
+        }
     }
 }
 
@@ -96,6 +122,7 @@ where
         ok(AuditService {
             service: Rc::new(service),
             store: self.store.clone(),
+            trusted_proxies: self.trusted_proxies.clone(),
         })
     }
 }
@@ -103,6 +130,7 @@ where
 pub(crate) struct AuditService<S> {
     service: Rc<S>,
     store: Option<AuditFileStore>,
+    trusted_proxies: Vec<IpNet>,
 }
 
 impl<S, B> Service<ServiceRequest> for AuditService<S>
@@ -132,7 +160,7 @@ where
         };
 
         let operation = extract_operation(req.path());
-        let client_ip = extract_client_ip(&req);
+        let client_ip = extract_client_ip(&req, &self.trusted_proxies);
 
         let user = req
             .extensions()
@@ -148,6 +176,7 @@ where
 
             let duration_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
             let status = res.status();
+            let request_id = Uuid::new_v4();
 
             let final_user = res
                 .request()
@@ -155,6 +184,48 @@ where
                 .get::<AuthenticatedUser>()
                 .map_or(user, |u| u.username.clone());
 
+            // Batch path: fan out one draft per BatchItem
+            let batch_drafts: Option<Vec<AuditEventDraft>> = res
+                .request()
+                .extensions()
+                .get::<KmipBatchOperations>()
+                .map(|batch_ops| {
+                    batch_ops
+                        .0
+                        .iter()
+                        .map(|ctx| {
+                            let item_result = ctx.result.clone().unwrap_or_else(|| {
+                                if status.is_success() || status.is_redirection() {
+                                    AuditResult::Success
+                                } else {
+                                    AuditResult::Failure(format!(
+                                        "{} {}",
+                                        status.as_u16(),
+                                        status.canonical_reason().unwrap_or("Unknown")
+                                    ))
+                                }
+                            });
+                            AuditEventDraft {
+                                timestamp,
+                                operation: ctx.operation.clone(),
+                                user: final_user.clone(),
+                                object_uid: ctx.object_uid.clone(),
+                                algorithm: ctx.algorithm.clone(),
+                                client_ip: client_ip.clone(),
+                                result: item_result,
+                                duration_ms,
+                                request_id: Some(request_id),
+                            }
+                        })
+                        .collect()
+                });
+
+            if let Some(drafts) = batch_drafts {
+                store.enqueue(drafts);
+                return Ok(res.map_into_left_body());
+            }
+
+            // Single-op path
             let final_operation = res
                 .request()
                 .extensions()
@@ -173,7 +244,7 @@ where
                 .get::<KmipAlgorithm>()
                 .map(|k| k.0.clone());
 
-            let draft: AuditEventDraft = if status.is_success() || status.is_redirection() {
+            let mut draft: AuditEventDraft = if status.is_success() || status.is_redirection() {
                 make_success_draft(
                     timestamp,
                     final_operation,
@@ -200,8 +271,9 @@ where
                     reason,
                 )
             };
+            draft.request_id = Some(request_id);
 
-            store.enqueue(draft);
+            store.enqueue(std::iter::once(draft));
 
             Ok(res.map_into_left_body())
         })
@@ -222,24 +294,37 @@ fn extract_operation(path: &str) -> String {
     }
 }
 
-/// Extracts the client IP from the `X-Forwarded-For` header or the peer address.
-fn extract_client_ip(req: &ServiceRequest) -> Option<String> {
-    // TODO: XFF header can be spoofed by clients when there is no trusted reverse
-    //       proxy in front of the KMS; validate against an IP allowlist in production.
-    if let Some(xff) = req.headers().get("x-forwarded-for") {
-        if let Ok(val) = xff.to_str() {
-            if let Some(ip) = val.split(',').next() {
-                let ip = ip.trim();
-                if !ip.is_empty() {
-                    return Some(ip.to_owned());
+/// Extracts the client IP address.
+///
+/// The `X-Forwarded-For` header is only trusted when the direct TCP peer address
+/// falls within one of the `trusted_proxies` CIDR ranges.  If the peer is not a
+/// trusted proxy, or if `trusted_proxies` is empty, the peer address is used
+/// directly — preventing clients from spoofing their apparent IP.
+fn extract_client_ip(req: &ServiceRequest, trusted_proxies: &[IpNet]) -> Option<String> {
+    let peer_ip = req.peer_addr().map(|a| a.ip());
+
+    let peer_is_trusted = peer_ip
+        .as_ref()
+        .is_some_and(|ip| trusted_proxies.iter().any(|cidr| cidr.contains(ip)));
+
+    if peer_is_trusted {
+        if let Some(xff) = req.headers().get("x-forwarded-for") {
+            if let Ok(val) = xff.to_str() {
+                if let Some(ip) = val.split(',').next() {
+                    let ip = ip.trim();
+                    if !ip.is_empty() {
+                        return Some(ip.to_owned());
+                    }
                 }
             }
         }
     }
-    req.peer_addr().map(|addr| addr.ip().to_string())
+
+    peer_ip.map(|ip| ip.to_string())
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 
@@ -342,5 +427,68 @@ mod tests {
             &draft.result,
             AuditResult::Failure(reason) if reason == "401 Unauthorized"
         ));
+    }
+
+    // ── extract_client_ip tests ──────────────────────────────────────────────
+
+    /// Helper: build a minimal `ServiceRequest` with a given peer address and
+    /// optional `X-Forwarded-For` header.  Uses `actix_web::test::TestRequest`.
+    fn make_request(peer: &str, xff: Option<&str>) -> actix_web::test::TestRequest {
+        let mut req = actix_web::test::TestRequest::default().peer_addr(peer.parse().unwrap());
+        if let Some(v) = xff {
+            req = req.insert_header(("x-forwarded-for", v));
+        }
+        req
+    }
+
+    #[test]
+    fn xff_ignored_when_no_trusted_proxies() {
+        let req = make_request("1.2.3.4:9000", Some("10.0.0.1")).to_srv_request();
+        let ip = extract_client_ip(&req, &[]);
+        assert_eq!(ip.as_deref(), Some("1.2.3.4"), "peer IP used, XFF ignored");
+    }
+
+    #[test]
+    fn xff_ignored_when_peer_not_in_trusted_cidr() {
+        let cidrs: Vec<IpNet> = vec!["10.0.0.0/8".parse().unwrap()];
+        let req = make_request("1.2.3.4:9000", Some("192.168.1.1")).to_srv_request();
+        let ip = extract_client_ip(&req, &cidrs);
+        assert_eq!(
+            ip.as_deref(),
+            Some("1.2.3.4"),
+            "peer is not in CIDR, XFF ignored"
+        );
+    }
+
+    #[test]
+    fn xff_used_when_peer_in_trusted_cidr() {
+        let cidrs: Vec<IpNet> = vec!["10.0.0.0/8".parse().unwrap()];
+        let req = make_request("10.0.0.1:9000", Some("203.0.113.5")).to_srv_request();
+        let ip = extract_client_ip(&req, &cidrs);
+        assert_eq!(
+            ip.as_deref(),
+            Some("203.0.113.5"),
+            "peer in CIDR, XFF first IP used"
+        );
+    }
+
+    #[test]
+    fn xff_first_ip_taken_from_comma_list() {
+        let cidrs: Vec<IpNet> = vec!["10.0.0.0/8".parse().unwrap()];
+        let req = make_request("10.0.0.2:9000", Some("203.0.113.5, 10.0.0.1")).to_srv_request();
+        let ip = extract_client_ip(&req, &cidrs);
+        assert_eq!(ip.as_deref(), Some("203.0.113.5"), "first XFF entry used");
+    }
+
+    #[test]
+    fn xff_absent_with_trusted_proxy_falls_back_to_peer() {
+        let cidrs: Vec<IpNet> = vec!["10.0.0.0/8".parse().unwrap()];
+        let req = make_request("10.0.0.1:9000", None).to_srv_request();
+        let ip = extract_client_ip(&req, &cidrs);
+        assert_eq!(
+            ip.as_deref(),
+            Some("10.0.0.1"),
+            "no XFF header, peer IP used"
+        );
     }
 }

--- a/crate/server/src/middlewares/audit.rs
+++ b/crate/server/src/middlewares/audit.rs
@@ -57,6 +57,7 @@ pub(crate) struct BatchItemAuditContext {
 pub(crate) struct KmipBatchOperations(pub Vec<BatchItemAuditContext>);
 
 use std::{
+    net::IpAddr,
     pin::Pin,
     rc::Rc,
     task::{Context, Poll},
@@ -162,11 +163,6 @@ where
         let operation = extract_operation(req.path());
         let client_ip = extract_client_ip(&req, &self.trusted_proxies);
 
-        let user = req
-            .extensions()
-            .get::<AuthenticatedUser>()
-            .map_or_else(|| UNAUTHENTICATED.to_owned(), |u| u.username.clone());
-
         let start = Instant::now();
         let timestamp = OffsetDateTime::now_utc();
         let svc = self.service.clone();
@@ -178,11 +174,13 @@ where
             let status = res.status();
             let request_id = Uuid::new_v4();
 
+            // AuditMiddleware runs outside the auth middlewares, so the user is only
+            // available in the request extensions after `svc.call` returns.
             let final_user = res
                 .request()
                 .extensions()
                 .get::<AuthenticatedUser>()
-                .map_or(user, |u| u.username.clone());
+                .map_or_else(|| UNAUTHENTICATED.to_owned(), |u| u.username.clone());
 
             // Batch path: fan out one draft per BatchItem
             let batch_drafts: Option<Vec<AuditEventDraft>> = res
@@ -311,9 +309,10 @@ fn extract_client_ip(req: &ServiceRequest, trusted_proxies: &[IpNet]) -> Option<
         if let Some(xff) = req.headers().get("x-forwarded-for") {
             if let Ok(val) = xff.to_str() {
                 if let Some(ip) = val.split(',').next() {
-                    let ip = ip.trim();
-                    if !ip.is_empty() {
-                        return Some(ip.to_owned());
+                    // Only trust a syntactically valid IP; otherwise fall back to the
+                    // peer address so garbage headers never reach the audit log.
+                    if let Ok(parsed) = ip.trim().parse::<IpAddr>() {
+                        return Some(parsed.to_string());
                     }
                 }
             }

--- a/crate/server/src/middlewares/jwt/jwt_config.rs
+++ b/crate/server/src/middlewares/jwt/jwt_config.rs
@@ -311,19 +311,19 @@ mod tests {
             ALLOWED_JWT_ALGORITHMS.contains(&Algorithm::RS256),
             "RS256 must be in the allowlist"
         );
-        assert!(check_alg(Algorithm::RS256).is_ok());
+        check_alg(Algorithm::RS256).unwrap()
     }
 
     #[test]
     fn a05_es256_is_accepted() {
         assert!(ALLOWED_JWT_ALGORITHMS.contains(&Algorithm::ES256));
-        assert!(check_alg(Algorithm::ES256).is_ok());
+        check_alg(Algorithm::ES256).unwrap()
     }
 
     #[test]
     fn a06_ps256_is_accepted() {
         assert!(ALLOWED_JWT_ALGORITHMS.contains(&Algorithm::PS256));
-        assert!(check_alg(Algorithm::PS256).is_ok());
+        check_alg(Algorithm::PS256).unwrap()
     }
 
     /// Full coverage: every algorithm in the allowlist must be accepted.

--- a/crate/server/src/middlewares/jwt/jwt_config.rs
+++ b/crate/server/src/middlewares/jwt/jwt_config.rs
@@ -311,19 +311,19 @@ mod tests {
             ALLOWED_JWT_ALGORITHMS.contains(&Algorithm::RS256),
             "RS256 must be in the allowlist"
         );
-        check_alg(Algorithm::RS256).unwrap()
+        assert!(check_alg(Algorithm::RS256).is_ok());
     }
 
     #[test]
     fn a05_es256_is_accepted() {
         assert!(ALLOWED_JWT_ALGORITHMS.contains(&Algorithm::ES256));
-        check_alg(Algorithm::ES256).unwrap()
+        assert!(check_alg(Algorithm::ES256).is_ok());
     }
 
     #[test]
     fn a06_ps256_is_accepted() {
         assert!(ALLOWED_JWT_ALGORITHMS.contains(&Algorithm::PS256));
-        check_alg(Algorithm::PS256).unwrap()
+        assert!(check_alg(Algorithm::PS256).is_ok());
     }
 
     /// Full coverage: every algorithm in the allowlist must be accepted.
@@ -339,6 +339,7 @@ mod tests {
 
     /// Error message quality: rejection must mention "not permitted".
     #[test]
+    #[allow(clippy::unwrap_used)]
     fn rejection_error_message_quality() {
         let result = check_alg(Algorithm::HS256);
         assert!(result.is_err());

--- a/crate/server/src/middlewares/mod.rs
+++ b/crate/server/src/middlewares/mod.rs
@@ -1,3 +1,6 @@
+mod audit;
+pub(crate) use audit::AuditMiddleware;
+
 mod tls_auth;
 pub(crate) use tls_auth::{extract_peer_certificate, tls_auth_fn};
 

--- a/crate/server/src/middlewares/mod.rs
+++ b/crate/server/src/middlewares/mod.rs
@@ -93,3 +93,9 @@ pub(crate) struct AuthenticatedUser {
     /// Which authentication method was used
     pub auth_method: AuthMethod,
 }
+
+/// KMIP-specific operation name injected by the KMIP route handlers
+/// so the audit middleware records the exact operation ("Encrypt", "Create", …)
+/// instead of the coarse path-derived grouping ("KMIP").
+#[derive(Debug, Clone)]
+pub(crate) struct KmipOperationName(pub String);

--- a/crate/server/src/middlewares/mod.rs
+++ b/crate/server/src/middlewares/mod.rs
@@ -1,5 +1,8 @@
 mod audit;
-pub(crate) use audit::{AuditMiddleware, KmipAlgorithm, KmipObjectUid, KmipOperationName};
+pub(crate) use audit::{
+    AuditMiddleware, BatchItemAuditContext, KmipAlgorithm, KmipBatchOperations, KmipObjectUid,
+    KmipOperationName,
+};
 
 mod tls_auth;
 pub(crate) use tls_auth::{extract_peer_certificate, tls_auth_fn};

--- a/crate/server/src/middlewares/mod.rs
+++ b/crate/server/src/middlewares/mod.rs
@@ -1,5 +1,5 @@
 mod audit;
-pub(crate) use audit::AuditMiddleware;
+pub(crate) use audit::{AuditMiddleware, KmipAlgorithm, KmipObjectUid, KmipOperationName};
 
 mod tls_auth;
 pub(crate) use tls_auth::{extract_peer_certificate, tls_auth_fn};
@@ -93,9 +93,3 @@ pub(crate) struct AuthenticatedUser {
     /// Which authentication method was used
     pub auth_method: AuthMethod,
 }
-
-/// KMIP-specific operation name injected by the KMIP route handlers
-/// so the audit middleware records the exact operation ("Encrypt", "Create", …)
-/// instead of the coarse path-derived grouping ("KMIP").
-#[derive(Debug, Clone)]
-pub(crate) struct KmipOperationName(pub String);

--- a/crate/server/src/routes/kmip.rs
+++ b/crate/server/src/routes/kmip.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use actix_web::{
-    HttpRequest, HttpResponse,
+    HttpMessage, HttpRequest, HttpResponse,
     http::header::CONTENT_TYPE,
     post,
     web::{Bytes, Data},
@@ -30,8 +30,45 @@ use crate::{
         operations::{dispatch, message},
     },
     error::KmsError,
+    middlewares::KmipOperationName,
     result::KResult,
 };
+
+/// Extracts the specific KMIP operation name from a TTLV for audit purposes.
+///
+/// * Single-operation requests (e.g. `"Encrypt"`, `"Create"`): returns `ttlv.tag`.
+/// * `RequestMessage` (batch): returns all `BatchItem` operation names joined with `+`
+///   (e.g. `"Create+Encrypt+Destroy"`), or `"Message"` if none can be found.
+fn extract_kmip_op_from_ttlv(ttlv: &TTLV) -> String {
+    use cosmian_kms_server_database::reexport::cosmian_kmip::ttlv::TTLValue;
+
+    if ttlv.tag != "RequestMessage" {
+        return ttlv.tag.clone();
+    }
+    if let TTLValue::Structure(items) = &ttlv.value {
+        let ops: Vec<String> = items
+            .iter()
+            .filter(|item| item.tag == "BatchItem")
+            .filter_map(|item| {
+                if let TTLValue::Structure(fields) = &item.value {
+                    fields.iter().find(|f| f.tag == "Operation").and_then(|f| {
+                        if let TTLValue::Enumeration(ev) = &f.value {
+                            Some(ev.name.clone())
+                        } else {
+                            None
+                        }
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect();
+        if !ops.is_empty() {
+            return ops.join("+"); // TODO: this is not standard, but it will be worked on in the future
+        }
+    }
+    "Message".to_owned()
+}
 
 /// When an Error occurs and generating an Error Response message fails, this message is sent
 /// with "Unknown Error" as the error message
@@ -158,6 +195,11 @@ pub(crate) async fn kmip_2_1_json(
     let auth_method = kms.get_auth_method(&req_http);
     debug!(target: "kmip", user=user, ?auth_method, tag=ttlv.tag.as_str(), "POST /kmip/2_1. Request: {:?} {}", ttlv.tag.as_str(), user);
 
+    // Inject exact operation name for the audit middleware
+    req_http
+        .extensions_mut()
+        .insert(KmipOperationName(extract_kmip_op_from_ttlv(&ttlv)));
+
     let ttlv = Box::pin(handle_ttlv(&kms, ttlv, &user, 2, 1)).await?;
 
     // Pre-allocate buffer to avoid repeated reallocations during JSON serialization.
@@ -270,6 +312,11 @@ async fn kmip_json_inner(req_http: HttpRequest, body: Bytes, kms: Data<Arc<KMS>>
         "POST /kmip {}.{} JSON. Request: {:?} {}", major ,minor, ttlv.tag.as_str(), user
     );
 
+    // Inject exact operation name for the audit middleware
+    req_http
+        .extensions_mut()
+        .insert(KmipOperationName(extract_kmip_op_from_ttlv(&ttlv)));
+
     if (major == 2 && minor == 1) || (major == 1 && minor == 4) {
         let span = tracing::info_span!("kmip", user = user.as_str(), tag = ttlv.tag.as_str());
         handle_ttlv(&kms, ttlv, &user, major, minor)
@@ -290,6 +337,22 @@ pub(crate) async fn kmip_binary(
 ) -> HttpResponse {
     // Recover the user from the request
     let user = kms.get_user(&req_http);
+
+    // Inject exact operation name for the audit middleware by peeking at the TTLV.
+    // Note: handle_ttlv_bytes re-parses internally; the peek here is intentionally
+    // lightweight and only used for audit context.
+    if let Ok((major, _minor)) = TTLV::find_version(body.as_ref()) {
+        let flavor = if major == 1 {
+            KmipFlavor::Kmip1
+        } else {
+            KmipFlavor::Kmip2
+        };
+        if let Ok(ttlv) = TTLV::from_bytes(body.as_ref(), flavor) {
+            req_http
+                .extensions_mut()
+                .insert(KmipOperationName(extract_kmip_op_from_ttlv(&ttlv)));
+        }
+    }
 
     // Handle the TTLV bytes request
     let response_bytes = handle_ttlv_bytes(&user, body.as_ref(), &kms).await;

--- a/crate/server/src/routes/kmip/audit.rs
+++ b/crate/server/src/routes/kmip/audit.rs
@@ -12,42 +12,59 @@
 // never a panic. A failure here affects only the audit record, not the KMIP response.
 
 use actix_web::{HttpMessage, HttpRequest};
+use cosmian_kms_access::audit::AuditResult;
 use cosmian_kms_server_database::reexport::cosmian_kmip::ttlv::{TTLV, TTLValue};
 
-use crate::middlewares::{KmipAlgorithm, KmipObjectUid, KmipOperationName};
+use crate::middlewares::{
+    BatchItemAuditContext, KmipAlgorithm, KmipBatchOperations, KmipObjectUid, KmipOperationName,
+};
 
 /// Extracts the specific KMIP operation name from a TTLV for audit purposes.
 ///
 /// * Single-operation requests (e.g. `"Encrypt"`, `"Create"`): returns `ttlv.tag`.
-/// * `RequestMessage` (batch): returns all `BatchItem` operation names joined with `+`
-///   (e.g. `"Create+Encrypt+Destroy"`), or `"Message"` if none can be found.
+/// * `RequestMessage` (batch): returns `"RequestMessage"` — callers that need
+///   per-item operation names should use `extract_batch_audit_contexts` instead.
 pub(super) fn extract_kmip_op_from_ttlv(ttlv: &TTLV) -> String {
-    if ttlv.tag != "RequestMessage" {
-        return ttlv.tag.clone();
-    }
-    if let TTLValue::Structure(items) = &ttlv.value {
-        let ops: Vec<String> = items
-            .iter()
-            .filter(|item| item.tag == "BatchItem")
-            .filter_map(|item| {
-                if let TTLValue::Structure(fields) = &item.value {
-                    fields.iter().find(|f| f.tag == "Operation").and_then(|f| {
-                        if let TTLValue::Enumeration(ev) = &f.value {
-                            Some(ev.name.clone())
-                        } else {
-                            None
-                        }
-                    })
+    ttlv.tag.clone()
+}
+
+/// Extracts per-`BatchItem` audit context from a `RequestMessage` TTLV.
+///
+/// For each `BatchItem` in the message, extracts:
+/// * `operation` — the KMIP operation enum name (e.g. `"Create"`, `"Locate"`)
+/// * `object_uid` — `UniqueIdentifier` direct child (absent for Create/CreateKeyPair)
+/// * `algorithm` — `CryptographicAlgorithm` from `Attributes` or `CryptographicParameters`
+///
+/// Infallible: missing or unexpected structure yields `None` fields, never a panic.
+/// `result` is `None` until backfilled by `inject_batch_response_contexts`.
+pub(super) fn extract_batch_audit_contexts(ttlv: &TTLV) -> Vec<BatchItemAuditContext> {
+    let TTLValue::Structure(items) = &ttlv.value else {
+        return vec![];
+    };
+    items
+        .iter()
+        .filter(|item| item.tag == "BatchItem")
+        .filter_map(|item| {
+            let TTLValue::Structure(fields) = &item.value else {
+                return None;
+            };
+            let op_name = fields.iter().find(|f| f.tag == "Operation").and_then(|f| {
+                if let TTLValue::Enumeration(ev) = &f.value {
+                    Some(ev.name.clone())
                 } else {
                     None
                 }
+            })?;
+            let object_uid = extract_object_uid(item, &op_name, false);
+            let algorithm = extract_algorithm(item, &op_name);
+            Some(BatchItemAuditContext {
+                operation: op_name,
+                object_uid,
+                algorithm,
+                result: None,
             })
-            .collect();
-        if !ops.is_empty() {
-            return ops.join("+"); // TODO: this is not standard, but it will be worked on in the future
-        }
-    }
-    "Message".to_owned()
+        })
+        .collect()
 }
 
 /// Depth-first search for the first `TTLV` node with the given tag.
@@ -152,10 +169,20 @@ fn extract_algorithm(ttlv: &TTLV, op_name: &str) -> Option<String> {
     }
 }
 
-/// Injects `KmipOperationName`, `KmipObjectUid`, and `KmipAlgorithm` into the
-/// request extensions for the audit middleware. Returns the operation name.
+/// Injects audit extensions into the request.
+///
+/// * **Batch** (`RequestMessage`): injects `KmipBatchOperations` with one entry per
+///   `BatchItem`. The middleware fans these out into separate `AuditEventDraft`s.
+/// * **Single-op**: injects `KmipOperationName`, `KmipObjectUid`, `KmipAlgorithm` as before.
+///
+/// Returns the operation name (tag) for use by `inject_response_uid`.
 /// `RefMut` is dropped on return — safe to call before `.await`.
 pub(super) fn inject_audit_request(req: &HttpRequest, ttlv: &TTLV) -> String {
+    if ttlv.tag == "RequestMessage" {
+        let contexts = extract_batch_audit_contexts(ttlv);
+        req.extensions_mut().insert(KmipBatchOperations(contexts));
+        return "RequestMessage".to_owned();
+    }
     let op_name = extract_kmip_op_from_ttlv(ttlv);
     let mut ext = req.extensions_mut();
     ext.insert(KmipOperationName(op_name.clone()));
@@ -170,9 +197,94 @@ pub(super) fn inject_audit_request(req: &HttpRequest, ttlv: &TTLV) -> String {
 
 /// Backfills `KmipObjectUid` from the response TTLV for `Create` / `CreateKeyPair`,
 /// where the UID is server-generated and absent from the request.
+///
+/// For **batch** requests (`KmipBatchOperations` present), iterates the `BatchItem`
+/// children of the `ResponseMessage` and per-item backfills:
+/// * `object_uid` for `Create`/`CreateKeyPair` items (server-generated UID)
+/// * `result` from the item's `ResultStatus`/`ResultReason`
+///
+/// Correlation is by position (index). When `BatchErrorContinuationOption` is used,
+/// the server may omit failed items from the response — in that case trailing items
+/// will not be backfilled. `UniqueBatchItemID` correlation is a future improvement.
 pub(super) fn inject_response_uid(req: &HttpRequest, response_ttlv: &TTLV, op_name: &str) {
-    if !op_name.contains('+')
-        && (op_name == "Create" || op_name == "CreateKeyPair")
+    // Batch path
+    if op_name == "RequestMessage" {
+        let mut ext = req.extensions_mut();
+        let Some(batch_ops) = ext.get_mut::<KmipBatchOperations>() else {
+            return;
+        };
+        let response_items = match &response_ttlv.value {
+            TTLValue::Structure(children) => children
+                .iter()
+                .filter(|c| c.tag == "BatchItem")
+                .collect::<Vec<_>>(),
+            _ => return,
+        };
+        for (ctx, resp_item) in batch_ops.0.iter_mut().zip(response_items.iter()) {
+            let TTLValue::Structure(fields) = &resp_item.value else {
+                continue;
+            };
+            // Backfill UID for Create/CreateKeyPair from response
+            if ctx.object_uid.is_none()
+                && (ctx.operation == "Create" || ctx.operation == "CreateKeyPair")
+            {
+                ctx.object_uid = find_ttlv_recursive(resp_item, "UniqueIdentifier").and_then(|t| {
+                    if let TTLValue::TextString(s) = &t.value {
+                        Some(s.clone())
+                    } else {
+                        None
+                    }
+                });
+            }
+            // Backfill per-item result from ResultStatus/ResultReason
+            let result_status = fields
+                .iter()
+                .find(|f| f.tag == "ResultStatus")
+                .and_then(|f| {
+                    if let TTLValue::Enumeration(ev) = &f.value {
+                        Some(ev.name.as_str())
+                    } else {
+                        None
+                    }
+                });
+            ctx.result = match result_status {
+                Some("Success" | "OperationPending" | "OperationUndone") => {
+                    Some(AuditResult::Success)
+                }
+                Some(status) => {
+                    let reason = fields
+                        .iter()
+                        .find(|f| f.tag == "ResultReason")
+                        .and_then(|f| {
+                            if let TTLValue::Enumeration(ev) = &f.value {
+                                Some(ev.name.clone())
+                            } else {
+                                None
+                            }
+                        })
+                        .or_else(|| {
+                            fields
+                                .iter()
+                                .find(|f| f.tag == "ResultMessage")
+                                .and_then(|f| {
+                                    if let TTLValue::TextString(s) = &f.value {
+                                        Some(s.clone())
+                                    } else {
+                                        None
+                                    }
+                                })
+                        })
+                        .unwrap_or_else(|| status.to_owned());
+                    Some(AuditResult::Failure(reason))
+                }
+                None => None,
+            };
+        }
+        return;
+    }
+
+    // Single-op path — backfill UID for Create/CreateKeyPair
+    if (op_name == "Create" || op_name == "CreateKeyPair")
         && req.extensions().get::<KmipObjectUid>().is_none()
     {
         if let Some(uid) = extract_object_uid(response_ttlv, op_name, true) {
@@ -182,6 +294,7 @@ pub(super) fn inject_response_uid(req: &HttpRequest, response_ttlv: &TTLV, op_na
 }
 
 #[cfg(test)]
+#[allow(clippy::indexing_slicing)]
 mod extraction_tests {
     use cosmian_kms_server_database::reexport::cosmian_kmip::ttlv::{
         KmipEnumerationVariant, TTLV, TTLValue,
@@ -311,5 +424,55 @@ mod extraction_tests {
         );
         let found = find_ttlv_recursive(&ttlv, "Target");
         assert!(matches!(found, Some(node) if node.tag == "Target"));
+    }
+
+    /// Batch with two items → two contexts with correct operation names.
+    #[test]
+    fn extract_batch_contexts_two_items() {
+        use super::extract_batch_audit_contexts;
+        let batch = structure(
+            "RequestMessage",
+            vec![
+                structure(
+                    "BatchItem",
+                    vec![
+                        enumv("Operation", "Create"),
+                        structure("Attributes", vec![]),
+                    ],
+                ),
+                structure("BatchItem", vec![enumv("Operation", "Locate")]),
+            ],
+        );
+        let contexts = extract_batch_audit_contexts(&batch);
+        assert_eq!(contexts.len(), 2);
+        assert_eq!(contexts[0].operation, "Create");
+        assert_eq!(contexts[1].operation, "Locate");
+    }
+
+    /// `BatchItem` with a direct `UniqueIdentifier` → context has `object_uid`.
+    #[test]
+    fn extract_batch_contexts_includes_uid() {
+        use super::extract_batch_audit_contexts;
+        let batch = structure(
+            "RequestMessage",
+            vec![structure(
+                "BatchItem",
+                vec![
+                    enumv("Operation", "Encrypt"),
+                    text("UniqueIdentifier", "key-abc"),
+                ],
+            )],
+        );
+        let contexts = extract_batch_audit_contexts(&batch);
+        assert_eq!(contexts.len(), 1);
+        assert_eq!(contexts[0].object_uid.as_deref(), Some("key-abc"));
+    }
+
+    /// `RequestMessage` with no `BatchItem` children → empty vec.
+    #[test]
+    fn extract_batch_contexts_empty_batch() {
+        use super::extract_batch_audit_contexts;
+        let batch = structure("RequestMessage", vec![]);
+        assert!(extract_batch_audit_contexts(&batch).is_empty());
     }
 }

--- a/crate/server/src/routes/kmip/audit.rs
+++ b/crate/server/src/routes/kmip/audit.rs
@@ -13,11 +13,43 @@
 
 use actix_web::{HttpMessage, HttpRequest};
 use cosmian_kms_access::audit::AuditResult;
-use cosmian_kms_server_database::reexport::cosmian_kmip::ttlv::{TTLV, TTLValue};
+use cosmian_kms_server_database::reexport::cosmian_kmip::{
+    kmip_0::kmip_types::{ErrorReason, ResultStatusEnumeration},
+    kmip_2_1::kmip_types::{CryptographicAlgorithm, OperationEnumeration},
+    ttlv::{TTLV, TTLValue},
+};
 
 use crate::middlewares::{
     BatchItemAuditContext, KmipAlgorithm, KmipBatchOperations, KmipObjectUid, KmipOperationName,
 };
+
+/// Reads the variant name of an enumeration field, tolerant of both TTLV wire encodings.
+///
+/// JSON-decoded TTLVs carry the variant name in `KmipEnumerationVariant::name`, but
+/// binary-decoded TTLVs carry only the numeric `value` (the name is empty — the wire
+/// format never transmits it). In the binary case the code is resolved through the
+/// field's *typed* enum via `resolve` (e.g. `OperationEnumeration::from_repr`). This is
+/// unambiguous because the caller statically knows which enum the field holds, so there
+/// is no cross-enum code collision (unlike a global reverse table where, e.g., `Create`
+/// and `Certificate` share code `0x01`).
+fn enum_field_name(
+    fields: &[TTLV],
+    tag: &str,
+    resolve: impl Fn(u32) -> Option<&'static str>,
+) -> Option<String> {
+    let variant = fields.iter().find(|f| f.tag == tag).and_then(|f| {
+        if let TTLValue::Enumeration(ev) = &f.value {
+            Some(ev)
+        } else {
+            None
+        }
+    })?;
+    if variant.name.is_empty() {
+        resolve(variant.value).map(str::to_owned)
+    } else {
+        Some(variant.name.clone())
+    }
+}
 
 /// Extracts the specific KMIP operation name from a TTLV for audit purposes.
 ///
@@ -48,15 +80,15 @@ pub(super) fn extract_batch_audit_contexts(ttlv: &TTLV) -> Vec<BatchItemAuditCon
             let TTLValue::Structure(fields) = &item.value else {
                 return None;
             };
-            let op_name = fields.iter().find(|f| f.tag == "Operation").and_then(|f| {
-                if let TTLValue::Enumeration(ev) = &f.value {
-                    Some(ev.name.clone())
-                } else {
-                    None
-                }
+            let op_name = enum_field_name(fields, "Operation", |code| {
+                OperationEnumeration::from_repr(code).map(Into::into)
             })?;
-            let object_uid = extract_object_uid(item, &op_name, false);
-            let algorithm = extract_algorithm(item, &op_name);
+            // In a batch item the operation fields live under `RequestPayload`, so
+            // UID/algorithm extraction must descend into it rather than search the
+            // `BatchItem` directly (a single-op TTLV has them as direct children).
+            let payload = fields.iter().find(|f| f.tag == "RequestPayload");
+            let object_uid = payload.and_then(|p| extract_object_uid(p, &op_name, false));
+            let algorithm = payload.and_then(|p| extract_algorithm(p, &op_name));
             Some(BatchItemAuditContext {
                 operation: op_name,
                 object_uid,
@@ -128,7 +160,13 @@ fn extract_object_uid(ttlv: &TTLV, op_name: &str, is_response: bool) -> Option<S
 fn extract_algorithm(ttlv: &TTLV, op_name: &str) -> Option<String> {
     let enum_name = |t: &TTLV| {
         if let TTLValue::Enumeration(ev) = &t.value {
-            Some(ev.name.clone())
+            if ev.name.is_empty() {
+                // Binary TTLV carries only the numeric code; resolve via the typed enum.
+                CryptographicAlgorithm::from_repr(ev.value)
+                    .map(|a| <&'static str>::from(a).to_owned())
+            } else {
+                Some(ev.name.clone())
+            }
         } else {
             None
         }
@@ -237,44 +275,30 @@ pub(super) fn inject_response_uid(req: &HttpRequest, response_ttlv: &TTLV, op_na
                 });
             }
             // Backfill per-item result from ResultStatus/ResultReason
-            let result_status = fields
-                .iter()
-                .find(|f| f.tag == "ResultStatus")
-                .and_then(|f| {
-                    if let TTLValue::Enumeration(ev) = &f.value {
-                        Some(ev.name.as_str())
-                    } else {
-                        None
-                    }
-                });
-            ctx.result = match result_status {
+            let result_status = enum_field_name(fields, "ResultStatus", |code| {
+                ResultStatusEnumeration::from_repr(code).map(Into::into)
+            });
+            ctx.result = match result_status.as_deref() {
                 Some("Success" | "OperationPending" | "OperationUndone") => {
                     Some(AuditResult::Success)
                 }
                 Some(status) => {
-                    let reason = fields
-                        .iter()
-                        .find(|f| f.tag == "ResultReason")
-                        .and_then(|f| {
-                            if let TTLValue::Enumeration(ev) = &f.value {
-                                Some(ev.name.clone())
-                            } else {
-                                None
-                            }
-                        })
-                        .or_else(|| {
-                            fields
-                                .iter()
-                                .find(|f| f.tag == "ResultMessage")
-                                .and_then(|f| {
-                                    if let TTLValue::TextString(s) = &f.value {
-                                        Some(s.clone())
-                                    } else {
-                                        None
-                                    }
-                                })
-                        })
-                        .unwrap_or_else(|| status.to_owned());
+                    let reason = enum_field_name(fields, "ResultReason", |code| {
+                        ErrorReason::from_repr(code).map(Into::into)
+                    })
+                    .or_else(|| {
+                        fields
+                            .iter()
+                            .find(|f| f.tag == "ResultMessage")
+                            .and_then(|f| {
+                                if let TTLValue::TextString(s) = &f.value {
+                                    Some(s.clone())
+                                } else {
+                                    None
+                                }
+                            })
+                    })
+                    .unwrap_or_else(|| status.to_owned());
                     Some(AuditResult::Failure(reason))
                 }
                 None => None,

--- a/crate/server/src/routes/kmip/audit.rs
+++ b/crate/server/src/routes/kmip/audit.rs
@@ -473,7 +473,7 @@ mod extraction_tests {
         assert_eq!(contexts[1].operation, "Locate");
     }
 
-    /// `BatchItem` with a direct `UniqueIdentifier` → context has `object_uid`.
+    /// `BatchItem` with a `UniqueIdentifier` under `RequestPayload` → context has `object_uid`.
     #[test]
     fn extract_batch_contexts_includes_uid() {
         use super::extract_batch_audit_contexts;
@@ -483,7 +483,7 @@ mod extraction_tests {
                 "BatchItem",
                 vec![
                     enumv("Operation", "Encrypt"),
-                    text("UniqueIdentifier", "key-abc"),
+                    structure("RequestPayload", vec![text("UniqueIdentifier", "key-abc")]),
                 ],
             )],
         );

--- a/crate/server/src/routes/kmip/audit.rs
+++ b/crate/server/src/routes/kmip/audit.rs
@@ -1,0 +1,315 @@
+//! Audit-context extraction for KMIP route handlers.
+//!
+//! These functions peek at the raw TTLV *before* full deserialization and inject
+//! `KmipOperationName`, `KmipObjectUid`, and `KmipAlgorithm` into the Actix
+//! request extensions so the audit middleware can record them after dispatch.
+//!
+
+// Note: Infallibility
+//
+// All functions in this module are infallible: no `unwrap`, no `expect`, no `?`.
+// Missing or unexpected TTLV structure always yields `None` or a fallback string —
+// never a panic. A failure here affects only the audit record, not the KMIP response.
+
+use actix_web::{HttpMessage, HttpRequest};
+use cosmian_kms_server_database::reexport::cosmian_kmip::ttlv::{TTLV, TTLValue};
+
+use crate::middlewares::{KmipAlgorithm, KmipObjectUid, KmipOperationName};
+
+/// Extracts the specific KMIP operation name from a TTLV for audit purposes.
+///
+/// * Single-operation requests (e.g. `"Encrypt"`, `"Create"`): returns `ttlv.tag`.
+/// * `RequestMessage` (batch): returns all `BatchItem` operation names joined with `+`
+///   (e.g. `"Create+Encrypt+Destroy"`), or `"Message"` if none can be found.
+pub(super) fn extract_kmip_op_from_ttlv(ttlv: &TTLV) -> String {
+    if ttlv.tag != "RequestMessage" {
+        return ttlv.tag.clone();
+    }
+    if let TTLValue::Structure(items) = &ttlv.value {
+        let ops: Vec<String> = items
+            .iter()
+            .filter(|item| item.tag == "BatchItem")
+            .filter_map(|item| {
+                if let TTLValue::Structure(fields) = &item.value {
+                    fields.iter().find(|f| f.tag == "Operation").and_then(|f| {
+                        if let TTLValue::Enumeration(ev) = &f.value {
+                            Some(ev.name.clone())
+                        } else {
+                            None
+                        }
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect();
+        if !ops.is_empty() {
+            return ops.join("+"); // TODO: this is not standard, but it will be worked on in the future
+        }
+    }
+    "Message".to_owned()
+}
+
+/// Depth-first search for the first `TTLV` node with the given tag.
+/// Used for response-side extraction where the layout is well-defined.
+fn find_ttlv_recursive<'a>(ttlv: &'a TTLV, tag: &str) -> Option<&'a TTLV> {
+    if ttlv.tag == tag {
+        return Some(ttlv);
+    }
+    if let TTLValue::Structure(children) = &ttlv.value {
+        for child in children {
+            if let Some(found) = find_ttlv_recursive(child, tag) {
+                return Some(found);
+            }
+        }
+    }
+    None
+}
+
+/// Extracts the `UniqueIdentifier` for audit purposes from a single-operation TTLV.
+///
+/// * `is_response = false` — looks for `UniqueIdentifier` as a **direct child** of
+///   the operation node (avoids picking up nested UIDs from `Link` structures).
+/// * `is_response = true` — used for Create/CreateKeyPair where the server-generated
+///   UID only appears in the response TTLV; performs a recursive search.
+///
+/// Returns `None` for batch (`RequestMessage`) TTLVs; the caller must not pass those.
+fn extract_object_uid(ttlv: &TTLV, op_name: &str, is_response: bool) -> Option<String> {
+    let text_string = |t: &TTLV| {
+        if let TTLValue::TextString(s) = &t.value {
+            Some(s.clone())
+        } else {
+            None
+        }
+    };
+    match op_name {
+        op if op.contains('+') => None,
+        "Create" | "CreateKeyPair" if is_response => {
+            find_ttlv_recursive(ttlv, "UniqueIdentifier").and_then(text_string)
+        }
+        "Create" | "CreateKeyPair" => None,
+        _ => {
+            if let TTLValue::Structure(children) = &ttlv.value {
+                children
+                    .iter()
+                    .find(|c| c.tag == "UniqueIdentifier")
+                    .and_then(text_string)
+            } else {
+                None
+            }
+        }
+    }
+}
+
+/// Extracts the `CryptographicAlgorithm` for audit purposes from a single-operation TTLV.
+///
+/// * Create / `CreateKeyPair` / Register: algorithm is in `Attributes → CryptographicAlgorithm`.
+/// * Encrypt / Decrypt / MAC / Sign / Verify / `SignatureVerify`: algorithm is in
+///   `CryptographicParameters → CryptographicAlgorithm`.
+///
+/// Returns `None` for operations that carry no algorithm information or for batch TTLVs.
+fn extract_algorithm(ttlv: &TTLV, op_name: &str) -> Option<String> {
+    let enum_name = |t: &TTLV| {
+        if let TTLValue::Enumeration(ev) = &t.value {
+            Some(ev.name.clone())
+        } else {
+            None
+        }
+    };
+    let child_algo = |parent: &TTLV| -> Option<String> {
+        if let TTLValue::Structure(c) = &parent.value {
+            c.iter()
+                .find(|t| t.tag == "CryptographicAlgorithm")
+                .and_then(enum_name)
+        } else {
+            None
+        }
+    };
+
+    match op_name {
+        op if op.contains('+') => None,
+        "Create" | "CreateKeyPair" | "Register" => {
+            if let TTLValue::Structure(children) = &ttlv.value {
+                children
+                    .iter()
+                    .find(|c| c.tag == "Attributes")
+                    .and_then(child_algo)
+            } else {
+                None
+            }
+        }
+        "Encrypt" | "Decrypt" | "MAC" | "Sign" | "Verify" | "SignatureVerify" => {
+            if let TTLValue::Structure(children) = &ttlv.value {
+                children
+                    .iter()
+                    .find(|c| c.tag == "CryptographicParameters")
+                    .and_then(child_algo)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Injects `KmipOperationName`, `KmipObjectUid`, and `KmipAlgorithm` into the
+/// request extensions for the audit middleware. Returns the operation name.
+/// `RefMut` is dropped on return — safe to call before `.await`.
+pub(super) fn inject_audit_request(req: &HttpRequest, ttlv: &TTLV) -> String {
+    let op_name = extract_kmip_op_from_ttlv(ttlv);
+    let mut ext = req.extensions_mut();
+    ext.insert(KmipOperationName(op_name.clone()));
+    if let Some(uid) = extract_object_uid(ttlv, &op_name, false) {
+        ext.insert(KmipObjectUid(uid));
+    }
+    if let Some(algo) = extract_algorithm(ttlv, &op_name) {
+        ext.insert(KmipAlgorithm(algo));
+    }
+    op_name
+}
+
+/// Backfills `KmipObjectUid` from the response TTLV for `Create` / `CreateKeyPair`,
+/// where the UID is server-generated and absent from the request.
+pub(super) fn inject_response_uid(req: &HttpRequest, response_ttlv: &TTLV, op_name: &str) {
+    if !op_name.contains('+')
+        && (op_name == "Create" || op_name == "CreateKeyPair")
+        && req.extensions().get::<KmipObjectUid>().is_none()
+    {
+        if let Some(uid) = extract_object_uid(response_ttlv, op_name, true) {
+            req.extensions_mut().insert(KmipObjectUid(uid));
+        }
+    }
+}
+
+#[cfg(test)]
+mod extraction_tests {
+    use cosmian_kms_server_database::reexport::cosmian_kmip::ttlv::{
+        KmipEnumerationVariant, TTLV, TTLValue,
+    };
+
+    use super::{extract_algorithm, extract_object_uid, find_ttlv_recursive};
+
+    fn text(tag: &str, value: &str) -> TTLV {
+        TTLV {
+            tag: tag.to_owned(),
+            value: TTLValue::TextString(value.to_owned()),
+        }
+    }
+
+    fn enumv(tag: &str, name: &str) -> TTLV {
+        TTLV {
+            tag: tag.to_owned(),
+            value: TTLValue::Enumeration(KmipEnumerationVariant {
+                value: 0,
+                name: name.to_owned(),
+            }),
+        }
+    }
+
+    fn structure(tag: &str, children: Vec<TTLV>) -> TTLV {
+        TTLV {
+            tag: tag.to_owned(),
+            value: TTLValue::Structure(children),
+        }
+    }
+
+    /// Create request: no UID in request, algorithm extracted from Attributes.
+    #[test]
+    fn create_request_no_uid_has_algorithm() {
+        let ttlv = structure(
+            "Create",
+            vec![
+                enumv("ObjectType", "SymmetricKey"),
+                structure("Attributes", vec![enumv("CryptographicAlgorithm", "AES")]),
+            ],
+        );
+        assert_eq!(extract_object_uid(&ttlv, "Create", false), None);
+        assert_eq!(extract_algorithm(&ttlv, "Create").as_deref(), Some("AES"));
+    }
+
+    /// Encrypt request: UID from direct child, algorithm from `CryptographicParameters`.
+    #[test]
+    fn encrypt_request_extracts_uid_and_algorithm() {
+        let ttlv = structure(
+            "Encrypt",
+            vec![
+                text("UniqueIdentifier", "my-key-id"),
+                structure(
+                    "CryptographicParameters",
+                    vec![enumv("CryptographicAlgorithm", "AES")],
+                ),
+            ],
+        );
+        assert_eq!(
+            extract_object_uid(&ttlv, "Encrypt", false).as_deref(),
+            Some("my-key-id")
+        );
+        assert_eq!(extract_algorithm(&ttlv, "Encrypt").as_deref(), Some("AES"));
+    }
+
+    /// Get request: UID from direct child, no algorithm.
+    #[test]
+    fn get_request_extracts_uid_no_algorithm() {
+        let ttlv = structure("Get", vec![text("UniqueIdentifier", "key-abc")]);
+        assert_eq!(
+            extract_object_uid(&ttlv, "Get", false).as_deref(),
+            Some("key-abc")
+        );
+        assert_eq!(extract_algorithm(&ttlv, "Get"), None);
+    }
+
+    /// Create response: recursive search finds the server-generated UID.
+    #[test]
+    fn create_response_extracts_uid_recursively() {
+        let ttlv = structure(
+            "CreateResponse",
+            vec![
+                text("UniqueIdentifier", "server-gen-uid"),
+                enumv("ObjectType", "SymmetricKey"),
+            ],
+        );
+        assert_eq!(
+            extract_object_uid(&ttlv, "Create", true).as_deref(),
+            Some("server-gen-uid")
+        );
+    }
+
+    /// Batch op names ('+'-joined): both extractors return None.
+    #[test]
+    fn batch_op_name_returns_none() {
+        let ttlv = structure("RequestMessage", vec![text("UniqueIdentifier", "some-id")]);
+        assert_eq!(extract_object_uid(&ttlv, "Create+Encrypt", false), None);
+        assert_eq!(extract_algorithm(&ttlv, "Create+Encrypt"), None);
+    }
+
+    /// Regression: a UID nested inside a Link structure must NOT be returned
+    /// for a direct-child-only search (e.g. on a Get response containing a link).
+    #[test]
+    fn nested_link_uid_not_leaked() {
+        let ttlv = structure(
+            "GetResponse",
+            vec![structure(
+                "Attributes",
+                vec![structure(
+                    "Link",
+                    vec![text("UniqueIdentifier", "linked-key-id")],
+                )],
+            )],
+        );
+        assert_eq!(extract_object_uid(&ttlv, "GetResponse", false), None);
+    }
+
+    /// `find_ttlv_recursive`: basic depth-first traversal.
+    #[test]
+    fn recursive_find_traverses_deeply() {
+        let ttlv = structure(
+            "Root",
+            vec![structure(
+                "Level1",
+                vec![structure("Level2", vec![text("Target", "found")])],
+            )],
+        );
+        let found = find_ttlv_recursive(&ttlv, "Target");
+        assert!(matches!(found, Some(node) if node.tag == "Target"));
+    }
+}

--- a/crate/server/src/routes/kmip/handlers.rs
+++ b/crate/server/src/routes/kmip/handlers.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use actix_web::{
-    HttpMessage, HttpRequest, HttpResponse,
+    HttpRequest, HttpResponse,
     http::header::CONTENT_TYPE,
     post,
     web::{Bytes, Data},
@@ -30,45 +30,10 @@ use crate::{
         operations::{dispatch, message},
     },
     error::KmsError,
-    middlewares::KmipOperationName,
     result::KResult,
 };
 
-/// Extracts the specific KMIP operation name from a TTLV for audit purposes.
-///
-/// * Single-operation requests (e.g. `"Encrypt"`, `"Create"`): returns `ttlv.tag`.
-/// * `RequestMessage` (batch): returns all `BatchItem` operation names joined with `+`
-///   (e.g. `"Create+Encrypt+Destroy"`), or `"Message"` if none can be found.
-fn extract_kmip_op_from_ttlv(ttlv: &TTLV) -> String {
-    use cosmian_kms_server_database::reexport::cosmian_kmip::ttlv::TTLValue;
-
-    if ttlv.tag != "RequestMessage" {
-        return ttlv.tag.clone();
-    }
-    if let TTLValue::Structure(items) = &ttlv.value {
-        let ops: Vec<String> = items
-            .iter()
-            .filter(|item| item.tag == "BatchItem")
-            .filter_map(|item| {
-                if let TTLValue::Structure(fields) = &item.value {
-                    fields.iter().find(|f| f.tag == "Operation").and_then(|f| {
-                        if let TTLValue::Enumeration(ev) = &f.value {
-                            Some(ev.name.clone())
-                        } else {
-                            None
-                        }
-                    })
-                } else {
-                    None
-                }
-            })
-            .collect();
-        if !ops.is_empty() {
-            return ops.join("+"); // TODO: this is not standard, but it will be worked on in the future
-        }
-    }
-    "Message".to_owned()
-}
+use super::audit::{inject_audit_request, inject_response_uid};
 
 /// When an Error occurs and generating an Error Response message fails, this message is sent
 /// with "Unknown Error" as the error message
@@ -195,12 +160,11 @@ pub(crate) async fn kmip_2_1_json(
     let auth_method = kms.get_auth_method(&req_http);
     debug!(target: "kmip", user=user, ?auth_method, tag=ttlv.tag.as_str(), "POST /kmip/2_1. Request: {:?} {}", ttlv.tag.as_str(), user);
 
-    // Inject exact operation name for the audit middleware
-    req_http
-        .extensions_mut()
-        .insert(KmipOperationName(extract_kmip_op_from_ttlv(&ttlv)));
+    let op_name = inject_audit_request(&req_http, &ttlv);
 
     let ttlv = Box::pin(handle_ttlv(&kms, ttlv, &user, 2, 1)).await?;
+
+    inject_response_uid(&req_http, &ttlv, &op_name);
 
     // Pre-allocate buffer to avoid repeated reallocations during JSON serialization.
     // Typical KMIP responses are 300-800 bytes; 512 avoids reallocs for most responses.
@@ -294,7 +258,6 @@ pub(crate) async fn kmip_json(
 
 /// Handle KMIP requests with JSON content type
 async fn kmip_json_inner(req_http: HttpRequest, body: Bytes, kms: Data<Arc<KMS>>) -> KResult<TTLV> {
-    // Recover the user from the request
     let user = kms.get_user(&req_http);
 
     // Deserialize the body directly to TTLV (avoiding intermediate Vec + Value allocations)
@@ -302,7 +265,6 @@ async fn kmip_json_inner(req_http: HttpRequest, body: Bytes, kms: Data<Arc<KMS>>
         std::str::from_utf8(&body).map_err(|e| KmsError::InvalidRequest(e.to_string()))?;
     let ttlv: TTLV = serde_json::from_str(body_str)?;
 
-    // Check the KMIP version
     let (major, minor) = get_kmip_version(&ttlv)?;
 
     debug!(
@@ -312,16 +274,17 @@ async fn kmip_json_inner(req_http: HttpRequest, body: Bytes, kms: Data<Arc<KMS>>
         "POST /kmip {}.{} JSON. Request: {:?} {}", major ,minor, ttlv.tag.as_str(), user
     );
 
-    // Inject exact operation name for the audit middleware
-    req_http
-        .extensions_mut()
-        .insert(KmipOperationName(extract_kmip_op_from_ttlv(&ttlv)));
+    let op_name = inject_audit_request(&req_http, &ttlv);
 
     if (major == 2 && minor == 1) || (major == 1 && minor == 4) {
         let span = tracing::info_span!("kmip", user = user.as_str(), tag = ttlv.tag.as_str());
-        handle_ttlv(&kms, ttlv, &user, major, minor)
+        let response_ttlv = Box::pin(handle_ttlv(&kms, ttlv, &user, major, minor))
             .instrument(span)
-            .await
+            .await?;
+
+        inject_response_uid(&req_http, &response_ttlv, &op_name);
+
+        Ok(response_ttlv)
     } else {
         Err(KmsError::InvalidRequest(
             "The /kmip endpoint only accepts KMIP 2.1 or 1.4 requests".to_owned(),
@@ -335,12 +298,8 @@ pub(crate) async fn kmip_binary(
     body: Bytes,
     kms: Data<Arc<KMS>>,
 ) -> HttpResponse {
-    // Recover the user from the request
     let user = kms.get_user(&req_http);
 
-    // Inject exact operation name for the audit middleware by peeking at the TTLV.
-    // Note: handle_ttlv_bytes re-parses internally; the peek here is intentionally
-    // lightweight and only used for audit context.
     if let Ok((major, _minor)) = TTLV::find_version(body.as_ref()) {
         let flavor = if major == 1 {
             KmipFlavor::Kmip1
@@ -348,16 +307,12 @@ pub(crate) async fn kmip_binary(
             KmipFlavor::Kmip2
         };
         if let Ok(ttlv) = TTLV::from_bytes(body.as_ref(), flavor) {
-            req_http
-                .extensions_mut()
-                .insert(KmipOperationName(extract_kmip_op_from_ttlv(&ttlv)));
+            inject_audit_request(&req_http, &ttlv);
         }
     }
 
-    // Handle the TTLV bytes request
     let response_bytes = handle_ttlv_bytes(&user, body.as_ref(), &kms).await;
 
-    // Send the response
     HttpResponse::Ok()
         .content_type("application/octet-stream")
         .body(response_bytes)
@@ -376,12 +331,10 @@ pub(crate) async fn handle_ttlv_bytes(user: &str, ttlv_bytes: &[u8], kms: &Arc<K
         .unwrap_or_else(|e| {
             let response_message = invalid_response_message(major, minor, e.to_string());
             warn!(target: "kmip", "Failed to process request:\n{response_message}");
-            // convert to TTLV
             let response_ttlv = to_ttlv(&response_message).unwrap_or_else(|e| {
                 error!(target: "kmip", "Failed to convert response message to TTLV: {}", e);
                 error_response_ttlv(major, minor, e.to_string().as_str())
             });
-            // convert to bytes
             TTLV::to_bytes(&response_ttlv, KmipFlavor::Kmip2).unwrap_or_else(|e| {
                 error!(target: "kmip", "Failed to convert Response TTLV to bytes: {}: TTLV:\n{:#?}", e,response_ttlv);
                 TTLV_ERROR_RESPONSE.to_vec()
@@ -406,7 +359,6 @@ async fn handle_ttlv_bytes_inner(
         )));
     };
 
-    // log the request bytes
     debug!(
         target: "kmip",
         user=user,
@@ -414,7 +366,6 @@ async fn handle_ttlv_bytes_inner(
         hex::encode(ttlv_bytes)
     );
 
-    // parse the TTLV bytes
     let ttlv = TTLV::from_bytes(ttlv_bytes, kmip_flavor).context("Failed to parse TTLV")?;
     let tag = ttlv.tag.clone();
     debug!(
@@ -430,13 +381,11 @@ async fn handle_ttlv_bytes_inner(
         "Request TTLV: {ttlv:#?}"
     );
 
-    // parse the Request Message
     let mut request_message = from_ttlv::<RequestMessage>(ttlv)
         .map_err(|e| KmsError::InvalidRequest(format!("Failed to parse RequestMessage: {e}")))?;
 
     perform_request_tweaks(&mut request_message, major, minor);
 
-    // log the request
     trace!(
         target: "kmip",
         user=user,
@@ -446,10 +395,8 @@ async fn handle_ttlv_bytes_inner(
 
     let mut response_message = message(kms, request_message, user).await?;
 
-    // Perform 1.1 and 1.2 Response Tweaks to ensure compatibility
     perform_response_tweaks(&mut response_message, major, minor);
 
-    // log the response
     trace!(
         target: "kmip",
         user=user,
@@ -457,7 +404,6 @@ async fn handle_ttlv_bytes_inner(
         "Response Message: {response_message}"
     );
 
-    // serialize the response to TTLV
     let response_ttlv = to_ttlv(&response_message)
         .map_err(|e| KmsError::InvalidRequest(format!("Failed to serialize response: {e}")))?;
 
@@ -468,7 +414,6 @@ async fn handle_ttlv_bytes_inner(
         "Response Message TTLV: {response_ttlv:#?}"
     );
 
-    // convert the TTLV to bytes
     let response_bytes = TTLV::to_bytes(&response_ttlv, kmip_flavor)
         .map_err(|e| KmsError::InvalidRequest(format!("Failed to convert TTLV to bytes: {e}")))?;
 
@@ -591,12 +536,11 @@ mod local_tests {
         ttlv::{KmipFlavor, TTLV, from_ttlv},
     };
 
-    use crate::routes::kmip::TTLV_ERROR_RESPONSE;
+    use super::TTLV_ERROR_RESPONSE;
 
     #[test]
     fn test_error_response_message_ttlv() {
         let ttlv = super::error_response_ttlv(2, 1, "error message");
-        // make sure we can parse the TTLV
         let _response: ResponseMessage = from_ttlv(ttlv).expect("Failed to parse response");
     }
 
@@ -604,7 +548,6 @@ mod local_tests {
     fn test_error_response_message_binary() {
         let ttlv = TTLV::from_bytes(&TTLV_ERROR_RESPONSE, KmipFlavor::Kmip1)
             .expect("Failed to parse response");
-        // make sure we can parse the TTLV
         let _response: ResponseMessage = from_ttlv(ttlv).expect("Failed to parse response");
     }
 }
@@ -710,21 +653,14 @@ fn strip_kmip_10_unsupported_attrs(response: &mut ResponseMessage) {
 
 /// Perform response tweaks for KMIP 1.1 and 1.2 since we only support structures for KMIP 1.4 and 2.1
 fn perform_request_tweaks(response: &mut RequestMessage, major: i32, minor: i32) {
-    // KMIP 1.1 and 1.2 Response Tweaks
     if major == 1 && minor <= 2 {
-        // Decrypt we request does not have the Authenticated Encryption Tag,
-        // so we must extract it from the data field when the encryption algorithm is an authenticated encryption algorithm
         for batch_item in &mut response.batch_item {
             let RequestMessageBatchItemVersioned::V14(item) = batch_item else {
-                continue; // Skip if not V14
+                continue;
             };
-            // If the operation is Encrypt and the response payload is present,
-            // we need to extract the Authenticated Encryption Tag from the Data field
-            // when the encryption algorithm is an authenticated encryption algorithm
             if let cosmian_kmip::kmip_1_4::kmip_operations::Operation::Decrypt(decrypt) =
                 &mut item.request_payload
             {
-                // Check if the encryption algorithm is an authenticated encryption algorithm
                 let cryptographic_parameters =
                     decrypt.cryptographic_parameters.clone().unwrap_or_else(|| {
                         cosmian_kmip::kmip_1_4::kmip_data_structures::CryptographicParameters {
@@ -755,9 +691,7 @@ fn perform_request_tweaks(response: &mut RequestMessage, major: i32, minor: i32)
                         }
                     };
                     if len > 0 {
-                        // Extract the Authenticated Encryption Tag from the Data field
                         if let Some(data) = &mut decrypt.data {
-                            // Assuming the last `len` bytes are the Authenticated Encryption Tag
                             if data.len() >= len {
                                 debug!(
                                     "This is a {major}.{minor} Decrypt message. Extracting \

--- a/crate/server/src/routes/kmip/handlers.rs
+++ b/crate/server/src/routes/kmip/handlers.rs
@@ -300,18 +300,29 @@ pub(crate) async fn kmip_binary(
 ) -> HttpResponse {
     let user = kms.get_user(&req_http);
 
+    // Best-effort: peek at the request TTLV to record the operation name, and
+    // remember the flavor so the response can be re-parsed for `inject_response_uid`
+    // below (`handle_ttlv_bytes` only returns bytes, not the response TTLV).
+    let mut flavor = KmipFlavor::Kmip2;
+    let mut op_name = None;
     if let Ok((major, _minor)) = TTLV::find_version(body.as_ref()) {
-        let flavor = if major == 1 {
+        flavor = if major == 1 {
             KmipFlavor::Kmip1
         } else {
             KmipFlavor::Kmip2
         };
         if let Ok(ttlv) = TTLV::from_bytes(body.as_ref(), flavor) {
-            inject_audit_request(&req_http, &ttlv);
+            op_name = Some(inject_audit_request(&req_http, &ttlv));
         }
     }
 
     let response_bytes = handle_ttlv_bytes(&user, body.as_ref(), &kms).await;
+
+    if let Some(op_name) = op_name {
+        if let Ok(response_ttlv) = TTLV::from_bytes(&response_bytes, flavor) {
+            inject_response_uid(&req_http, &response_ttlv, &op_name);
+        }
+    }
 
     HttpResponse::Ok()
         .content_type("application/octet-stream")

--- a/crate/server/src/routes/kmip/mod.rs
+++ b/crate/server/src/routes/kmip/mod.rs
@@ -1,0 +1,3 @@
+mod audit;
+mod handlers;
+pub(crate) use handlers::{handle_ttlv_bytes, kmip, kmip_2_1_json};

--- a/crate/server/src/start_kms_server.rs
+++ b/crate/server/src/start_kms_server.rs
@@ -1608,7 +1608,10 @@ pub async fn prepare_kms_server(kms_server: Arc<KMS>) -> KResult<actix_web::dev:
             ))
             // Tamper-evident audit logging: wraps every auth method above so both
             // successful and failed authentication attempts are recorded (LIFO wrap order).
-            .wrap(AuditMiddleware::new(kms_server_for_http.audit_store.clone()))
+            .wrap(AuditMiddleware::new(
+                kms_server_for_http.audit_store.clone(),
+                kms_server_for_http.params.audit_trusted_proxy_cidrs.clone(),
+            ))
             // CORS: KMIP is a server-to-server protocol; restrict to same-origin by default.
             // Additional origins (e.g. a Vite dev server in E2E tests) can be allowed via
             // `cors_allowed_origins` / `KMS_CORS_ALLOWED_ORIGINS`. Enterprise-integration scopes

--- a/crate/server/src/start_kms_server.rs
+++ b/crate/server/src/start_kms_server.rs
@@ -56,9 +56,9 @@ use crate::{
     cron,
     error::KmsError,
     middlewares::{
-        AuthVerifier, JwksManager, JwtConfig, SessionAuth, SpireTokenCache, api_token_middleware,
-        ensure_auth_middleware, extract_peer_certificate, jwt_auth_middleware,
-        otel_http_metrics_middleware, spire_token_middleware, tls_auth_fn,
+        AuditMiddleware, AuthVerifier, JwksManager, JwtConfig, SessionAuth, SpireTokenCache,
+        api_token_middleware, ensure_auth_middleware, extract_peer_certificate,
+        jwt_auth_middleware, otel_http_metrics_middleware, spire_token_middleware, tls_auth_fn,
         vault_token_optional_middleware,
     },
     result::{KResult, KResultHelper},
@@ -1606,6 +1606,9 @@ pub async fn prepare_kms_server(kms_server: Arc<KMS>) -> KResult<actix_web::dev:
                     spire_default_username.clone(),
                 ),
             ))
+            // Tamper-evident audit logging: wraps every auth method above so both
+            // successful and failed authentication attempts are recorded (LIFO wrap order).
+            .wrap(AuditMiddleware::new(kms_server_for_http.audit_store.clone()))
             // CORS: KMIP is a server-to-server protocol; restrict to same-origin by default.
             // Additional origins (e.g. a Vite dev server in E2E tests) can be allowed via
             // `cors_allowed_origins` / `KMS_CORS_ALLOWED_ORIGINS`. Enterprise-integration scopes
@@ -1828,6 +1831,7 @@ mod tests {
 
     // ── J1–J4: JWKS HTTPS URI validation (compiled out in `insecure` builds) ─
     #[cfg(not(feature = "insecure"))]
+    #[expect(clippy::unwrap_used)]
     mod jwks_https_guard {
         use super::*;
 

--- a/crate/server/src/start_kms_server.rs
+++ b/crate/server/src/start_kms_server.rs
@@ -1831,7 +1831,6 @@ mod tests {
 
     // ── J1–J4: JWKS HTTPS URI validation (compiled out in `insecure` builds) ─
     #[cfg(not(feature = "insecure"))]
-    #[expect(clippy::unwrap_used)]
     mod jwks_https_guard {
         use super::*;
 

--- a/crate/server/src/tests/audit_middleware.rs
+++ b/crate/server/src/tests/audit_middleware.rs
@@ -33,12 +33,16 @@ fn temp_path(label: &str) -> PathBuf {
 
 /// End-to-end audit chain test.
 ///
-/// Sends four KMIP operations through a live in-process KMS with `AuditMiddleware`
+/// Sends five KMIP operations through a live in-process KMS with `AuditMiddleware`
 /// wired in, then reads the resulting JSONL file and verifies:
-///  * Four events were recorded (Create, Encrypt, Decrypt-failure, Create+Locate batch).
-///  * Operation names match.
-///  * Result types are correct (Success / Failure as expected).
-///  * `object_uid` is populated on Create, Encrypt, and Decrypt.
+///  * Six events were recorded:
+///    [0] Create, [1] Encrypt, [2] Decrypt-failure,
+///    [3] batch-Create, [4] batch-Locate  ← two events from one `RequestMessage`
+///    [5] standalone-Locate
+///  * Per-item operation names, results, and `object_uid` are correct.
+///  * Events [3] and [4] share the same `request_id` (same batch).
+///  * Event [3]'s `request_id` differs from event [0]'s (different HTTP requests).
+///  * All single-op events carry a `request_id`.
 ///  * The hash chain is intact (`verify_event` + `verify_chain_link`).
 ///  * Every event produces a well-formed CEF line (`to_cef_line`).
 #[tokio::test]
@@ -127,9 +131,8 @@ async fn audit_records_create_encrypt_failure_and_batch() -> KResult<()> {
 
         // 5. Standalone Locate → ensures a single-op "Locate" operation also appears
         //    in the audit log (not just as part of a batch "Create+Locate").
-        let locate_request = cosmian_kms_server_database::reexport::cosmian_kmip::kmip_2_1::kmip_operations::Locate {
-            ..Default::default()
-        };
+        let locate_request =
+            cosmian_kms_server_database::reexport::cosmian_kmip::kmip_2_1::kmip_operations::Locate::default();
         let _locate_resp: cosmian_kms_server_database::reexport::cosmian_kmip::kmip_2_1::kmip_operations::LocateResponse =
             post_2_1(&app, locate_request).await?;
 
@@ -157,8 +160,8 @@ async fn audit_records_create_encrypt_failure_and_batch() -> KResult<()> {
 
     assert_eq!(
         events.len(),
-        5,
-        "expected 5 audit events, got {}",
+        6,
+        "expected 6 audit events, got {}",
         events.len()
     );
 
@@ -166,8 +169,9 @@ async fn audit_records_create_encrypt_failure_and_batch() -> KResult<()> {
     assert_eq!(events[0].operation, "Create", "event 0");
     assert_eq!(events[1].operation, "Encrypt", "event 1");
     assert_eq!(events[2].operation, "Decrypt", "event 2");
-    assert_eq!(events[3].operation, "Create+Locate", "event 3 (batch)");
-    assert_eq!(events[4].operation, "Locate", "event 4 (standalone)");
+    assert_eq!(events[3].operation, "Create", "event 3 (batch-Create)");
+    assert_eq!(events[4].operation, "Locate", "event 4 (batch-Locate)");
+    assert_eq!(events[5].operation, "Locate", "event 5 (standalone)");
 
     // Results
     assert_eq!(
@@ -193,7 +197,12 @@ async fn audit_records_create_encrypt_failure_and_batch() -> KResult<()> {
     assert_eq!(
         events[4].result,
         AuditResult::Success,
-        "event 4 (standalone Locate) should be Success"
+        "event 4 should be Success"
+    );
+    assert_eq!(
+        events[5].result,
+        AuditResult::Success,
+        "event 5 (standalone Locate) should be Success"
     );
 
     // Object UIDs: Create fills it from the response; Encrypt/Decrypt read it from the request
@@ -213,6 +222,36 @@ async fn audit_records_create_encrypt_failure_and_batch() -> KResult<()> {
         Some("00000000-0000-0000-0000-000000000000"),
         "event 2 uid"
     );
+    // batch-Create: UID backfilled from the response
+    assert!(
+        events[3].object_uid.is_some(),
+        "event 3 (batch-Create) should have a uid"
+    );
+
+    // request_id: batch items [3] and [4] share the same request_id
+    assert!(
+        events[3].request_id.is_some(),
+        "event 3 must have request_id"
+    );
+    assert!(
+        events[4].request_id.is_some(),
+        "event 4 must have request_id"
+    );
+    assert_eq!(
+        events[3].request_id, events[4].request_id,
+        "batch items share the same request_id"
+    );
+    assert_ne!(
+        events[3].request_id, events[0].request_id,
+        "different HTTP requests must have different request_ids"
+    );
+    // All single-op events carry a request_id
+    for (i, ev) in events.iter().enumerate() {
+        assert!(
+            ev.request_id.is_some(),
+            "event {i} should have a request_id"
+        );
+    }
 
     // Hash chain integrity
     let mut prev = None;
@@ -251,6 +290,14 @@ async fn audit_records_create_encrypt_failure_and_batch() -> KResult<()> {
             "unexpected CEF header for event id={}: {cef}",
             ev.id
         );
+        // Events with request_id must include cs5
+        if ev.request_id.is_some() {
+            assert!(
+                cef.contains("cs5Label=requestId"),
+                "CEF missing cs5Label for event id={}: {cef}",
+                ev.id
+            );
+        }
     }
 
     Ok(())

--- a/crate/server/src/tests/audit_middleware.rs
+++ b/crate/server/src/tests/audit_middleware.rs
@@ -1,0 +1,257 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::{path::PathBuf, time::Duration};
+
+use cosmian_kms_access::audit::{AuditResult, to_cef_line, verify_chain_link, verify_event};
+use cosmian_kms_server_database::reexport::cosmian_kmip::{
+    kmip_0::{
+        kmip_messages::{RequestMessage, RequestMessageBatchItemVersioned, RequestMessageHeader},
+        kmip_types::{BlockCipherMode, ProtocolVersion},
+    },
+    kmip_2_1::{
+        extra::tagging::{EMPTY_TAGS, VENDOR_ID_COSMIAN},
+        kmip_messages::RequestMessageBatchItem,
+        kmip_operations::{Encrypt, Operation},
+        kmip_types::{CryptographicAlgorithm, CryptographicParameters, UniqueIdentifier},
+        requests::symmetric_key_create_request,
+    },
+};
+use cosmian_logger::log_init;
+use zeroize::Zeroizing;
+
+use crate::{
+    result::KResult,
+    tests::test_utils::{self, post_2_1, post_kmip_json},
+};
+
+fn temp_path(label: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "kms_audit_e2e_{}_{label}.jsonl",
+        std::process::id()
+    ))
+}
+
+/// End-to-end audit chain test.
+///
+/// Sends four KMIP operations through a live in-process KMS with `AuditMiddleware`
+/// wired in, then reads the resulting JSONL file and verifies:
+///  * Four events were recorded (Create, Encrypt, Decrypt-failure, Create+Locate batch).
+///  * Operation names match.
+///  * Result types are correct (Success / Failure as expected).
+///  * `object_uid` is populated on Create, Encrypt, and Decrypt.
+///  * The hash chain is intact (`verify_event` + `verify_chain_link`).
+///  * Every event produces a well-formed CEF line (`to_cef_line`).
+#[tokio::test]
+async fn audit_records_create_encrypt_failure_and_batch() -> KResult<()> {
+    log_init(option_env!("RUST_LOG"));
+
+    let path = temp_path("e2e_chain");
+    let fut = async {
+        let (app, _store) = test_utils::test_app_with_audit(&path).await;
+
+        // 1. Create AES-256-GCM key (FIPS-approved)
+        let create_request = symmetric_key_create_request(
+            VENDOR_ID_COSMIAN,
+            None,
+            256,
+            CryptographicAlgorithm::AES,
+            EMPTY_TAGS,
+            false,
+            None,
+        )?;
+        let create_response: cosmian_kms_server_database::reexport::cosmian_kmip::kmip_2_1::kmip_operations::CreateResponse =
+            post_2_1(&app, create_request).await?;
+        let uid = create_response.unique_identifier;
+
+        // 2. Encrypt with the created key (AES-GCM)
+        let encrypt_request = Encrypt {
+            unique_identifier: Some(uid.clone()),
+            cryptographic_parameters: Some(CryptographicParameters {
+                cryptographic_algorithm: Some(CryptographicAlgorithm::AES),
+                block_cipher_mode: Some(BlockCipherMode::GCM),
+                ..CryptographicParameters::default()
+            }),
+            data: Some(Zeroizing::new(b"hello audit".to_vec())),
+            ..Default::default()
+        };
+        let _enc_resp: cosmian_kms_server_database::reexport::cosmian_kmip::kmip_2_1::kmip_operations::EncryptResponse =
+            post_2_1(&app, encrypt_request).await?;
+
+        // 3. Decrypt with a non-existent key → OperationFailed (Failure event)
+        let bad_uid =
+            UniqueIdentifier::TextString("00000000-0000-0000-0000-000000000000".to_owned());
+        let decrypt_request = cosmian_kms_server_database::reexport::cosmian_kmip::kmip_2_1::kmip_operations::Decrypt {
+            unique_identifier: Some(bad_uid),
+            data: Some(b"ciphertext".to_vec()),
+            ..Default::default()
+        };
+        // Failure is expected; ignore the Err
+        drop(
+            post_2_1::<_, _, cosmian_kms_server_database::reexport::cosmian_kmip::kmip_2_1::kmip_operations::DecryptResponse, _>(
+                &app,
+                decrypt_request,
+            )
+            .await,
+        );
+
+        // 4. Batch: Create + Locate in one RequestMessage
+        let batch_create = symmetric_key_create_request(
+            VENDOR_ID_COSMIAN,
+            None,
+            256,
+            CryptographicAlgorithm::AES,
+            EMPTY_TAGS,
+            false,
+            None,
+        )?;
+        let batch_request = RequestMessage {
+            request_header: RequestMessageHeader {
+                protocol_version: ProtocolVersion {
+                    protocol_version_major: 2,
+                    protocol_version_minor: 1,
+                },
+                maximum_response_size: Some(9999),
+                batch_count: 2,
+                ..Default::default()
+            },
+            batch_item: vec![
+                RequestMessageBatchItemVersioned::V21(RequestMessageBatchItem::new(
+                    Operation::Create(batch_create),
+                )),
+                RequestMessageBatchItemVersioned::V21(RequestMessageBatchItem::new(
+                    Operation::Locate(Box::default()),
+                )),
+            ],
+        };
+        let _batch_resp = post_kmip_json(&app, &batch_request).await?;
+
+        // 5. Standalone Locate → ensures a single-op "Locate" operation also appears
+        //    in the audit log (not just as part of a batch "Create+Locate").
+        let locate_request = cosmian_kms_server_database::reexport::cosmian_kmip::kmip_2_1::kmip_operations::Locate {
+            ..Default::default()
+        };
+        let _locate_resp: cosmian_kms_server_database::reexport::cosmian_kmip::kmip_2_1::kmip_operations::LocateResponse =
+            post_2_1(&app, locate_request).await?;
+
+        Ok::<UniqueIdentifier, crate::error::KmsError>(uid)
+    };
+
+    let uid = Box::pin(fut).await?;
+
+    // Give the background writer time to flush — matches the pattern in file_store.rs tests.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Parse and validate the audit log
+    let file = std::fs::File::open(&path).expect("audit file not created");
+    let events: Vec<cosmian_kms_access::audit::AuditEvent> =
+        std::io::BufRead::lines(std::io::BufReader::new(file))
+            .filter_map(|l| {
+                let l = l.unwrap();
+                if l.trim().is_empty() {
+                    None
+                } else {
+                    Some(serde_json::from_str(&l).unwrap())
+                }
+            })
+            .collect();
+
+    assert_eq!(
+        events.len(),
+        5,
+        "expected 5 audit events, got {}",
+        events.len()
+    );
+
+    // Operation names
+    assert_eq!(events[0].operation, "Create", "event 0");
+    assert_eq!(events[1].operation, "Encrypt", "event 1");
+    assert_eq!(events[2].operation, "Decrypt", "event 2");
+    assert_eq!(events[3].operation, "Create+Locate", "event 3 (batch)");
+    assert_eq!(events[4].operation, "Locate", "event 4 (standalone)");
+
+    // Results
+    assert_eq!(
+        events[0].result,
+        AuditResult::Success,
+        "event 0 should be Success"
+    );
+    assert_eq!(
+        events[1].result,
+        AuditResult::Success,
+        "event 1 should be Success"
+    );
+    assert!(
+        matches!(&events[2].result, AuditResult::Failure(_)),
+        "event 2 should be Failure, got {:?}",
+        events[2].result
+    );
+    assert_eq!(
+        events[3].result,
+        AuditResult::Success,
+        "event 3 should be Success"
+    );
+    assert_eq!(
+        events[4].result,
+        AuditResult::Success,
+        "event 4 (standalone Locate) should be Success"
+    );
+
+    // Object UIDs: Create fills it from the response; Encrypt/Decrypt read it from the request
+    let uid_str = uid.to_string();
+    assert_eq!(
+        events[0].object_uid.as_deref(),
+        Some(uid_str.as_str()),
+        "event 0 uid"
+    );
+    assert_eq!(
+        events[1].object_uid.as_deref(),
+        Some(uid_str.as_str()),
+        "event 1 uid"
+    );
+    assert_eq!(
+        events[2].object_uid.as_deref(),
+        Some("00000000-0000-0000-0000-000000000000"),
+        "event 2 uid"
+    );
+
+    // Hash chain integrity
+    let mut prev = None;
+    for ev in &events {
+        assert!(
+            verify_event(ev),
+            "hash integrity failed for event id={}",
+            ev.id
+        );
+        assert!(
+            verify_chain_link(ev, prev),
+            "chain link broken at event id={}",
+            ev.id
+        );
+        prev = Some(ev);
+    }
+
+    // Client IP is None under actix_web::test (no real TCP peer).
+    // This documents the test-harness limitation: `peer_addr()` returns None,
+    // so `extract_client_ip` falls back to None. Real deployments with TLS/TCP
+    // will populate this field. This assertion locks in the current behaviour
+    // so a future refactor doesn't claim to test client_ip capture without it actually working.
+    for ev in &events {
+        assert!(
+            ev.client_ip.is_none(),
+            "actix_web::test has no peer_addr; client_ip must be None for event id={}",
+            ev.id
+        );
+    }
+
+    // CEF output sanity — every event must produce a valid CEF line
+    for ev in &events {
+        let cef = to_cef_line(ev, "test");
+        assert!(
+            cef.starts_with("CEF:0|Cosmian|KMS|test|"),
+            "unexpected CEF header for event id={}: {cef}",
+            ev.id
+        );
+    }
+
+    Ok(())
+}

--- a/crate/server/src/tests/audit_middleware.rs
+++ b/crate/server/src/tests/audit_middleware.rs
@@ -1,27 +1,35 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use std::{path::PathBuf, time::Duration};
+use std::path::PathBuf;
 
+use actix_web::{
+    http::StatusCode,
+    test::{self as actix_test, call_service},
+};
 use cosmian_kms_access::audit::{AuditResult, to_cef_line, verify_chain_link, verify_event};
 use cosmian_kms_server_database::reexport::cosmian_kmip::{
     kmip_0::{
-        kmip_messages::{RequestMessage, RequestMessageBatchItemVersioned, RequestMessageHeader},
-        kmip_types::{BlockCipherMode, ProtocolVersion},
+        kmip_messages::{
+            RequestMessage, RequestMessageBatchItemVersioned, RequestMessageHeader,
+            ResponseMessage, ResponseMessageBatchItemVersioned,
+        },
+        kmip_types::{BlockCipherMode, ProtocolVersion, ResultStatusEnumeration},
     },
     kmip_2_1::{
         extra::tagging::{EMPTY_TAGS, VENDOR_ID_COSMIAN},
         kmip_messages::RequestMessageBatchItem,
-        kmip_operations::{Encrypt, Operation},
+        kmip_operations::{Decrypt, Encrypt, Operation},
         kmip_types::{CryptographicAlgorithm, CryptographicParameters, UniqueIdentifier},
         requests::symmetric_key_create_request,
     },
+    ttlv::{KmipFlavor, to_ttlv},
 };
 use cosmian_logger::log_init;
 use zeroize::Zeroizing;
 
 use crate::{
     result::KResult,
-    tests::test_utils::{self, post_2_1, post_kmip_json},
+    tests::test_utils::{self, post_2_1, post_kmip_binary, post_kmip_json},
 };
 
 fn temp_path(label: &str) -> PathBuf {
@@ -50,9 +58,8 @@ async fn audit_records_create_encrypt_failure_and_batch() -> KResult<()> {
     log_init(option_env!("RUST_LOG"));
 
     let path = temp_path("e2e_chain");
+    let (app, store) = test_utils::test_app_with_audit(&path).await;
     let fut = async {
-        let (app, _store) = test_utils::test_app_with_audit(&path).await;
-
         // 1. Create AES-256-GCM key (FIPS-approved)
         let create_request = symmetric_key_create_request(
             VENDOR_ID_COSMIAN,
@@ -141,8 +148,9 @@ async fn audit_records_create_encrypt_failure_and_batch() -> KResult<()> {
 
     let uid = Box::pin(fut).await?;
 
-    // Give the background writer time to flush — matches the pattern in file_store.rs tests.
-    tokio::time::sleep(Duration::from_millis(200)).await;
+    // Deterministic drain barrier instead of a fixed sleep: once flush()
+    // returns, every enqueued event has been written (and synced).
+    store.flush().await;
 
     // Parse and validate the audit log
     let file = std::fs::File::open(&path).expect("audit file not created");
@@ -299,6 +307,324 @@ async fn audit_records_create_encrypt_failure_and_batch() -> KResult<()> {
             );
         }
     }
+
+    Ok(())
+}
+
+/// Wraps a single KMIP `Operation` in a `RequestMessage`.
+///
+/// Binary TTLV requests always deserialize as a `RequestMessage` server-side
+/// (`handle_ttlv_bytes_inner` calls `from_ttlv::<RequestMessage>` unconditionally),
+/// unlike `/kmip/2_1` which accepts a bare operation TTLV. So every binary request
+/// in this test, even a "single" one, has to go through this wrapper.
+fn single_op_message(op: Operation) -> RequestMessage {
+    RequestMessage {
+        request_header: RequestMessageHeader {
+            protocol_version: ProtocolVersion {
+                protocol_version_major: 2,
+                protocol_version_minor: 1,
+            },
+            batch_count: 1,
+            ..Default::default()
+        },
+        batch_item: vec![RequestMessageBatchItemVersioned::V21(
+            RequestMessageBatchItem::new(op),
+        )],
+    }
+}
+
+/// Extracts the `unique_identifier` from a `CreateResponse` in the first batch item.
+fn created_uid(response: &ResponseMessage) -> UniqueIdentifier {
+    let ResponseMessageBatchItemVersioned::V21(item) = &response.batch_item[0] else {
+        panic!("expected a V21 response batch item");
+    };
+    let Some(Operation::CreateResponse(create_response)) = &item.response_payload else {
+        panic!(
+            "expected a CreateResponse payload, got {:?}",
+            item.response_payload
+        );
+    };
+    create_response.unique_identifier.clone()
+}
+
+/// End-to-end audit test over the binary TTLV wire format (`application/octet-stream`),
+/// the encoding used by native KMIP clients (HSMs, other vendors' libraries) rather
+/// than the JSON convenience endpoints. Mirrors
+/// `audit_records_create_encrypt_failure_and_batch` step for step, so `SEC-01`
+/// (binary responses never reached `inject_response_uid`) is covered for both
+/// single-op and batch object UIDs.
+///
+/// Every binary KMIP request is wire-tagged `RequestMessage` (even a "single" op),
+/// so it always goes through the batch fan-out path in `AuditMiddleware`. That path
+/// derives each item's `AuditResult` from the KMIP response's `ResultStatus`, not
+/// from the (always-200) HTTP status of `kmip_binary`. Before the `SEC-01` fix,
+/// `inject_response_uid` was never called for binary, so that per-item result was
+/// never backfilled and every binary event silently fell back to the generic
+/// HTTP-200-derived `Success`, even for a request whose KMIP payload failed. The
+/// `events[2]` assertion below (`Decrypt` with a bogus UID) is what would have
+/// caught that: the result must be `Failure`, not `Success`.
+#[tokio::test]
+async fn audit_records_binary_create_encrypt_failure_and_batch() -> KResult<()> {
+    log_init(option_env!("RUST_LOG"));
+
+    let path = temp_path("e2e_chain_binary");
+    let (app, store) = test_utils::test_app_with_audit(&path).await;
+    let fut = async {
+        // 1. Create AES-256-GCM key (FIPS-approved), sent as binary TTLV.
+        let create_request = symmetric_key_create_request(
+            VENDOR_ID_COSMIAN,
+            None,
+            256,
+            CryptographicAlgorithm::AES,
+            EMPTY_TAGS,
+            false,
+            None,
+        )?;
+        let create_response = post_kmip_binary(
+            &app,
+            &single_op_message(Operation::Create(create_request)),
+            KmipFlavor::Kmip2,
+        )
+        .await?;
+        let uid = created_uid(&create_response);
+
+        // 2. Encrypt with the created key (AES-GCM)
+        let encrypt_request = Encrypt {
+            unique_identifier: Some(uid.clone()),
+            cryptographic_parameters: Some(CryptographicParameters {
+                cryptographic_algorithm: Some(CryptographicAlgorithm::AES),
+                block_cipher_mode: Some(BlockCipherMode::GCM),
+                ..CryptographicParameters::default()
+            }),
+            data: Some(Zeroizing::new(b"hello audit binary".to_vec())),
+            ..Default::default()
+        };
+        let _encrypt_response = post_kmip_binary(
+            &app,
+            &single_op_message(Operation::Encrypt(Box::new(encrypt_request))),
+            KmipFlavor::Kmip2,
+        )
+        .await?;
+
+        // 3. Decrypt with a non-existent key → the response batch item carries
+        //    ResultStatus = OperationFailed, but the HTTP status is still 200.
+        let bad_uid =
+            UniqueIdentifier::TextString("00000000-0000-0000-0000-000000000000".to_owned());
+        let decrypt_request = Decrypt {
+            unique_identifier: Some(bad_uid),
+            data: Some(b"ciphertext".to_vec()),
+            ..Default::default()
+        };
+        let decrypt_response = post_kmip_binary(
+            &app,
+            &single_op_message(Operation::Decrypt(Box::new(decrypt_request))),
+            KmipFlavor::Kmip2,
+        )
+        .await?;
+        let ResponseMessageBatchItemVersioned::V21(decrypt_item) = &decrypt_response.batch_item[0]
+        else {
+            panic!("expected a V21 response batch item");
+        };
+        assert_ne!(
+            decrypt_item.result_status,
+            ResultStatusEnumeration::Success,
+            "decrypting with a bogus uid should fail at the KMIP level"
+        );
+
+        // 4. Batch: Create + Locate in one RequestMessage
+        let batch_create = symmetric_key_create_request(
+            VENDOR_ID_COSMIAN,
+            None,
+            256,
+            CryptographicAlgorithm::AES,
+            EMPTY_TAGS,
+            false,
+            None,
+        )?;
+        let batch_request = RequestMessage {
+            request_header: RequestMessageHeader {
+                protocol_version: ProtocolVersion {
+                    protocol_version_major: 2,
+                    protocol_version_minor: 1,
+                },
+                maximum_response_size: Some(9999),
+                batch_count: 2,
+                ..Default::default()
+            },
+            batch_item: vec![
+                RequestMessageBatchItemVersioned::V21(RequestMessageBatchItem::new(
+                    Operation::Create(batch_create),
+                )),
+                RequestMessageBatchItemVersioned::V21(RequestMessageBatchItem::new(
+                    Operation::Locate(Box::default()),
+                )),
+            ],
+        };
+        let _batch_resp = post_kmip_binary(&app, &batch_request, KmipFlavor::Kmip2).await?;
+
+        // 5. Standalone Locate → ensures a single-op "Locate" operation also appears
+        //    in the audit log (not just as part of a batch "Create+Locate").
+        let _locate_resp = post_kmip_binary(
+            &app,
+            &single_op_message(Operation::Locate(Box::default())),
+            KmipFlavor::Kmip2,
+        )
+        .await?;
+
+        Ok::<UniqueIdentifier, crate::error::KmsError>(uid)
+    };
+
+    let uid = Box::pin(fut).await?;
+
+    // Deterministic drain barrier instead of a fixed sleep.
+    store.flush().await;
+
+    let file = std::fs::File::open(&path).expect("audit file not created");
+    let events: Vec<cosmian_kms_access::audit::AuditEvent> =
+        std::io::BufRead::lines(std::io::BufReader::new(file))
+            .filter_map(|l| {
+                let l = l.unwrap();
+                if l.trim().is_empty() {
+                    None
+                } else {
+                    Some(serde_json::from_str(&l).unwrap())
+                }
+            })
+            .collect();
+
+    assert_eq!(
+        events.len(),
+        6,
+        "expected 6 audit events, got {}",
+        events.len()
+    );
+
+    assert_eq!(events[0].operation, "Create", "event 0");
+    assert_eq!(events[1].operation, "Encrypt", "event 1");
+    assert_eq!(events[2].operation, "Decrypt", "event 2");
+    assert_eq!(events[3].operation, "Create", "event 3 (batch-Create)");
+    assert_eq!(events[4].operation, "Locate", "event 4 (batch-Locate)");
+    assert_eq!(events[5].operation, "Locate", "event 5 (standalone)");
+
+    assert_eq!(events[0].result, AuditResult::Success, "event 0");
+    assert_eq!(events[1].result, AuditResult::Success, "event 1");
+    assert!(
+        matches!(&events[2].result, AuditResult::Failure(_)),
+        "event 2 should be Failure (this is the assertion SEC-01 broke silently \
+         for binary requests), got {:?}",
+        events[2].result
+    );
+    assert_eq!(events[3].result, AuditResult::Success, "event 3");
+    assert_eq!(events[4].result, AuditResult::Success, "event 4");
+    assert_eq!(events[5].result, AuditResult::Success, "event 5");
+
+    // Object UIDs: the whole point of SEC-01 — binary responses now populate this too.
+    let uid_str = uid.to_string();
+    assert_eq!(
+        events[0].object_uid.as_deref(),
+        Some(uid_str.as_str()),
+        "event 0 uid"
+    );
+    assert_eq!(
+        events[1].object_uid.as_deref(),
+        Some(uid_str.as_str()),
+        "event 1 uid"
+    );
+    assert_eq!(
+        events[2].object_uid.as_deref(),
+        Some("00000000-0000-0000-0000-000000000000"),
+        "event 2 uid"
+    );
+    assert!(
+        events[3].object_uid.is_some(),
+        "event 3 (batch-Create) should have a uid"
+    );
+
+    // Hash chain integrity holds regardless of wire format.
+    let mut prev = None;
+    for ev in &events {
+        assert!(
+            verify_event(ev),
+            "hash integrity failed for event id={}",
+            ev.id
+        );
+        assert!(
+            verify_chain_link(ev, prev),
+            "chain link broken at event id={}",
+            ev.id
+        );
+        prev = Some(ev);
+    }
+
+    Ok(())
+}
+
+/// CQ-05a: an unauthenticated request must still produce an audit event.
+///
+/// `AuditMiddleware` is wrapped outside `ensure_auth_middleware` in production
+/// (`start_kms_server.rs`), specifically so it can record requests that never
+/// reach a handler because auth rejected them first. `test_app_with_audit_and_auth`
+/// replicates that relative wrap order with no upstream JWT/API-token/cert
+/// middleware, so `ensure_auth_middleware` always returns 401.
+#[tokio::test]
+async fn audit_records_401_unauthenticated() -> KResult<()> {
+    log_init(option_env!("RUST_LOG"));
+
+    let path = temp_path("e2e_401");
+    let (app, store) = test_utils::test_app_with_audit_and_auth(&path).await;
+    let fut = async {
+        let create_request = symmetric_key_create_request(
+            VENDOR_ID_COSMIAN,
+            None,
+            256,
+            CryptographicAlgorithm::AES,
+            EMPTY_TAGS,
+            false,
+            None,
+        )?;
+        let req = actix_test::TestRequest::post()
+            .uri("/kmip/2_1")
+            .set_json(to_ttlv(&create_request)?)
+            .to_request();
+        let res = call_service(&app, req).await;
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED, "expected 401");
+
+        Ok::<(), crate::error::KmsError>(())
+    };
+
+    Box::pin(fut).await?;
+
+    // Deterministic drain barrier instead of a fixed sleep.
+    store.flush().await;
+
+    let file = std::fs::File::open(&path).expect("audit file not created");
+    let events: Vec<cosmian_kms_access::audit::AuditEvent> =
+        std::io::BufRead::lines(std::io::BufReader::new(file))
+            .filter_map(|l| {
+                let l = l.unwrap();
+                if l.trim().is_empty() {
+                    None
+                } else {
+                    Some(serde_json::from_str(&l).unwrap())
+                }
+            })
+            .collect();
+
+    assert_eq!(
+        events.len(),
+        1,
+        "expected exactly 1 audit event, got {}",
+        events.len()
+    );
+    assert!(
+        matches!(&events[0].result, AuditResult::Failure(reason) if reason == "401 Unauthorized"),
+        "expected a 401 Unauthorized failure event, got {:?}",
+        events[0].result
+    );
+    assert_eq!(
+        events[0].user, "unauthenticated",
+        "unauthenticated request must be attributed to the unauthenticated user"
+    );
 
     Ok(())
 }

--- a/crate/server/src/tests/mod.rs
+++ b/crate/server/src/tests/mod.rs
@@ -1,3 +1,4 @@
+mod audit_middleware;
 mod azure_ekm;
 mod bulk_encrypt_decrypt_tests;
 #[cfg(feature = "non-fips")]

--- a/crate/server/src/tests/test_utils.rs
+++ b/crate/server/src/tests/test_utils.rs
@@ -17,7 +17,7 @@ use actix_web::{
 use cosmian_kms_server_database::reexport::cosmian_kmip::{
     kmip_0::kmip_messages::{RequestMessage, ResponseMessage},
     kmip_2_1::{kmip_operations::LocateResponse, kmip_types::UniqueIdentifier},
-    ttlv::{TTLV, from_ttlv, to_ttlv},
+    ttlv::{KmipFlavor, TTLV, from_ttlv, to_ttlv},
 };
 use cosmian_logger::info;
 use serde::{Serialize, de::DeserializeOwned};
@@ -31,7 +31,7 @@ use crate::{
     },
     core::{KMS, audit::AuditFileStore},
     kms_bail,
-    middlewares::AuditMiddleware,
+    middlewares::{AuditMiddleware, ensure_auth_middleware},
     result::KResult,
     routes,
     start_kms_server::handle_google_cse_rsa_keypair,
@@ -448,6 +448,40 @@ pub(crate) async fn test_app_with_audit(
     (test::init_service(app).await, store)
 }
 
+/// Creates a test application that records every KMIP request to an audit file,
+/// with `ensure_auth_middleware` enforcing authentication (`auth_is_configured = true`).
+/// No JWT/API-token/cert middleware is wired in, so every request lacks an
+/// `AuthenticatedUser` and is rejected with 401 — used to test that `AuditMiddleware`
+/// (wrapped outside `ensure_auth_middleware`, mirroring the production order in
+/// `start_kms_server.rs`) still records the failed attempt.
+pub(crate) async fn test_app_with_audit_and_auth(
+    audit_path: &std::path::Path,
+) -> (
+    impl Service<Request, Response = ServiceResponse<impl MessageBody>, Error = actix_web::Error>,
+    AuditFileStore,
+) {
+    let clap_config = https_clap_config();
+    let server_params =
+        Arc::new(ServerParams::try_from(clap_config).expect("cannot create server params"));
+
+    let kms_server = Arc::new(
+        KMS::instantiate(server_params.clone())
+            .await
+            .expect("cannot instantiate KMS server"),
+    );
+
+    let store = AuditFileStore::start(audit_path, 128).expect("cannot start audit store");
+
+    let app = App::new()
+        .app_data(Data::new(kms_server.clone()))
+        .service(routes::kmip::kmip_2_1_json)
+        .service(routes::kmip::kmip)
+        .wrap(ensure_auth_middleware(kms_server.clone(), true))
+        .wrap(AuditMiddleware::new(Some(store.clone()), vec![]));
+
+    (test::init_service(app).await, store)
+}
+
 pub(crate) async fn post_2_1<B, O, R, S>(app: &S, operation: O) -> KResult<R>
 where
     O: Serialize,
@@ -510,6 +544,38 @@ where
     }
     let body = read_body(res).await;
     let ttlv: TTLV = serde_json::from_slice(&body)?;
+    Ok(from_ttlv(ttlv)?)
+}
+
+/// Post a full `RequestMessage` as binary TTLV (`application/octet-stream`) to `/kmip`
+/// and return the parsed `ResponseMessage`. Exercises `kmip_binary`, the wire format
+/// used by native KMIP clients (HSMs, other vendors' libraries), as opposed to
+/// `post_kmip_json`'s JSON transport.
+pub(crate) async fn post_kmip_binary<B, S>(
+    app: &S,
+    request_message: &RequestMessage,
+    flavor: KmipFlavor,
+) -> KResult<ResponseMessage>
+where
+    S: Service<Request, Response = ServiceResponse<B>, Error = actix_web::Error>,
+    B: MessageBody,
+{
+    let ttlv = to_ttlv(request_message)?;
+    let request_bytes = ttlv.to_bytes(flavor)?;
+    let req = test::TestRequest::post()
+        .uri("/kmip")
+        .insert_header(("Content-Type", "application/octet-stream"))
+        .set_payload(request_bytes)
+        .to_request();
+    let res = call_service(app, req).await;
+    if res.status() != StatusCode::OK {
+        kms_bail!(
+            "{}",
+            String::from_utf8(read_body(res).await.to_vec()).unwrap_or_else(|_| "[N/A".to_owned())
+        );
+    }
+    let body = read_body(res).await;
+    let ttlv = TTLV::from_bytes(&body, flavor)?;
     Ok(from_ttlv(ttlv)?)
 }
 

--- a/crate/server/src/tests/test_utils.rs
+++ b/crate/server/src/tests/test_utils.rs
@@ -29,8 +29,9 @@ use crate::{
         ClapConfig, GoogleCseConfig, HttpConfig, MainDBConfig, ServerParams, SocketServerConfig,
         TlsConfig,
     },
-    core::KMS,
+    core::{KMS, audit::AuditFileStore},
     kms_bail,
+    middlewares::AuditMiddleware,
     result::KResult,
     routes,
     start_kms_server::handle_google_cse_rsa_keypair,
@@ -360,6 +361,91 @@ pub(crate) async fn test_app_with_clap_config(
     app = app.service(crypto_scope);
 
     test::init_service(app).await
+}
+
+/// Creates a test application that records every KMIP request to an audit file.
+///
+/// Returns the initialised Actix service **and** the `AuditFileStore` handle.
+/// After the test sends its requests, drop the service then
+/// `tokio::time::sleep(Duration::from_millis(200)).await` to let the background
+/// writer flush — the same pattern used in `core::audit::file_store` tests.
+pub(crate) async fn test_app_with_audit(
+    audit_path: &std::path::Path,
+) -> (
+    impl Service<Request, Response = ServiceResponse<impl MessageBody>, Error = actix_web::Error>,
+    AuditFileStore,
+) {
+    let clap_config = https_clap_config();
+    let server_params =
+        Arc::new(ServerParams::try_from(clap_config).expect("cannot create server params"));
+
+    let kms_server = Arc::new(
+        KMS::instantiate(server_params.clone())
+            .await
+            .expect("cannot instantiate KMS server"),
+    );
+
+    if server_params.google_cse.google_cse_enable {
+        handle_google_cse_rsa_keypair(&kms_server, &server_params)
+            .await
+            .expect("start KMS server: failed managing Google CSE RSA Keypair");
+    }
+
+    let store = AuditFileStore::start(audit_path, 128).expect("cannot start audit store");
+
+    let mut app = App::new()
+        .app_data(Data::new(kms_server.clone()))
+        .wrap(AuditMiddleware::new(Some(store.clone())))
+        .service(routes::root_redirect::root_redirect_to_ui)
+        .service(routes::health::get_health)
+        .service(web::scope("/.well-known").service(routes::jwks::get_jwks))
+        .service(routes::get_version)
+        .service(routes::kmip::kmip_2_1_json)
+        .service(routes::kmip::kmip)
+        .service(routes::access::list_owned_objects)
+        .service(routes::access::list_access_rights_obtained)
+        .service(routes::access::list_accesses)
+        .service(routes::access::grant_access)
+        .service(routes::access::revoke_access)
+        .service(routes::access::get_create_access)
+        .service(routes::access::get_privileged_access);
+
+    let google_cse_jwt_config = google_cse_auth(None)
+        .await
+        .expect("cannot setup Google CSE auth");
+
+    let google_cse_scope = web::scope("/google_cse")
+        .app_data(Data::new(Some(google_cse_jwt_config)))
+        .service(routes::google_cse::get_status)
+        .service(routes::google_cse::wrap)
+        .service(routes::google_cse::unwrap)
+        .service(routes::google_cse::private_key_sign)
+        .service(routes::google_cse::private_key_decrypt)
+        .service(routes::google_cse::privileged_wrap)
+        .service(routes::google_cse::privileged_unwrap)
+        .service(routes::google_cse::privileged_private_key_decrypt)
+        .service(routes::google_cse::digest)
+        .service(routes::google_cse::certs)
+        .service(routes::google_cse::rewrap)
+        .service(routes::google_cse::delegate);
+
+    app = app.service(google_cse_scope);
+
+    let crypto_scope = web::scope("/v1/crypto")
+        .service(routes::jose::encrypt_handler)
+        .service(routes::jose::decrypt_handler)
+        .service(routes::jose::sign_handler)
+        .service(routes::jose::verify_handler)
+        .service(routes::jose::mac_handler)
+        .service(routes::jose::create_key_handler)
+        .service(routes::jose::delete_key_handler)
+        .service(routes::jose::unwrap_key_handler)
+        .service(routes::jose::add_tags_handler)
+        .service(routes::jose::remove_tags_handler)
+        .service(routes::jose::list_tags_handler);
+    app = app.service(crypto_scope);
+
+    (test::init_service(app).await, store)
 }
 
 pub(crate) async fn post_2_1<B, O, R, S>(app: &S, operation: O) -> KResult<R>

--- a/crate/server/src/tests/test_utils.rs
+++ b/crate/server/src/tests/test_utils.rs
@@ -395,7 +395,7 @@ pub(crate) async fn test_app_with_audit(
 
     let mut app = App::new()
         .app_data(Data::new(kms_server.clone()))
-        .wrap(AuditMiddleware::new(Some(store.clone())))
+        .wrap(AuditMiddleware::new(Some(store.clone()), vec![]))
         .service(routes::root_redirect::root_redirect_to_ui)
         .service(routes::health::get_health)
         .service(web::scope("/.well-known").service(routes::jwks::get_jwks))

--- a/crate/test_kms_server/src/test_server.rs
+++ b/crate/test_kms_server/src/test_server.rs
@@ -167,14 +167,14 @@ fn path_to_string(p: &Path) -> Result<String, KmsClientError> {
 /// - if the server fails to start
 pub async fn start_test_kms_server_with_config(mut config: ClapConfig) -> &'static TestsContext {
     trace!("Starting test server with config : {:#?}", config);
-    ONCE.get_or_try_init(|| async move {
+    Box::pin(ONCE.get_or_try_init(|| async move {
         // Allocate a dynamic port to avoid conflicts with other test servers
         allocate_dynamic_port(&mut config)?;
         let server_params = ServerParams::try_from(config).context(
             "Failed to create ServerParams from ClapConfig in start_default_test_kms_server",
         )?;
         start_from_server_params(server_params).await
-    })
+    }))
     .await
     .unwrap_or_else(|e| {
         error!("failed to start default test server: {e}");

--- a/documentation/docs/adr/0003-audit-log-single-writer-design.md
+++ b/documentation/docs/adr/0003-audit-log-single-writer-design.md
@@ -55,7 +55,7 @@ When the channel is full, incoming events are **dropped (drop-newest)** and an `
 logged. The writer never blocks the request path. The hash chain advances normally; the
 compliance log has a gap but stays structurally valid.
 
-Ring-buffer semantics (drop-oldest) were explicitly rejected — see *Alternatives Considered*.
+Ring-buffer semantics (drop-oldest) were explicitly rejected — see _Alternatives Considered_.
 
 ### Channel capacity
 
@@ -91,8 +91,10 @@ load at 1 000 req/s given one `fsync` ≈ 1 ms on NVMe storage (4 096 × ~500 B 
 - **NEG-003**: `object_uid` and `algorithm` fields are always `None` — the HTTP middleware
   layer does not have access to the deserialized KMIP payload. Filling these requires injecting
   KMIP-layer extensions into the request context (tracked in `tradeoofs.md` T1).
-- **NEG-004**: Batch KMIP requests produce one audit event for N operations; individual
-  per-operation outcomes and object_uids are not recorded (tracked in `tradeoofs.md` T2).
+- **NEG-004** ✅ **Resolved**: Batch KMIP requests now produce one audit event **per `BatchItem`**,
+  linked by a shared `request_id` (UUID v4). Each item carries its own `operation`,
+  `object_uid`, `algorithm`, and per-item `result` parsed from the `ResponseMessage`
+  `ResultStatus`/`ResultReason`. See `tradeoofs.md` T2.
 
 ## Alternatives Considered
 

--- a/documentation/docs/adr/0003-audit-log-single-writer-design.md
+++ b/documentation/docs/adr/0003-audit-log-single-writer-design.md
@@ -1,0 +1,159 @@
+---
+title: "ADR-0003: Tamper-Evident JSONL Audit Log — Single-Writer Architecture"
+status: "Accepted"
+date: "2026-07-09"
+authors: "contributors, security architects, compliance engineers"
+tags: ["architecture", "decision", "audit", "compliance", "security"]
+supersedes: ""
+superseded_by: ""
+---
+
+# ADR-0003: Tamper-Evident JSONL Audit Log — Single-Writer Architecture
+
+## Status
+
+Accepted
+
+## Context
+
+Cosmian KMS must produce a verifiable, tamper-evident record of every KMIP operation to satisfy:
+
+- **FIPS key lifecycle accountability** — every Create, Rotate, Destroy event must be traceable
+  to a principal.
+- **PCI-DSS Req 10** — automated audit trail for all system components; individual access to
+  cardholder data must be logged with user identity and timestamp.
+- **HIPAA §164.312(b)** — hardware and software activity in electronic information systems.
+- **NIST SP 800-66r2** — audit controls for ePHI systems.
+
+The KMS serves concurrent KMIP requests across multiple Actix-web worker threads. A naive
+"each thread appends directly to a file" design would require a mutex around every write, adding
+latency on the hot request path and risking interleaved or corrupted JSONL lines.
+
+## Decision
+
+Implement the audit subsystem as a **single-writer background task** accessed via a bounded
+`tokio::sync::mpsc` channel:
+
+- The Actix-web middleware calls `enqueue()` — a non-blocking `try_send` — after each KMIP
+  operation. The request thread never touches the file.
+- One background `tokio::spawn` task is the sole owner of the open file, the monotonic id
+  counter, and the rolling `prev_hash`. No mutex is needed.
+- Each persisted JSONL row carries a SHA-256 hash chain:
+  - `prev_hash` — SHA-256 of the previous row's canonical bytes (all-zeros for row 0)
+  - `row_hash` — SHA-256 of this row's canonical bytes (including `prev_hash`)
+- Every write is followed by `sync_data()` (one `fsync` per event) to guarantee durability
+  against OS crash or power failure.
+- On server restart the writer reads only the last 64 KiB of the existing log (O(1) regardless
+  of file size) to resume the chain. The last event's `row_hash` is verified before trusting it
+  as the chain seed; a mismatch aborts startup with a clear error.
+- The audit file is opened in `start()` **before** spawning the writer task (fail-fast: an
+  unwritable path aborts server startup, not silently disables audit logging at runtime).
+
+### Overflow policy
+
+When the channel is full, incoming events are **dropped (drop-newest)** and an `ERROR` is
+logged. The writer never blocks the request path. The hash chain advances normally; the
+compliance log has a gap but stays structurally valid.
+
+Ring-buffer semantics (drop-oldest) were explicitly rejected — see *Alternatives Considered*.
+
+### Channel capacity
+
+The channel capacity is operator-configurable via `--audit-channel-capacity` /
+`KMS_AUDIT_CHANNEL_CAPACITY` (default: **4096**). The default absorbs ~4 seconds of sustained
+load at 1 000 req/s given one `fsync` ≈ 1 ms on NVMe storage (4 096 × ~500 B ≈ 2 MiB peak).
+
+## Consequences
+
+### Positive
+
+- **POS-001**: Zero mutex contention on the hot request path — `try_send` is lock-free.
+- **POS-002**: Write ordering is guaranteed; no possibility of interleaved JSONL lines.
+- **POS-003**: The hash chain provides cryptographic tamper detection: any deletion,
+  reordering, or field modification in any row is detectable offline with
+  `ckms audit verify --path <file>`.
+- **POS-004**: Durability: `sync_data()` per write means at most one event is lost on a hard
+  crash; the chain resumes cleanly from the last durably written row.
+- **POS-005**: O(1) startup regardless of log file size — only the last 64 KiB is read.
+- **POS-006**: Fail-fast startup detects unwritable paths immediately, before any requests
+  are served.
+- **POS-007**: Channel capacity is user-configurable, allowing operators to tune
+  burst-buffering vs. memory footprint for their deployment.
+
+### Negative
+
+- **NEG-001**: One `fsync` per event caps write throughput to ~1 000–2 000 events/sec on
+  typical NVMe storage. High-throughput deployments (>1 000 req/s) will see channel
+  saturation and dropped events.
+- **NEG-002**: Under saturation, dropped events are undetectable in the chain — a compliance
+  auditor cannot distinguish "nothing happened" from "events were silently lost" without
+  monitoring the server log for `"AuditFileStore: channel full"`.
+- **NEG-003**: `object_uid` and `algorithm` fields are always `None` — the HTTP middleware
+  layer does not have access to the deserialized KMIP payload. Filling these requires injecting
+  KMIP-layer extensions into the request context (tracked in `tradeoofs.md` T1).
+- **NEG-004**: Batch KMIP requests produce one audit event for N operations; individual
+  per-operation outcomes and object_uids are not recorded (tracked in `tradeoofs.md` T2).
+
+## Alternatives Considered
+
+### Ring-buffer overflow (drop-oldest)
+
+- **ALT-001 Description**: Replace the bounded MPSC with a lock-protected `VecDeque` or a
+  lock-free ring. When full, evict the oldest buffered (not-yet-written) event to make room
+  for the newest.
+- **ALT-002 Rejection Reason**: Vulnerable to **log-flooding attacks** — an adversary
+  generating a burst of noise events can overwrite early incriminating events still in the
+  buffer before they reach disk. Drop-newest is the standard policy for compliance-grade audit
+  logs (`auditd`, `rsyslog`, `syslog-ng` all use it). Additionally, for KMS events that form
+  causal chains (Create → Encrypt → Destroy), losing the beginning of a burst (Create) while
+  keeping the end (Destroy) is worse forensically than the reverse.
+
+### Mutex-protected direct file append
+
+- **ALT-003 Description**: Each Actix-web worker acquires a `Mutex<File>` and appends
+  directly, computing the hash in the locked section.
+- **ALT-004 Rejection Reason**: Contention across worker threads adds latency on every KMIP
+  request. Serialisation is only guaranteed if all writers hold the same lock, which rules out
+  async tasks on different threads. Deadlock risk if a writer panics while holding the lock.
+
+### Blocking write with back-pressure
+
+- **ALT-005 Description**: Replace `try_send` with `send` (async await) so the request thread
+  blocks until the writer has capacity.
+- **ALT-006 Rejection Reason**: Propagates file-I/O latency (including `fsync`) directly into
+  request latency. Under storage degradation, all KMIP requests stall. Unacceptable for a
+  production KMS. The bounded channel isolates storage hiccups from the request path.
+
+### Batched fsync (every N events or every T ms)
+
+- **ALT-007 Description**: Accumulate N events in the writer before calling `sync_data()`,
+  trading durability for throughput.
+- **ALT-008 Rejection Reason**: Increases the window of events lost on a crash (up to N, not
+  1). For a compliance audit trail this is a clear regression. Deferred as a Phase 2 option
+  for high-throughput deployments that document the tradeoff explicitly.
+
+## Implementation Notes
+
+- **IMP-001**: Core implementation: `crate/server/src/core/audit/file_store.rs`
+- **IMP-002**: Config structs: `crate/server/src/config/command_line/audit_config.rs`;
+  resolved params: `crate/server/src/config/params/server_params.rs`
+- **IMP-003**: Wiring point: `crate/server/src/core/kms/mod.rs` →
+  `create_audit_store(&server_params)` → `AuditFileStore::start(path, channel_capacity)`
+- **IMP-004**: Middleware enqueue: `crate/server/src/middlewares/audit.rs`
+- **IMP-005**: Offline verification CLI: `crate/clients/clap/src/actions/audit.rs`
+  (`ckms audit verify --path <file>`)
+- **IMP-006**: Saturation monitoring — alert on `"AuditFileStore: channel full"` in server
+  log. See `SECURITY.md` §7 for operational guidance.
+- **IMP-007**: Known gaps tracked in `.agents/tradeoofs.md`: T1 (`object_uid` always None),
+  T2 (batch event granularity), T3 (silent drop detectability), T6 (log rotation breaks
+  offline verify), T7 (XFF spoofing).
+
+## References
+
+- **REF-001**: `ADR-0002` — Key Auto-Rotation Keyset Chain Design (hash chain precedent)
+- **REF-002**: PCI-DSS v4.0 Requirement 10 — Track and Monitor All Access
+- **REF-003**: NIST SP 800-92 — Guide to Computer Security Log Management
+- **REF-004**: FIPS 140-3 — key lifecycle accountability requirements
+- **REF-005**: `SECURITY.md` §7 — Audit log saturation operational guidance
+- **REF-006**: `.agents/tradeoofs.md` — full list of known gaps and planned fixes
+- **REF-007**: `CHANGELOG/feat_audit_and_siem.md` — branch-level change log for this feature

--- a/documentation/docs/adr/0004-audit-middleware-extension-injection.md
+++ b/documentation/docs/adr/0004-audit-middleware-extension-injection.md
@@ -17,7 +17,7 @@ Accepted
 ## Context
 
 Every KMIP operation — including authentication failures — must produce an audit event
-(see ADR-0003). The challenge is *where* in the call stack to intercept it. The KMS has
+(see ADR-0003). The challenge is _where_ in the call stack to intercept it. The KMS has
 a layered architecture:
 
 ```
@@ -32,9 +32,9 @@ HTTP client
 Two hard requirements compete:
 
 1. **401/403 authentication failures must be audited.** This means the audit hook must run
-   *outside* the auth middlewares so it sees their rejection responses.
+   _outside_ the auth middlewares so it sees their rejection responses.
 2. **Per-operation context (`object_uid`, `algorithm`) should be captured.** This context
-   only exists *inside* the KMIP dispatch layer, deep in the stack.
+   only exists _inside_ the KMIP dispatch layer, deep in the stack.
 
 Instrumenting every individual KMIP operation handler (≈40 operations) would satisfy
 requirement 2 but misses requirement 1 for failed auth. A pure outer middleware satisfies
@@ -63,13 +63,13 @@ before** the CORS middleware in `start_kms_server.rs`:
 The KMIP route handler, after TTLV parsing but before (or after) dispatch, injects
 structured context into the Actix request extensions:
 
-| Extension type      | Populated by          | Content                                       |
-|---------------------|-----------------------|-----------------------------------------------|
-| `KmipOperationName` | TTLV parser           | `"Encrypt"`, `"Create"`, `"Create+Destroy"` … |
-| `KmipObjectUid`     | route handler         | UID from request or server-assigned (Create)  |
-| `KmipAlgorithm`     | route handler         | `"AES"`, `"RSA"`, …                           |
+| Extension type      | Populated by  | Content                                       |
+| ------------------- | ------------- | --------------------------------------------- |
+| `KmipOperationName` | TTLV parser   | `"Encrypt"`, `"Create"`, `"Create+Destroy"` … |
+| `KmipObjectUid`     | route handler | UID from request or server-assigned (Create)  |
+| `KmipAlgorithm`     | route handler | `"AES"`, `"RSA"`, …                           |
 
-The outer middleware reads these extensions when composing the `AuditEventDraft`.  If an
+The outer middleware reads these extensions when composing the `AuditEventDraft`. If an
 extension is absent (e.g. non-KMIP endpoint, or extraction failed) the field defaults to
 `None` — the audit record is degraded but the request is never affected.
 
@@ -123,7 +123,7 @@ mechanism is in place; filling it is incremental per-operation work.
 ### `From<ServiceResponse>` extraction only (no extension injection)
 
 - **ALT-003 Description**: The outer middleware attempts to infer `object_uid` and
-  `algorithm` by deserialising the TTLV *response* body.
+  `algorithm` by deserialising the TTLV _response_ body.
 - **ALT-004 Rejection Reason**: TTLV response bodies are not always structured to expose
   UIDs (e.g. `EncryptResponse` does not echo back the key UID). Response bodies can be
   large. Double-parsing the body adds latency and complexity. The extension injection
@@ -146,7 +146,7 @@ mechanism is in place; filling it is incremental per-operation work.
 - **IMP-003**: Injection site: `crate/server/src/routes/kmip/audit.rs`
   (`inject_kmip_audit_context()` called from KMIP route handlers)
 - **IMP-004**: Middleware registration: `crate/server/src/start_kms_server.rs`
-  (`.wrap(AuditMiddleware::new(audit_store.clone()))` before `.wrap(cors)`)
+  (`.wrap(AuditMiddleware::new(audit_store.clone(), trusted_proxy_cidrs.clone()))` before `.wrap(cors)`)
 - **IMP-005**: To fill T1 — inject `KmipObjectUid` from each operation handler's
   request/response TTLV; see `tradeoofs.md` and `.agents/prompts/fill-audit-object-uid.md`
 - **IMP-006**: Infallibility rule: all functions in `routes/kmip/audit.rs` must be

--- a/documentation/docs/adr/0004-audit-middleware-extension-injection.md
+++ b/documentation/docs/adr/0004-audit-middleware-extension-injection.md
@@ -1,0 +1,161 @@
+---
+title: "ADR-0004: HTTP-Layer Audit Middleware with Actix Extension Injection"
+status: "Accepted"
+date: "2026-07-09"
+authors: "contributors, security architects, compliance engineers"
+tags: ["architecture", "decision", "audit", "middleware", "actix-web"]
+supersedes: ""
+superseded_by: ""
+---
+
+# ADR-0004: HTTP-Layer Audit Middleware with Actix Extension Injection
+
+## Status
+
+Accepted
+
+## Context
+
+Every KMIP operation — including authentication failures — must produce an audit event
+(see ADR-0003). The challenge is *where* in the call stack to intercept it. The KMS has
+a layered architecture:
+
+```
+HTTP client
+  │
+  ▼  Actix-web middlewares (CORS, EnsureAuth, JwtAuth, TlsAuth, RateLimit, …)
+  ▼  KMIP route handler (TTLV deserialisation → dispatch → TTLV serialisation)
+  ▼  KMS core (operations: Create, Encrypt, Destroy, …)
+  ▼  Database / HSM backends
+```
+
+Two hard requirements compete:
+
+1. **401/403 authentication failures must be audited.** This means the audit hook must run
+   *outside* the auth middlewares so it sees their rejection responses.
+2. **Per-operation context (`object_uid`, `algorithm`) should be captured.** This context
+   only exists *inside* the KMIP dispatch layer, deep in the stack.
+
+Instrumenting every individual KMIP operation handler (≈40 operations) would satisfy
+requirement 2 but misses requirement 1 for failed auth. A pure outer middleware satisfies
+requirement 1 but cannot directly see KMIP-layer data (requirement 2).
+
+## Decision
+
+Implement a two-part design:
+
+### Part 1 — Outer HTTP middleware
+
+An Actix-web `Transform` / `Service` wrapper (`AuditMiddleware`) is registered **just
+before** the CORS middleware in `start_kms_server.rs`:
+
+- It fires **after the inner service has returned** (post-response hook), recording the
+  HTTP status code and wall-clock duration.
+- It always runs, even when inner services return 401/403 — unauthenticated events are
+  recorded with `user = "unauthenticated"`.
+- When `AuditFileStore` is `None` (audit disabled) the middleware is a zero-cost
+  pass-through (single `Option::is_none()` check).
+- CORS `OPTIONS` preflight requests are not audited (CORS middleware handles them before
+  the audit wrapper runs — acceptable, as preflight carries no KMIP semantics).
+
+### Part 2 — Actix extension injection from the KMIP route layer
+
+The KMIP route handler, after TTLV parsing but before (or after) dispatch, injects
+structured context into the Actix request extensions:
+
+| Extension type      | Populated by          | Content                                       |
+|---------------------|-----------------------|-----------------------------------------------|
+| `KmipOperationName` | TTLV parser           | `"Encrypt"`, `"Create"`, `"Create+Destroy"` … |
+| `KmipObjectUid`     | route handler         | UID from request or server-assigned (Create)  |
+| `KmipAlgorithm`     | route handler         | `"AES"`, `"RSA"`, …                           |
+
+The outer middleware reads these extensions when composing the `AuditEventDraft`.  If an
+extension is absent (e.g. non-KMIP endpoint, or extraction failed) the field defaults to
+`None` — the audit record is degraded but the request is never affected.
+
+**Infallibility principle**: all TTLV extraction functions are explicitly infallible. A
+parsing failure returns `None`; it never propagates an error to the response or panics.
+Audit context extraction is best-effort; the KMIP response is authoritative.
+
+### Current state vs. full design
+
+`KmipObjectUid` and `KmipAlgorithm` injection are defined and exported but not yet
+populated by all operation handlers (tracked as T1 in `tradeoofs.md`). The extension
+mechanism is in place; filling it is incremental per-operation work.
+
+## Consequences
+
+### Positive
+
+- **POS-001**: Authentication failures (401/403) are audited with no per-handler changes.
+- **POS-002**: Adding audit coverage to a new KMIP operation requires only populating
+  `KmipObjectUid` and `KmipAlgorithm` extensions — no changes to the audit middleware
+  or the storage layer.
+- **POS-003**: The middleware is a zero-overhead pass-through when audit is disabled.
+- **POS-004**: Infallibility guarantees that a buggy TTLV extractor never breaks the
+  KMIP response.
+- **POS-005**: Middleware ordering is explicit and documented in `start_kms_server.rs`.
+
+### Negative
+
+- **NEG-001**: Until all handlers inject `KmipObjectUid`, the field is `None` — the log
+  cannot answer "which key was used", failing FIPS key lifecycle accountability and
+  PCI-DSS 10.2.1.2 (tracked: T1).
+- **NEG-002**: Batch `RequestMessage` with N `BatchItems` produces one audit event.
+  Per-item granularity requires a different enqueue API (tracked: T2).
+- **NEG-003**: The `client_ip` is taken from `X-Forwarded-For` without validating the
+  peer IP against a trusted-proxy allowlist — spoofable (tracked: T7).
+- **NEG-004**: Middleware ordering is implicit in `start_kms_server.rs` registration
+  order; a future reordering could accidentally exclude auth-failure events.
+
+## Alternatives Considered
+
+### Per-operation instrumentation in the dispatch layer
+
+- **ALT-001 Description**: Add an `audit(&mut self, event: AuditEventDraft)` call inside
+  each of the ~40 `crate/server/src/core/operations/<op>.rs` handlers, after the
+  operation completes.
+- **ALT-002 Rejection Reason**: Does not capture authentication failures (the dispatch
+  layer is never reached on a 401). Requires touching every operation handler — high
+  coupling and high churn. A cross-cutting concern belongs in a middleware, not scattered
+  across 40 files.
+
+### `From<ServiceResponse>` extraction only (no extension injection)
+
+- **ALT-003 Description**: The outer middleware attempts to infer `object_uid` and
+  `algorithm` by deserialising the TTLV *response* body.
+- **ALT-004 Rejection Reason**: TTLV response bodies are not always structured to expose
+  UIDs (e.g. `EncryptResponse` does not echo back the key UID). Response bodies can be
+  large. Double-parsing the body adds latency and complexity. The extension injection
+  approach puts the extraction at the right layer (knows the request context) with no
+  double-parsing.
+
+### Actix `HttpRequest::extensions_mut()` in a post-dispatch hook
+
+- **ALT-005 Description**: Use Actix's `on_connect` or a request finaliser callback to
+  write audit data after the inner future resolves.
+- **ALT-006 Rejection Reason**: Actix-web does not have a first-class post-dispatch hook
+  that receives both the request extensions and the final response simultaneously. The
+  `Transform`/`Service` wrapper pattern is the idiomatic Actix way to wrap request-response
+  pairs; it is well-understood, tested, and used by other middlewares in this codebase.
+
+## Implementation Notes
+
+- **IMP-001**: Middleware: `crate/server/src/middlewares/audit.rs`
+- **IMP-002**: Extension types exported from `crate/server/src/middlewares/mod.rs`
+- **IMP-003**: Injection site: `crate/server/src/routes/kmip/audit.rs`
+  (`inject_kmip_audit_context()` called from KMIP route handlers)
+- **IMP-004**: Middleware registration: `crate/server/src/start_kms_server.rs`
+  (`.wrap(AuditMiddleware::new(audit_store.clone()))` before `.wrap(cors)`)
+- **IMP-005**: To fill T1 — inject `KmipObjectUid` from each operation handler's
+  request/response TTLV; see `tradeoofs.md` and `.agents/prompts/fill-audit-object-uid.md`
+- **IMP-006**: Infallibility rule: all functions in `routes/kmip/audit.rs` must be
+  `fn f(..) -> Option<String>` or return a fallback — never `KResult`.
+
+## References
+
+- **REF-001**: ADR-0003 — Tamper-Evident JSONL Audit Log (storage layer decisions)
+- **REF-002**: Actix-web middleware docs — `Transform` / `Service` pattern
+- **REF-003**: `tradeoofs.md` T1, T2, T7 — known gaps in this design
+- **REF-004**: `crate/server/src/middlewares/audit.rs` — "Design decisions" doc comment
+- **REF-005**: `crate/server/src/start_kms_server.rs` — middleware registration order

--- a/documentation/docs/adr/0005-cef-siem-export-format.md
+++ b/documentation/docs/adr/0005-cef-siem-export-format.md
@@ -1,0 +1,150 @@
+---
+title: "ADR-0005: CEF v25 as SIEM Export Format for Audit Events"
+status: "Accepted"
+date: "2026-07-09"
+authors: "contributors, security operations engineers, compliance engineers"
+tags: ["architecture", "decision", "audit", "siem", "cef", "interoperability"]
+supersedes: ""
+superseded_by: ""
+---
+
+# ADR-0005: CEF v25 as SIEM Export Format for Audit Events
+
+## Status
+
+Accepted
+
+## Context
+
+The tamper-evident JSONL audit log (ADR-0003) stores events in a KMS-specific JSON schema
+optimised for hash-chain verification. Compliance environments additionally require feeding
+audit events into centralised SIEM systems such as ArcSight, Splunk, IBM QRadar, or
+Microsoft Sentinel for:
+
+- Real-time alerting on suspicious patterns (e.g. mass `Destroy` operations)
+- Cross-system correlation (KMS events alongside firewall, IdP, and application logs)
+- Long-term retention and search under SIEM licencing
+
+SIEM connectors are diverse and often expect a vendor-neutral wire format rather than
+a proprietary JSON schema. The KMS must choose a serialisation format that:
+
+1. Is widely supported by existing SIEM connectors with no custom parser.
+2. Carries the fields needed for compliance (user, timestamp, operation, outcome, IP).
+3. Is space-efficient enough for high-volume forwarding.
+4. Remains a *view* of the audit record — it must not replace the authoritative JSONL log.
+
+## Decision
+
+Implement `to_cef_line()` on `AuditEvent` producing a **CEF v25** (ArcSight Common Event
+Format, revision 25) line string.
+
+```text
+CEF:0|Cosmian|KMS|<version>|<operation>|<operation>|<severity>|<extensions>
+```
+
+Severity mapping:
+| Outcome | CEF severity | Rationale |
+|---|---|---|
+| `Success` | 5 (Medium) | Normal operation |
+| Auth failure (401/403) | 7 (High) | Potential intrusion |
+| Other failure | 6 (Medium-High) | Operational issue |
+
+Extension fields: `rt` (epoch ms), `suser` (user), `src` (client IP), `outcome`,
+`act` (operation), `duid` (object UID), `cs1` (algorithm), `cs2` (duration ms).
+
+CEF is implemented as a **pure serialisation method** (`fn to_cef_line(&self) -> String`)
+on `AuditEvent`. It is not a transport; callers are responsible for forwarding the string
+to a syslog socket, a file, or a network destination. This keeps the KMS codebase free of
+SIEM-specific network transport dependencies.
+
+## Consequences
+
+### Positive
+
+- **POS-001**: CEF is natively ingested by ArcSight, Splunk (via CIM auto-detection),
+  IBM QRadar (DSM), Microsoft Sentinel, and most major SIEMs without a custom parser.
+- **POS-002**: The format is self-describing (vendor, product, version embedded) — no
+  schema negotiation needed.
+- **POS-003**: Single-line format is trivially forwarded via `syslog`, `filebeat`,
+  `fluentd`, or direct UDP/TCP without framing issues.
+- **POS-004**: Pure serialisation: zero network dependencies added to the codebase;
+  no async runtime required; no TLS certificate management for the SIEM transport.
+- **POS-005**: `object_uid`, `algorithm`, and `client_ip` map directly to CEF standard
+  extension keys (`duid`, `cs1`, `src`) — no custom-key gymnastics.
+
+### Negative
+
+- **NEG-001**: CEF is a flat key=value line; the hash-chain fields (`prev_hash`,
+  `row_hash`) are not included. CEF output alone is not verifiable — the JSONL file
+  remains the authoritative audit record.
+- **NEG-002**: CEF escaping rules (backslash, pipe) require careful handling; a bug in
+  the serialiser could produce malformed lines silently accepted by some SIEMs but
+  rejected by others.
+- **NEG-003**: The transport layer is delegated to the operator (syslog daemon, file
+  tail agent). There is no built-in forwarding; operators must configure their own
+  pipeline.
+- **NEG-004**: CEF `cs` (custom string) fields have no semantic standard — `cs1` for
+  algorithm and `cs2` for duration are KMS-specific conventions that must be documented
+  for SIEM operators.
+
+## Alternatives Considered
+
+### Syslog (RFC 5424) structured data
+
+- **ALT-001 Description**: Emit RFC 5424 messages with a structured-data element (SD-ID
+  `cosmian_kms@<PEN>`) carrying audit fields. Natively supported by syslogd, rsyslog,
+  syslog-ng.
+- **ALT-002 Rejection Reason**: RFC 5424 structured data requires a registered Private
+  Enterprise Number (PEN) for the SD-ID to be unambiguous in external environments.
+  SIEM ingestion of RFC 5424 structured data is less uniform than CEF — many SIEMs treat
+  the SD-ID as opaque. CEF has broader out-of-the-box support.
+
+### LEEF (IBM Log Event Extended Format)
+
+- **ALT-003 Description**: IBM's LEEF is the native format for IBM QRadar, similar in
+  structure to CEF.
+- **ALT-004 Rejection Reason**: LEEF is QRadar-specific. CEF has wider multi-vendor
+  support (ArcSight, Splunk, Sentinel, QRadar, and others all ingest CEF). Implementing
+  both would be duplication; CEF is the more universal choice.
+
+### OCSF (Open Cybersecurity Schema Framework)
+
+- **ALT-005 Description**: OCSF (AWS + 18 partners, 2022) is a JSON schema for security
+  events with a formal taxonomy. Growing adoption in cloud-native SIEMs.
+- **ALT-006 Rejection Reason**: OCSF tooling and SIEM connector maturity is lower than
+  CEF as of 2026 for on-premise KMS deployments. The OCSF schema is richer but heavier;
+  the per-event JSON overhead is larger than a CEF line. CEF remains the dominant choice
+  for on-premise compliance tooling. OCSF support can be added later as a second
+  serialiser without removing CEF.
+
+### Raw KMS JSON (reuse JSONL schema)
+
+- **ALT-007 Description**: Forward the JSONL audit line directly to the SIEM.
+- **ALT-008 Rejection Reason**: Custom JSON schema requires a SIEM-side parser for each
+  SIEM product. Includes `prev_hash` / `row_hash` fields that are meaningless to a SIEM.
+  Does not map to any standard event taxonomy, so cross-system correlation is harder.
+
+## Implementation Notes
+
+- **IMP-001**: Serialiser: `crate/access/src/audit/cef.rs` — `to_cef_line()`
+- **IMP-002**: CEF v25 spec reference: ArcSight CEF Implementation Standard, version 25
+  (HP/Micro Focus/OpenText)
+- **IMP-003**: Severity thresholds (5/6/7) are constants in `cef.rs`; operators needing
+  different mappings should adjust there.
+- **IMP-004**: Transport is out of scope for this implementation. Recommended pattern:
+  tail the JSONL file with `filebeat` / `fluent-bit`, convert each line via
+  `ckms audit to-cef`, pipe to a syslog destination.
+- **IMP-005**: CEF escaping: `|` → `\|`, `\` → `\\` in header fields;
+  `=` → `\=`, `\n` → `\\n`, `\r` → `\\r` in extension values. Covered by unit tests
+  in `cef.rs`.
+- **IMP-006**: The `row_hash` and `prev_hash` fields are intentionally absent from CEF
+  output — document this explicitly for SIEM operators: the CEF stream alone is not
+  chain-verifiable.
+
+## References
+
+- **REF-001**: ADR-0003 — Tamper-Evident JSONL Audit Log (authoritative record)
+- **REF-002**: ADR-0004 — HTTP-Layer Audit Middleware (capture architecture)
+- **REF-003**: ArcSight CEF Implementation Standard v25 (HP/Micro Focus/OpenText)
+- **REF-004**: OCSF v1.x specification — https://schema.ocsf.io
+- **REF-005**: `crate/access/src/audit/cef.rs`

--- a/documentation/docs/configuration/audit-logs.md
+++ b/documentation/docs/configuration/audit-logs.md
@@ -46,10 +46,29 @@ When `audit.file.path` is omitted the file defaults to `<root-data-path>/audit.j
 | `--audit-enable`           | `KMS_AUDIT_ENABLE`           | `false`                        | Enable the audit pipeline. When `false` no file is created and no writer thread is spawned.                                              |
 | `--audit-file-path`        | `KMS_AUDIT_FILE_PATH`        | `<root-data-path>/audit.jsonl` | Absolute path to the JSONL audit log file. Parent directories are created automatically on first write.                                  |
 | `--audit-channel-capacity` | `KMS_AUDIT_CHANNEL_CAPACITY` | `4096`                         | Capacity of the bounded in-memory channel between request threads and the writer task. Each event is ≈ 500 B (≈ 2 MiB total at default). |
+| `--audit-trusted-proxy-cidrs` | `KMS_AUDIT_TRUSTED_PROXY_CIDRS` | _(empty)_                    | Comma-separated CIDR blocks (e.g. `10.0.0.0/8,172.16.0.0/12`) of reverse proxies/load balancers allowed to set `client_ip` via `X-Forwarded-For`. See [Client IP and reverse proxies](#client-ip-and-reverse-proxies). |
 
 > **Tip**: if you see `AuditFileStore: channel full` in the server log under sustained high load, raise
 > `--audit-channel-capacity`. When the channel is full the event is dropped (non-blocking) and an
 > `error!` line is emitted — the request itself is never blocked.
+
+### Client IP and reverse proxies
+
+By default (`--audit-trusted-proxy-cidrs` empty), `client_ip` in every audit event is always the
+direct TCP peer address — the `X-Forwarded-For` header is ignored entirely.
+
+If the KMS runs **directly reachable** by clients (no reverse proxy/load balancer in front), leave
+this unset: the TCP peer address is always the real client.
+
+If the KMS runs **behind a reverse proxy or load balancer**, the direct TCP peer is always the
+proxy, not the real client. Set `--audit-trusted-proxy-cidrs` to the proxy's IP/CIDR so the audit
+middleware knows it can trust `X-Forwarded-For` coming from that address — otherwise every audit
+event will record the proxy's IP instead of the real client's.
+
+**Never** trust `X-Forwarded-For` unconditionally: any direct caller can set that header to an
+arbitrary value, corrupting the forensic trail (e.g. framing another IP, or hiding its own).
+Restricting trust to known proxy CIDRs prevents this while still letting a legitimate reverse
+proxy forward the real client IP.
 
 ---
 

--- a/documentation/docs/configuration/audit-logs.md
+++ b/documentation/docs/configuration/audit-logs.md
@@ -1,0 +1,158 @@
+# Audit logging
+
+The Eviden KMS server can write a cryptographically-chained, tamper-evident audit trail of every
+KMIP operation to a local JSONL file. Each line is a JSON object; the file is human-readable and
+can be parsed by any standard tooling.
+
+Audit logging is **disabled by default**. No file is created and no background writer thread is
+spawned until the feature is explicitly enabled.
+
+---
+
+## Enable audit logging
+
+=== "TOML configuration file"
+
+    ```toml
+    [audit]
+    enabled = true
+
+    [audit.file]
+    path = "/var/log/cosmian-kms/audit.jsonl"
+    ```
+
+=== "Command line"
+
+    ```bash
+    cosmian_kms --audit-enable --audit-file-path /var/log/cosmian-kms/audit.jsonl
+    ```
+
+=== "Environment variables"
+
+    ```bash
+    export KMS_AUDIT_ENABLE=true
+    export KMS_AUDIT_FILE_PATH=/var/log/cosmian-kms/audit.jsonl
+    cosmian_kms
+    ```
+
+When `audit.file.path` is omitted the file defaults to `<root-data-path>/audit.jsonl`.
+
+---
+
+## Configuration reference
+
+| CLI flag                   | Environment variable         | Default                        | Description                                                                                                                              |
+| -------------------------- | ---------------------------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `--audit-enable`           | `KMS_AUDIT_ENABLE`           | `false`                        | Enable the audit pipeline. When `false` no file is created and no writer thread is spawned.                                              |
+| `--audit-file-path`        | `KMS_AUDIT_FILE_PATH`        | `<root-data-path>/audit.jsonl` | Absolute path to the JSONL audit log file. Parent directories are created automatically on first write.                                  |
+| `--audit-channel-capacity` | `KMS_AUDIT_CHANNEL_CAPACITY` | `4096`                         | Capacity of the bounded in-memory channel between request threads and the writer task. Each event is ≈ 500 B (≈ 2 MiB total at default). |
+
+> **Tip**: if you see `AuditFileStore: channel full` in the server log under sustained high load, raise
+> `--audit-channel-capacity`. When the channel is full the event is dropped (non-blocking) and an
+> `error!` line is emitted — the request itself is never blocked.
+
+---
+
+## Event schema
+
+Each line in the JSONL file is a complete JSON object with the following fields:
+
+| Field         | Type                                     | Nullable | Description                                                                                                                          |
+| ------------- | ---------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `id`          | `integer`                                | No       | Monotonically increasing row counter, starting at 0.                                                                                 |
+| `timestamp`   | `string` (RFC 3339 / UTC)                | No       | Wall-clock time of the KMIP operation.                                                                                               |
+| `operation`   | `string`                                 | No       | KMIP operation name, e.g. `"Create"`, `"Encrypt"`, `"Destroy"`. Batch requests produce a `+`-joined name such as `"Create+Encrypt"`. |
+| `user`        | `string`                                 | No       | Authenticated username. `"unauthenticated"` when no identity was presented (e.g. 401 paths).                                         |
+| `object_uid`  | `string` or `null`                       | Yes      | KMIP `UniqueIdentifier` of the object involved. `null` when unavailable (e.g. failed auth, batch).                                   |
+| `algorithm`   | `string` or `null`                       | Yes      | Cryptographic algorithm, e.g. `"AES"`, `"RSA"`. `null` when the operation carries no algorithm.                                      |
+| `client_ip`   | `string` or `null`                       | Yes      | Source IP from `X-Forwarded-For` (if present) or the TCP peer address.                                                               |
+| `result`      | `"Success"` or `{"Failure": "<reason>"}` | No       | Outcome of the operation.                                                                                                            |
+| `duration_ms` | `integer`                                | No       | Wall-clock duration of the operation in milliseconds.                                                                                |
+| `prev_hash`   | `string` (64 hex chars)                  | No       | SHA-256 of the previous row's canonical bytes. All-zeros for the first row (`id = 0`).                                               |
+| `row_hash`    | `string` (64 hex chars)                  | No       | SHA-256 of this row's canonical bytes (including `prev_hash`).                                                                       |
+
+**Example event**:
+
+```json
+{
+  "id": 4,
+  "timestamp": "2026-05-06T20:31:42.321328507Z",
+  "operation": "Encrypt",
+  "user": "admin",
+  "object_uid": "417fe2de-827d-48d0-8d51-851bec315b76",
+  "algorithm": "AES",
+  "client_ip": "127.0.0.1",
+  "result": "Success",
+  "duration_ms": 1,
+  "prev_hash": "e492c0f02860bc6c428259d44414651eda3aaaee2f48eb857144c940ac0fe909",
+  "row_hash": "699a2837830af4a26fe79aeb48509fc707507e514da5850d953366a14e730c38"
+}
+```
+
+---
+
+## Hash chain
+
+Every persisted event includes a SHA-256 hash chain that makes tampering detectable offline.
+
+The hash is computed over a canonical byte sequence of the event's fields:
+`id || timestamp || operation || user || object_uid || algorithm || client_ip || result || duration_ms || prev_hash`
+
+`prev_hash` of the first event (`id = 0`) is the 32-byte all-zeros sentinel.
+
+Any modification to a field in any row — including reordering rows, deleting rows, or appending
+forged rows — breaks at least one `prev_hash → row_hash` link and is detected by `ckms audit verify`.
+
+#### Durability
+
+Each write is followed by [`fsync()`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/fsync.html) to ensure data is physically written to disk. Events survive
+an OS crash or power failure as long as the storage medium has confirmed the write.
+
+On restart the server reads only the last 64 KiB of an existing log file to resume the chain. **If the last event's `row_hash` does not verify, the server refuses to start and reports the corrupted line.**
+
+---
+
+## Verify the chain offline
+
+You can run the following command:
+
+```bash
+ckms audit verify --path /var/log/cosmian-kms/audit.jsonl
+```
+
+**Sample output: intact chain**:
+
+```
+Verified 42 events. Chain is intact.
+```
+
+**Sample output: tampered file**:
+
+```
+TAMPERED: event id=17 row_hash mismatch
+```
+
+**Exit codes**: `0` = intact, `1` = broken or tampered.
+
+With `--verbose`, a summary line is printed for every event:
+
+```
+id=0  2026-05-06T20:31:15Z  Create   chain=ok
+id=1  2026-05-06T20:31:15Z  Encrypt  chain=ok
+...
+```
+
+---
+
+## Best practices
+
+- Use an **append-only** filesystem or object store (e.g. S3 with Object Lock) for the audit
+  file.
+- Restrict read access to the audit file to the KMS process user and auditors only; the file
+  contains usernames and operation details.
+- Retain audit files for the compliance window required by your framework
+  (PCI-DSS Req. 10.7: 12 months; HIPAA §164.312(b): 6 years).
+- If the server refuses to start because the last event's `row_hash` does not verify
+  (corrupted write), move the file aside and restart — the server will create a fresh log.
+  Keep the corrupted file for forensic review.
+- For SIEM ingestion and CEF export, see [SIEMs](./siems.md).

--- a/documentation/docs/configuration/log-reference.md
+++ b/documentation/docs/configuration/log-reference.md
@@ -111,7 +111,7 @@ Crate path: `crate/server`
 | `info` | `POST /kms/xks/v1/keys/{key_id}/encrypt - operation: {} - id: {} - user: {}` | `src/routes/aws_xks/encrypt_decrypt/encrypt_.rs` | `key_id`: XKS key identifier | - |
 | `info` | `POST /kms/xks/v1/keys/{key_id}/metadata - operation: {} - id: {} - user: {}` | `src/routes/aws_xks/key_metadata.rs` | `key_id`: XKS key identifier | - |
 | `info` | `Refreshing JWKS` | `src/middlewares/jwt/jwks.rs` | - | - |
-| `info` | `Response TTLV: {ttlv:?}` | `src/routes/kmip.rs` | `ttlv`: TTLV-encoded response | - |
+| `info` | `Response TTLV: {ttlv:?}` | `src/routes/kmip/handlers.rs` | `ttlv`: TTLV-encoded response | - |
 | `info` | `Revoked object type: {}` | `src/core/operations/revoke.rs` | - | - |
 | `info` | `RSA Keypair for Google CSE already exists (detected by UNIQUE constraint). Continuing without error.` | `src/start_kms_server.rs` | - | - |
 | `info` | `RSA Keypair for Google CSE already exists (pre-check).` | `src/start_kms_server.rs` | - | - |
@@ -476,17 +476,17 @@ Crate path: `crate/server`
 | `trace` | `{}` | `src/core/operations/attributes/delete.rs` | — | — |
 | `trace` | `{}` | `src/core/operations/certify/certify_op.rs` | — | — |
 | `trace` | `{}` | `src/core/operations/locate.rs` | — | — |
-| `error` | `Failed to convert response message to TTLV: {}` | `src/routes/kmip.rs` | — | ×2 in this file |
-| `error` | `Failed to find KMIP version` | `src/routes/kmip.rs` | — | — |
-| `error` | `Failed to parse RequestMessage: {}` | `src/routes/kmip.rs` | — | — |
-| `error` | `Failed to process request: {}` | `src/routes/kmip.rs` | — | ×2 in this file |
+| `error` | `Failed to convert response message to TTLV: {}` | `src/routes/kmip/handlers.rs` | — | ×2 in this file |
+| `error` | `Failed to find KMIP version` | `src/routes/kmip/handlers.rs` | — | — |
+| `error` | `Failed to parse RequestMessage: {}` | `src/routes/kmip/handlers.rs` | — | — |
+| `error` | `Failed to process request: {}` | `src/routes/kmip/handlers.rs` | — | ×2 in this file |
 | `error` | `OpenSSL does not appear to be available (version number is 0).              Please verify that OpenSSL is correctly installed and accessible.` | `src/main.rs` | — | — |
 | `warn` | `An Edwards Keypair on curve 25519 should not be requested to perform                              ECDH. Creating anyway.` | `src/core/operations/create_key_pair.rs` | — | — |
 | `warn` | `An Edwards Keypair on curve 448 should not be requested to perform                              ECDH. Creating anyway.` | `src/core/operations/create_key_pair.rs` | — | — |
 | `warn` | `CRL signature could not be verified against chain issuers; issuer: {:?}.                          Continuing with status checks.` | `src/core/operations/validate.rs` | — | — |
 | `warn` | `Import: CRL check could not be completed ({e}),                              proceeding with {desired_state:?} state` | `src/core/operations/import.rs` | `e`, `desired_state` | — |
 | `warn` | `The UI index HTML folder does not contain an index.html file:                  {ui_index_html_folder:#?}` | `src/config/params/server_params.rs` | `ui_index_html_folder` | — |
-| `warn` | `Unsupported Block Cipher Mode for AES: {x:?}. The Authenticated                                  Encryption Tag will NOT be extracted.` | `src/routes/kmip.rs` | `x` | — |
+| `warn` | `Unsupported Block Cipher Mode for AES: {x:?}. The Authenticated                                  Encryption Tag will NOT be extracted.` | `src/routes/kmip/handlers.rs` | `x` | — |
 | `warn` | `User-supplied keyUsage in extension config overrides the RFC-mandated PQC keyUsage              extension (RFC 9881/9909/9935)` | `src/core/operations/certify/build_certificate.rs` | — | — |
 | `debug` | `...unwrapping the key block with key uid: {unwrapping_key_uid} using an encryption              oracle, user: {user}` | `src/core/wrapping/unwrap.rs` | `unwrapping_key_uid`, `user` | — |
 | `debug` | `...unwrapping the key block with key uid: {unwrapping_key_uid} using the KMS, user:              {user}` | `src/core/wrapping/unwrap.rs` | `unwrapping_key_uid`, `user` | — |
@@ -503,12 +503,12 @@ Crate path: `crate/server`
 | `debug` | `DeriveKey: No derivation data provided - this may be acceptable if a Secret Data              object identifier is provided` | `src/core/operations/derive_key.rs` | — | — |
 | `debug` | `Import: certificate is revoked per CRL check,                              setting state to Compromised` | `src/core/operations/import.rs` | — | — |
 | `debug` | `JWT: An authenticated user was found; there is no need to authenticate                      twice...` | `src/middlewares/jwt/jwt_middleware.rs` | — | — |
-| `debug` | `Request bytes: {}` | `src/routes/kmip.rs` | — | — |
-| `debug` | `Request TTLV: {ttlv:#?}` | `src/routes/kmip.rs` | `ttlv` | — |
-| `debug` | `Response Message Bytes: {}` | `src/routes/kmip.rs` | — | — |
-| `debug` | `Response Message TTLV: {response_ttlv:#?}` | `src/routes/kmip.rs` | `response_ttlv` | — |
+| `debug` | `Request bytes: {}` | `src/routes/kmip/handlers.rs` | — | — |
+| `debug` | `Request TTLV: {ttlv:#?}` | `src/routes/kmip/handlers.rs` | `ttlv` | — |
+| `debug` | `Response Message Bytes: {}` | `src/routes/kmip/handlers.rs` | — | — |
+| `debug` | `Response Message TTLV: {response_ttlv:#?}` | `src/routes/kmip/handlers.rs` | `response_ttlv` | — |
 | `debug` | `The user: {user}, is authorized to wrap with the key {wrapping_key_uid}. Encoding: {:?},          format: {}` | `src/core/wrapping/wrap.rs` | `user`, `wrapping_key_uid` | — |
-| `debug` | `This is a {major}.{minor} Decrypt message. Extracting                                      Authenticated Encryption Tag of length {len} from Data field` | `src/routes/kmip.rs` | `major`, `minor`, `len` | — |
+| `debug` | `This is a {major}.{minor} Decrypt message. Extracting                                      Authenticated Encryption Tag of length {len} from Data field` | `src/routes/kmip/handlers.rs` | `major`, `minor`, `len` | — |
 | `trace` | `Certify PublicKeyAndSubjectName:{unique_identifier}: public key:                  {from_public_key}` | `src/core/operations/certify/certify_op.rs` | `unique_identifier`, `from_public_key` | — |
 | `trace` | `ciphertext: {ciphertext:?}, nonce: {nonce:?}, aad: {aad:?}, tag: {tag:?},              padding_method: {padding_method:?}` | `src/core/operations/decrypt.rs` | `ciphertext`, `nonce`, `aad`, `tag`, `padding_method` | — |
 | `trace` | `enter export_get op={:?} req={}` | `src/core/operations/export_get.rs` | — | ×2 in this file |
@@ -521,13 +521,13 @@ Crate path: `crate/server`
 | `trace` | `process_symmetric_key set Raw uid={}` | `src/core/operations/export_get.rs` | — | — |
 | `trace` | `process_symmetric_key set TransparentSymmetricKey uid={}` | `src/core/operations/export_get.rs` | — | — |
 | `trace` | `processing symmetric key uid={} state={:?} requested_format={:?}` | `src/core/operations/export_get.rs` | — | — |
-| `trace` | `Request Message: {request_message}` | `src/routes/kmip.rs` | `request_message` | — |
-| `trace` | `Response Message: {response_message}` | `src/routes/kmip.rs` | `response_message` | — |
+| `trace` | `Request Message: {request_message}` | `src/routes/kmip/handlers.rs` | `request_message` | — |
+| `trace` | `Response Message: {response_message}` | `src/routes/kmip/handlers.rs` | `response_message` | — |
 | `trace` | `retrieved object uid={} type={:?} state={:?} key_fmt={:?}` | `src/core/operations/export_get.rs` | — | — |
 | `trace` | `uid_or_tags: {uid_or_tags:?}, user: {user},          operation_type: {operation_type:?}` | `src/core/retrieve_object_utils.rs` | `uid_or_tags`, `user`, `operation_type` | — |
-| `error` | `Failed to convert Response TTLV to bytes: {}: TTLV:\n{:#?}` | `src/routes/kmip.rs` | — | — |
-| `warn` | `Failed to process request:\n{response_message}` | `src/routes/kmip.rs` | `response_message` | — |
-| `info` | `\n{:?}` | `src/routes/kmip.rs` | — | — |
+| `error` | `Failed to convert Response TTLV to bytes: {}: TTLV:\n{:#?}` | `src/routes/kmip/handlers.rs` | — | — |
+| `warn` | `Failed to process request:\n{response_message}` | `src/routes/kmip/handlers.rs` | `response_message` | — |
+| `info` | `\n{:?}` | `src/routes/kmip/handlers.rs` | — | — |
 | `trace` | `JWK has been found:\n{jwk:?}` | `src/middlewares/jwt/jwt_config.rs` | `jwk` | — |
 | `trace` | `JWK has been found:\n{jwk:?}` | `src/routes/google_cse/jwt.rs` | `jwk` | — |
 | `warn` | `Failed to persist auto-deactivation of object {}: {}` | `src/core/retrieve_object_utils.rs` | - | ×2 in this file |
@@ -608,12 +608,12 @@ Crate path: `crate/server`
 | `trace` | `GET /v1/crypto/keys/{kid}/tags` | `src/routes/jose/tags.rs` | `kid` | - |
 | `trace` | `` JWKS key order is database insertion order — not stable across restarts or backends.          Returning {} eligible key(s); consumers must match by `kid`, not position. `` | `src/routes/jwks.rs` | - | - |
 | `trace` | `POST /v1/crypto/keys/{kid}/tags` | `src/routes/jose/tags.rs` | `kid` | - |
-| `error` | `Failed to serialize response to JSON: {e}` | `src/routes/kmip.rs` | `e` | - |
+| `error` | `Failed to serialize response to JSON: {e}` | `src/routes/kmip/handlers.rs` | `e` | - |
 | `info` | `http_workers not configured; defaulting to total core count ({total})` | `src/start_kms_server.rs` | `total` | - |
 | `info` | `KMS HTTP server configured with {http_workers} worker thread(s)` | `src/start_kms_server.rs` | `http_workers` | - |
-| `debug` | `POST /kmip {}.{} Binary. Request: {:?} {}` | `src/routes/kmip.rs` | - | - |
-| `debug` | `POST /kmip {}.{} JSON. Request: {:?} {}` | `src/routes/kmip.rs` | - | - |
-| `debug` | `POST /kmip/2_1. Request: {:?} {}` | `src/routes/kmip.rs` | - | - |
+| `debug` | `POST /kmip {}.{} Binary. Request: {:?} {}` | `src/routes/kmip/handlers.rs` | - | - |
+| `debug` | `POST /kmip {}.{} JSON. Request: {:?} {}` | `src/routes/kmip/handlers.rs` | - | - |
+| `debug` | `POST /kmip/2_1. Request: {:?} {}` | `src/routes/kmip/handlers.rs` | - | - |
 | `warn` | `JOSE CEK cache insert error for {uid}: {e}` | `src/routes/jose/cek_cache.rs` | `uid`, `e` | - |
 | `warn` | `JOSE CEK cache peek error for {uid}: {e}` | `src/routes/jose/cek_cache.rs` | `uid`, `e` | - |
 | `warn` | `JOSE CEK cache: failed to construct KMIP SymmetricKey: {e}` | `src/routes/jose/cek_cache.rs` | `e` | - |
@@ -669,6 +669,13 @@ Crate path: `crate/server`
 | `warn` | `UI is enabled but ui_session_salt is not set. A random salt will be generated                  per process, which invalidates existing sessions on restart. Set a persistent                  salt for production use.` | `src/start_kms_server.rs` | - | Emitted when the web UI is enabled but `ui_session_salt` (or `KMS_UI_SESSION_SALT`) is not configured. Sessions will not survive server restarts. Set a stable secret value for production. |
 | `trace` | `force_refresh: cooldown active, skipping` | `src/middlewares/jwt/jwks.rs` | - | JWKS cache force-refresh was requested but the cooldown window has not elapsed; the refresh is skipped to prevent DoS via repeated JWKS fetches. |
 | `info` | `Starting Cosmian KMS server version {}` | `src/main.rs` | - | - |
+| `error` | `AuditFileStore: channel full, dropping audit event` | `src/core/audit/file_store.rs` | - | Channel at capacity; event dropped, accounted for by an eviction sentinel on next successful write |
+| `error` | `AuditFileStore: failed to write event id={}: {e} — event dropped` | `src/core/audit/file_store.rs` | `id`, `e` | `id`/`prev_hash` not advanced; next event reuses this slot to preserve chain continuity |
+| `error` | `AuditFileStore: final sync failed: {e}` | `src/core/audit/file_store.rs` | `e` | `fsync` failure during graceful shutdown |
+| `error` | `AuditFileStore: id counter overflow at i64::MAX —                      audit logging stopped. Rotate the log file and restart.` | `src/core/audit/file_store.rs` | - | id space exhausted; audit logging halts until the log file is rotated |
+| `error` | `AuditFileStore: writer task has stopped, audit event dropped` | `src/core/audit/file_store.rs` | - | Channel closed; `enqueue` silently drops the event |
+| `debug` | `AuditFileStore: resuming at id={next_id}, prev_hash={}` | `src/core/audit/file_store.rs` | `next_id`, `prev_hash` | `prev_hash` is truncated to its first 8 bytes (hex) |
+| `debug` | `AuditFileStore: writer loop exited (channel closed)` | `src/core/audit/file_store.rs` | - | Graceful shutdown complete |
 
 ### `cosmian_kms_server_database`
 

--- a/documentation/docs/configuration/logging.md
+++ b/documentation/docs/configuration/logging.md
@@ -260,19 +260,19 @@ To quickly validate that OTLP export works without the full stack:
 
 === "Docker"
 
-  ```bash
-  docker run -p 16686:16686 -p 4317:4317 \
-    -e COLLECTOR_OTLP_ENABLED=true \
-    jaegertracing/all-in-one:latest
-  ```
+```bash
+docker run -p 16686:16686 -p 4317:4317 \
+  -e COLLECTOR_OTLP_ENABLED=true \
+  jaegertracing/all-in-one:latest
+```
 
 === "kms.toml"
 
-  ```toml
-  [logging]
-  otlp = "http://localhost:4317"
-  quiet = true
-  ```
+```toml
+[logging]
+otlp = "http://localhost:4317"
+quiet = true
+```
 
 Then start the KMS locally:
 
@@ -284,3 +284,9 @@ Open [http://localhost:16686](http://localhost:16686) to browse traces in the Ja
 
 > For production use, replace Jaeger with the full OTel Collector + VictoriaMetrics + Grafana
 > stack described above.
+
+---
+
+## Structured audit log
+
+For tamper-evident, compliance-grade event recording, see [Audit logs](./audit-logs.md).

--- a/documentation/docs/configuration/siems.md
+++ b/documentation/docs/configuration/siems.md
@@ -1,0 +1,77 @@
+# Audit SIEM integration
+
+!!! note "Current integration model"
+
+    The KMS does **not** push events to a SIEM directly yet. Instead, the local JSONL file is
+    the authoritative audit store: external SIEMs consume it either by tailing the file
+    directly or by using the `ckms audit export` CLI tool for format conversion.
+
+    A native push pipeline (OpenTelemetry, syslog/CEF, Splunk HEC) [is a planned feature](https://github.com/Cosmian/kms/issues/881?issue=Cosmian%7Ckms%7C937),
+    and will add server-side configuration sections for direct SIEM delivery.
+
+The `ckms audit` subcommands work **entirely offline**: no running KMS server is required.
+
+For the full `ckms audit export` CLI reference — flags, output formats, CEF field mapping, and
+examples — see [Audit commands](https://docs.cosmian.com/kms_clients/audit/).
+
+---
+
+## Splunk (recommended)
+
+Splunk tails the JSONL audit file directly using its Universal Forwarder or a local monitor
+input. This is the only integration that ingests events continuously with no format
+conversion and no custom transport: JSONL in, JSON events out, and delivery state is tracked
+by Splunk.
+
+Add to `inputs.conf` on the indexer or a forwarder:
+
+```ini
+[monitor:///var/log/cosmian-kms/audit.jsonl]
+disabled = false
+sourcetype = _json
+index = kms_audit
+```
+
+With Splunk's built-in `_json` sourcetype, one JSON object per line is parsed as a JSON event
+and top-level fields are searchable. Before enabling the monitor, validate field extraction
+against representative audit events and make sure the `kms_audit` index exists with the
+appropriate retention and access controls.
+
+---
+
+## CEF export for testing and verification
+
+The `ckms audit export --format cef` command converts the JSONL store into CEF and prints it
+to stdout. This is a **manual, one-shot** operation intended for verification — sending a
+sample of events to a CEF listener to confirm parsing and field mapping. It is **not** a
+continuous ingest pipeline; each run re-reads the file from the beginning (or from `--since`)
+and there is no delivery guarantee over the wire.
+
+### Ad hoc export to any listener
+
+For a quick one-off check against any CEF listener:
+
+```bash
+# Send today's events as CEF to a test listener on port 5514
+ckms audit export --format cef \
+  --path /var/log/cosmian-kms/audit.jsonl \
+  --since "$(date -u +%Y-%m-%dT00:00:00Z)" \
+  | nc -u -w 1 <host> 5514
+```
+
+!!! warning "Testing only — expect loss"
+
+    - **UDP has no delivery guarantee**: events can be silently dropped or reordered.
+    - **Use a port ≥ 1024** (e.g. `5514`): port 514 is privileged on Linux and usually
+      occupied by the system syslog daemon.
+    - **No cursor state**: each run re-exports from the beginning of the file (or from
+      `--since`). This is fine for verification and unsuitable for continuous delivery.
+
+---
+
+!!! warning "Restrict access to the audit file"
+
+    The audit file contains actor identities, client IP addresses, object identifiers, and
+    operation metadata. Restrict file ownership to the KMS process user and grant read access
+    only to the collection agent. Do not expose the file over untrusted networks without
+    encryption.

--- a/documentation/docs/kms_clients/audit.md
+++ b/documentation/docs/kms_clients/audit.md
@@ -1,0 +1,157 @@
+## ckms audit
+
+Manage the KMS audit log file offline.
+
+All `ckms audit` commands work **directly on a JSONL file** — no running KMS server is required.
+The subcommands are suitable for scripts, cron jobs, and SIEM export pipelines.
+
+### Usage
+
+`ckms audit <subcommand>`
+
+### Subcommands
+
+**`export`** Export events from the audit log in JSON or CEF format.
+
+**`verify`** Verify the SHA-256 hash chain of the audit log.
+
+---
+
+## ckms audit export
+
+Export events from the audit log to stdout. Supports JSON (default) and CEF output.
+
+### Usage
+
+`ckms audit export --path <FILE> [options]`
+
+### Arguments
+
+`--path [-p] <FILE>` Path to the JSONL audit log file.
+_Required._ Can also be set via `KMS_AUDIT_FILE_PATH`.
+
+`--since <RFC3339>` Export only events whose `timestamp` is greater than or equal to this value.
+The value must be an RFC 3339 timestamp, e.g. `2026-05-01T00:00:00Z`.
+
+`--format <FORMAT>` Output format. One of `json` (default) or `cef`.
+
+`--kms-version <STRING>` KMS version string to embed in the CEF device version header.
+If omitted the field is left blank. Useful when merging exports from multiple nodes.
+
+### Output formats
+
+**`json`** — Emits one JSON object per line on stdout (JSONL). Same schema as the log file.
+
+**`cef`** — Emits one CEF line per event on stdout (`CEF:0` header, Common Event Format spec 0.1):
+
+```
+CEF:0|Cosmian|KMS|<version>|<operation>|<operation>|<severity>|rt=<epoch_ms> suser=<user> ...
+```
+
+#### CEF field mapping
+
+The CEF header fields (`Device Vendor`, `Device Product`, `Device Version`, `Signature ID`, `Name`, `Severity`)
+are set automatically. Extension fields carry the structured event data:
+
+| CEF extension key | Label        | Value                                                              |
+| ----------------- | ------------ | ------------------------------------------------------------------ |
+| `rt`              | —            | Event time as Unix epoch milliseconds.                             |
+| `suser`           | —            | Authenticated username.                                            |
+| `src`             | —            | Client IP. **Omitted** when the IP is not available.               |
+| `outcome`         | —            | `"Success"` or `"Failure"`.                                        |
+| `reason`          | —            | Failure reason string. **Omitted** on success.                     |
+| `act`             | —            | KMIP operation name (e.g. `"Encrypt"`, `"Create+Destroy"`).        |
+| `cn1`             | `durationMs` | Wall-clock operation duration in milliseconds.                     |
+| `cs1`             | `objectUID`  | KMIP `UniqueIdentifier`. **Omitted** when `null`.                  |
+| `cs2`             | `algorithm`  | Cryptographic algorithm. **Omitted** when `null`.                  |
+| `cs3`             | `auditId`    | Monotonically increasing event ID (integer, from `event.id`).      |
+| `cs4`             | `timestamp`  | RFC 3339 UTC timestamp string (human-readable complement to `rt`). |
+
+> **CEF severity** is derived from the result: `5` (Medium) for `Success`; `7` (High) for
+> authorization failures (401 / 403); `6` (Medium-High) for all other failures.
+
+### Examples
+
+Export all events as JSONL:
+
+```bash
+ckms audit export --path /var/log/cosmian-kms/audit.jsonl > events.jsonl
+```
+
+Export events since a given date as CEF, piped to a SIEM:
+
+```bash
+ckms audit export \
+  --path /var/log/cosmian-kms/audit.jsonl \
+  --format cef \
+  --since "2026-05-01T00:00:00Z" \
+  | nc -u splunk-host 514
+```
+
+---
+
+## ckms audit verify
+
+Verify the SHA-256 hash chain of a JSONL audit log file.
+
+Checks that:
+
+1. Each event's `row_hash` matches a freshly computed hash of its fields.
+2. Each event's `prev_hash` matches the `row_hash` of the previous event (or is all-zeros for the first event).
+
+Exits with code **0** when the chain is intact, or **1** when a broken link is detected.
+
+### Usage
+
+`ckms audit verify --path <FILE> [options]`
+
+### Arguments
+
+`--path [-p] <FILE>` Path to the JSONL audit log file.
+_Required._ Can also be set via `KMS_AUDIT_FILE_PATH`.
+
+`--verbose` Print a summary line for every event even when the chain is valid.
+_Default: false._
+
+### Exit codes
+
+| Code | Meaning                                 |
+| ---- | --------------------------------------- |
+| `0`  | All events verified — chain is intact.  |
+| `1`  | A tampered or broken link was detected. |
+
+### Output examples
+
+Chain intact:
+
+```
+Verified 42 events. Chain is intact.
+```
+
+Tampered file:
+
+```
+TAMPERED: event id=17 row_hash mismatch
+```
+
+Verbose mode:
+
+```
+id=0  2026-05-06T20:31:15Z  Create   chain=ok
+id=1  2026-05-06T20:31:15Z  Encrypt  chain=ok
+...
+```
+
+### Examples
+
+Verify a log file and fail CI if the chain is broken:
+
+```bash
+ckms audit verify --path /var/log/cosmian-kms/audit.jsonl
+```
+
+Verbose verification for debugging:
+
+```bash
+ckms audit verify --path audit.jsonl --verbose
+```

--- a/documentation/nav.yml
+++ b/documentation/nav.yml
@@ -133,6 +133,8 @@ nav:
       - Obtaining TLS Certificates: configuration/certificates.md
       - Logging and telemetry: configuration/logging.md
       - Log reference: configuration/log-reference.md
+      - Audit logs: configuration/audit-logs.md
+      - SIEMs: configuration/siems.md
       - Monitoring:
           - Setup: configuration/monitoring-setup.md
           - Metrics reference: configuration/otlp-metrics.md
@@ -164,5 +166,6 @@ nav:
           - Examples: kms_clients/configuration.md
       - Usage:
           - Command Line Interface: kms_clients/usage.md
+          - Audit log management: kms_clients/audit.md
       - Access Rights: kms_clients/authorization.md
       - S/MIME Gmail: kms_clients/smime_gmail.md

--- a/monitoring/OTLP_METRICS.md
+++ b/monitoring/OTLP_METRICS.md
@@ -84,67 +84,67 @@ The server exposes the following instruments via OTLP, as implemented in `crate/
 
 ### KMIP Operations
 
-| Metric | Type | Labels |
-|--------|------|--------|
-| `kms.kmip.operations.total` | counter | `operation` |
-| `kms.kmip.operations.per_user.total` | counter | `operation`, `user` |
-| `kms.kmip.operation.duration` | histogram (s) | `operation` |
+| Metric                               | Type          | Labels              |
+| ------------------------------------ | ------------- | ------------------- |
+| `kms.kmip.operations.total`          | counter       | `operation`         |
+| `kms.kmip.operations.per_user.total` | counter       | `operation`, `user` |
+| `kms.kmip.operation.duration`        | histogram (s) | `operation`         |
 
-> **Note:** The `user` label in `kms.kmip.operations.per_user.total` and `kms.permissions.granted.per_user.total` carries whatever string the authentication middleware extracts (e.g. an OAuth subject, email address, or service-account identifier); operators connecting these metrics to a cloud OTLP backend should be aware that this value will be stored in the backend.
+> **Note:** The `user` label in `kms.kmip.operations.per_user.total` and `kms.permissions.granted.per_user.total` is a truncated SHA-256 hash of the identity string extracted by the authentication middleware (e.g. an OAuth subject, email address, or service-account identifier), not the raw value. The hash is deterministic (the same user always produces the same label, so per-user trend/cardinality analysis still works) but non-reversible, so it cannot be used to identify a real user from the OTLP backend alone. The authoritative record of which user performed which operation is the audit log, not OTEL metrics.
 
 ### Users & Permissions
 
-| Metric | Type | Labels |
-|--------|------|--------|
-| `kms.active.users` | up-down counter | — |
-| `kms.permissions.granted.per_user.total` | counter | `user`, `permission_type` |
-| `kms.permissions.granted.total` | counter | — |
+| Metric                                   | Type            | Labels                    |
+| ---------------------------------------- | --------------- | ------------------------- |
+| `kms.active.users`                       | up-down counter | —                         |
+| `kms.permissions.granted.per_user.total` | counter         | `user`, `permission_type` |
+| `kms.permissions.granted.total`          | counter         | —                         |
 
 ### Database Metrics
 
-| Metric | Type | Labels |
-|--------|------|--------|
-| `kms.database.operations.total` | counter | `operation`, `backend`, `outcome` |
+| Metric                            | Type          | Labels                            |
+| --------------------------------- | ------------- | --------------------------------- |
+| `kms.database.operations.total`   | counter       | `operation`, `backend`, `outcome` |
 | `kms.database.operation.duration` | histogram (s) | `operation`, `backend`, `outcome` |
 
 `backend`: `sqlite` · `postgresql` · `mysql` · `redis` — `outcome`: `success` · `error`
 
 ### HTTP Metrics
 
-| Metric | Type | Labels |
-|--------|------|--------|
-| `kms.http.requests.total` | counter | `method`, `path`, `status` |
+| Metric                      | Type          | Labels                     |
+| --------------------------- | ------------- | -------------------------- |
+| `kms.http.requests.total`   | counter       | `method`, `path`, `status` |
 | `kms.http.request.duration` | histogram (s) | `method`, `path`, `status` |
 
 ### Server Health
 
-| Metric | Type | Labels |
-|--------|------|--------|
-| `kms.server.uptime` | counter (monotonic, s) | — |
-| `kms.server.start_time` | up-down counter | — |
-| `kms.active.connections` | up-down counter | — |
-| `kms.errors.total` | counter | `error_type` |
+| Metric                   | Type                   | Labels       |
+| ------------------------ | ---------------------- | ------------ |
+| `kms.server.uptime`      | counter (monotonic, s) | —            |
+| `kms.server.start_time`  | up-down counter        | —            |
+| `kms.active.connections` | up-down counter        | —            |
+| `kms.errors.total`       | counter                | `error_type` |
 
 ### Objects & Keys
 
-| Metric | Type | Labels |
-|--------|------|--------|
-| `kms.objects.total` | gauge | — |
-| `kms.keys.active.count` | gauge | — |
+| Metric                  | Type  | Labels |
+| ----------------------- | ----- | ------ |
+| `kms.objects.total`     | gauge | —      |
+| `kms.keys.active.count` | gauge | —      |
 
 `kms.keys.active.count` counts all **non-destroyed** key objects (SymmetricKey, PrivateKey,
 PublicKey, SplitKey) across all non-terminal states: PreActive, Active, Deactivated, Compromised.
 
 ### Cache
 
-| Metric | Type | Labels |
-|--------|------|--------|
+| Metric                       | Type    | Labels                |
+| ---------------------------- | ------- | --------------------- |
 | `kms.cache.operations.total` | counter | `operation`, `result` |
 
 ### HSM
 
-| Metric | Type | Labels |
-|--------|------|--------|
+| Metric                     | Type    | Labels                   |
+| -------------------------- | ------- | ------------------------ |
 | `kms.hsm.operations.total` | counter | `operation`, `hsm_model` |
 
 ## OTLP Collector Configuration
@@ -160,7 +160,7 @@ receivers:
 
 exporters:
   otlp:
-    endpoint: ${env:OTLP_ENDPOINT}  # Forward to Jaeger, etc.
+    endpoint: ${env:OTLP_ENDPOINT} # Forward to Jaeger, etc.
 
 service:
   pipelines:
@@ -251,9 +251,9 @@ otlp = "https://otlp-lb.example.com:4317"
 
 1. **Check KMS logs** for OTLP connection errors:
 
-    ```bash
-    cosmian_kms --log-level debug
-    ```
+   ```bash
+   cosmian_kms --log-level debug
+   ```
 
 2. **Check Collector logs**:
 
@@ -269,11 +269,11 @@ docker compose --profile otel-test logs -f otel-collector
 
 ## Files Reference
 
-| File | Purpose |
-|------|---------|
-| `otel-collector-config.yaml` | OTLP Collector configuration |
-| `docker-compose.yml` | Local development stack (use profile `otel-test`) |
-| `crate/server/src/core/otel_metrics.rs` | Metrics instruments and recording helpers |
+| File                                    | Purpose                                           |
+| --------------------------------------- | ------------------------------------------------- |
+| `otel-collector-config.yaml`            | OTLP Collector configuration                      |
+| `docker-compose.yml`                    | Local development stack (use profile `otel-test`) |
+| `crate/server/src/core/otel_metrics.rs` | Metrics instruments and recording helpers         |
 
 ## Differences from HTTP /metrics Endpoint
 

--- a/resources/kms.toml
+++ b/resources/kms.toml
@@ -70,6 +70,17 @@ hostname = "0.0.0.0"
 # so they appear in the endpoint immediately (default: true).
 # jwks_endpoint_auto_tag = true
 
+# ── Audit logging ────────────────────────────────────────────────────────────
+# Append a tamper-evident SHA-256-chained JSONL line for every KMIP operation.
+# Uncomment the section below and set `enabled = true` to activate.
+#
+# [audit]
+# enabled = true
+#
+# [audit.file]
+# path = "/var/lib/cosmian/kms/audit.jsonl"
+# channel_capacity = 4096
+
 [db]
 database_type = "redis-findex"
 database_url = "redis://0.0.0.0:6379"

--- a/resources/kms.toml
+++ b/resources/kms.toml
@@ -60,26 +60,28 @@ hostname = "0.0.0.0"
 # WARNING: this endpoint is intentionally unauthenticated — any client can read
 # the listed public keys.  Enable only when you want third parties to verify
 # JWT signatures or discover your public keys.
-[jwks_endpoint]
-# Enable the /.well-known/jwks.json endpoint (default: false).
+
+#[jwks_endpoint]
 # jwks_endpoint_enabled = false
-# Maximum number of public keys returned per response (default: 50).
+
 # Responses exceeding this limit include X-JWKS-Truncated: true.
 # jwks_endpoint_max_keys = 50
+
 # Automatically tag key pairs created via POST /v1/crypto/keys with "jwks"
-# so they appear in the endpoint immediately (default: true).
 # jwks_endpoint_auto_tag = true
 
 # ── Audit logging ────────────────────────────────────────────────────────────
-# Append a tamper-evident SHA-256-chained JSONL line for every KMIP operation.
-# Uncomment the section below and set `enabled = true` to activate.
-#
 # [audit]
 # enabled = true
 #
 # [audit.file]
 # path = "/var/lib/cosmian/kms/audit.jsonl"
 # channel_capacity = 4096
+#
+# Only uncomment trusted_proxy_cidrs if the KMS sits behind a reverse proxy or
+# load balancer. Leave it unset otherwise (client_ip then always reflects the
+# real TCP peer address).
+# trusted_proxy_cidrs = ["10.0.0.0/8"]
 
 [db]
 database_type = "redis-findex"


### PR DESCRIPTION
## Description

Names should not appear in OTel logs

So in 2 words, they were basically hashed (Sha256), this function is basically it:

```rust
    /// Hashes a user identity into a short, non-reversible hex digest suitable
    /// for use as a metric label (per OTEL's `user.hash` semantic convention).
    fn hash_user(user: &str) -> String {
        let digest = Sha256::digest(user.as_bytes());
        let full_hex = hex::encode(digest);
        full_hex
            .get(..USER_LABEL_HASH_HEX_LEN)
            .unwrap_or(&full_hex)
            .to_owned()
    }
```

This PR has already been tested by the KMS tester : https://github.com/Cosmian/kms/pull/1063

If any comments, please read the closed past PR first