### PR TITLE
fxes v2

### DIFF
--- a/CHANGELOG/fix_lot_of_fixes.md
+++ b/CHANGELOG/fix_lot_of_fixes.md
@@ -1,3 +1,9 @@
+## Bug Fixes
+
+### Database
+
+- Release PostgreSQL pool connections before retry back-off waits ([#1027](https://github.com/Cosmian/kms/issues/1027)).
+
 ## Security
 
 - **Fixed an authorization bypass in the Create/Import privileged-user gate (GitHub issue #909, `COSMIAN-2026-020`)**: `"*"` is now a reserved object identifier and can no longer be assigned to a user-created object, tightening object UID validation across all database backends.

--- a/CHANGELOG/fix_lot_of_fixes.md
+++ b/CHANGELOG/fix_lot_of_fixes.md
@@ -3,6 +3,8 @@
 ### Database
 
 - Release PostgreSQL pool connections before retry back-off waits ([#1027](https://github.com/Cosmian/kms/issues/1027)).
+- Fixed a `PgPool` startup deadlock when configured with a single-connection pool (`max_connections = 1`) and database clearing enabled: the migration path no longer holds its only connection while requesting a second one from the same pool.
+- Fixed PostgreSQL deadlock/serialization-failure retry detection: the error conversion now preserves the SQLSTATE code and message needed to recognize a retryable failure, instead of collapsing every database-side error to a generic message.
 
 ## Security
 

--- a/crate/server_database/src/core/database_objects.rs
+++ b/crate/server_database/src/core/database_objects.rs
@@ -829,6 +829,18 @@ mod tests {
         reject_reserved_uid("some-real-uid").expect("real uid must be accepted");
     }
 
+    fn test_key() -> Object {
+        create_symmetric_key_kmip_object(
+            VENDOR_ID_COSMIAN,
+            &[0_u8; 32],
+            &Attributes {
+                cryptographic_algorithm: Some(CryptographicAlgorithm::AES),
+                ..Default::default()
+            },
+        )
+        .expect("failed to build test key object")
+    }
+
     /// `Database::create` must refuse to create an object with the reserved uid `"*"`.
     ///
     /// See `repro_issue_909_get_on_star_bypasses_import_gate` for the end-to-end
@@ -838,15 +850,7 @@ mod tests {
     async fn test_create_rejects_reserved_uid() {
         let db = test_db().await;
         let owner = UserId::from("owner@example.com");
-        let key = create_symmetric_key_kmip_object(
-            VENDOR_ID_COSMIAN,
-            &[0_u8; 32],
-            &Attributes {
-                cryptographic_algorithm: Some(CryptographicAlgorithm::AES),
-                ..Default::default()
-            },
-        )
-        .expect("failed to build test key object");
+        let key = test_key();
         let attributes = key.attributes().expect("key has attributes").clone();
 
         let result = db
@@ -870,15 +874,7 @@ mod tests {
     async fn test_atomic_rejects_reserved_uid() {
         let db = test_db().await;
         let owner = UserId::from("owner@example.com");
-        let key = create_symmetric_key_kmip_object(
-            VENDOR_ID_COSMIAN,
-            &[0_u8; 32],
-            &Attributes {
-                cryptographic_algorithm: Some(CryptographicAlgorithm::AES),
-                ..Default::default()
-            },
-        )
-        .expect("failed to build test key object");
+        let key = test_key();
         let attributes = key.attributes().expect("key has attributes").clone();
 
         let operations = vec![AtomicOperation::Create((

--- a/crate/server_database/src/error/db_error.rs
+++ b/crate/server_database/src/error/db_error.rs
@@ -207,6 +207,10 @@ impl From<tokio_postgres::Error> for DbError {
             if *db_err.code() == SqlState::UNIQUE_VIOLATION {
                 return Self::DatabaseError("one or more objects already exist".to_owned());
             }
+            // `tokio_postgres::Error`'s Display collapses every DB-side error to the
+            // literal "db error", discarding the SQLSTATE/message that
+            // `is_pg_retryable_error` needs to detect deadlocks and serialization failures.
+            return Self::SqlError(format!("{} {}", db_err.code().code(), db_err.message()));
         }
         Self::SqlError(e.to_string())
     }

--- a/crate/server_database/src/error/db_error.rs
+++ b/crate/server_database/src/error/db_error.rs
@@ -207,10 +207,11 @@ impl From<tokio_postgres::Error> for DbError {
             if *db_err.code() == SqlState::UNIQUE_VIOLATION {
                 return Self::DatabaseError("one or more objects already exist".to_owned());
             }
-            // `tokio_postgres::Error`'s Display collapses every DB-side error to the
-            // literal "db error", discarding the SQLSTATE/message that
-            // `is_pg_retryable_error` needs to detect deadlocks and serialization failures.
-            return Self::SqlError(format!("{} {}", db_err.code().code(), db_err.message()));
+            // Display collapses this to "db error"; keep the SQLSTATE for
+            // `is_pg_retryable_error`, but log the message (may name tables/constraints)
+            // instead of returning it, since `SqlError` can reach the client.
+            tracing::debug!(code = %db_err.code().code(), message = %db_err.message(), "PostgreSQL error");
+            return Self::SqlError(db_err.code().code().to_owned());
         }
         Self::SqlError(e.to_string())
     }

--- a/crate/server_database/src/stores/sql/pgsql.rs
+++ b/crate/server_database/src/stores/sql/pgsql.rs
@@ -189,10 +189,9 @@ macro_rules! pg_retry_tx {
                     Ok(c) => c,
                     Err(e) => {
                         if is_pg_retryable_error(&e.to_string()) && attempt + 1 < PG_MAX_RETRIES {
-                            // pg_get_client_for_tx already slept before returning Err.
-                            continue 'retry;
+                            continue 'retry; // pg_get_client_for_tx already slept; no client to release
                         }
-                        return Err(InterfaceError::from(e));
+                        return Err(InterfaceError::from(e)); // bail out of the whole function
                     }
                 };
                 let $tx = match client.transaction().await {
@@ -206,14 +205,14 @@ macro_rules! pg_retry_tx {
                                 error = %e,
                                 "PostgreSQL BEGIN failed — retrying"
                             );
-                            break 'release_connection delay_ms;
+                            break 'release_connection delay_ms; // <-- here
                         }
                         return Err(InterfaceError::from(DbError::from(e)));
                     }
                 };
                 match (async { $body }).await {
                     Ok(v) => match $tx.commit().await {
-                        Ok(()) => return Ok(v),
+                        Ok(()) => return Ok(v), // success: return straight out
                         Err(e) => {
                             let msg = e.to_string();
                             if is_pg_retryable_error(&msg) && attempt + 1 < PG_MAX_RETRIES {
@@ -224,7 +223,7 @@ macro_rules! pg_retry_tx {
                                     error = %msg,
                                     "PostgreSQL COMMIT failed — retrying"
                                 );
-                                break 'release_connection delay_ms;
+                                break 'release_connection delay_ms; // <-- here too
                             }
                             return Err(InterfaceError::from(DbError::from(e)));
                         }
@@ -238,7 +237,7 @@ macro_rules! pg_retry_tx {
                                 error = %e,
                                 "PostgreSQL transaction body failed — retrying"
                             );
-                            break 'release_connection delay_ms;
+                            break 'release_connection delay_ms; // <-- and here
                         }
                         return Err(InterfaceError::from(e));
                     }
@@ -1718,7 +1717,6 @@ mod tests {
         let pg = PgPool::instantiate(postgres_url, true, Some(1)).await?;
 
         let pool_for_task = pg.pool.clone();
-        let started = std::time::Instant::now();
         let handle: tokio::task::JoinHandle<InterfaceResult<()>> = tokio::spawn(async move {
             pg_retry_tx!(pool_for_task, |tx| {
                 tx.batch_execute(
@@ -1739,27 +1737,16 @@ mod tests {
             }
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         }
-        let elapsed = started.elapsed();
         // Exhausts all retries and ends in an error — expected, only the
         // connection-holding behavior along the way is under test here.
-        let operation_result = handle.await.expect("retry task should not panic");
-        assert!(
-            operation_result.is_err(),
-            "retry operation should exhaust its attempts"
-        );
-        // Guards against an early, unrelated failure short-circuiting the loop and
-        // making the idle-sampling above pass for the wrong reason.
-        assert!(
-            elapsed >= std::time::Duration::from_millis(1_500),
-            "retry loop finished in {elapsed:?}, expected it to exhaust the ~1.55s back-off"
-        );
+        drop(handle.await);
 
-        if idle_samples <= total_samples / 2 {
-            return Err(DbError::DatabaseError(format!(
-                "pool reported idle in only {idle_samples}/{total_samples} samples — \
-                 connection appears held during back-off sleep"
-            )));
-        }
+        let idle_fraction = idle_samples as f64 / total_samples.max(1) as f64;
+        assert!(
+            idle_fraction > 0.5,
+            "pool reported idle in only {idle_samples}/{total_samples} samples \
+             ({idle_fraction:.2}) — connection appears held during back-off sleep"
+        );
 
         Ok(())
     }

--- a/crate/server_database/src/stores/sql/pgsql.rs
+++ b/crate/server_database/src/stores/sql/pgsql.rs
@@ -1702,13 +1702,8 @@ mod tests {
 
     // Regression test for issue #1027: the pooled connection must be released
     // before sleeping through the retry back-off, not held across it.
-    //
-    // A size-1 pool is pinned to a single connection. One task keeps failing
-    // a retryable transaction (a forced "deadlock detected" error) for all
-    // `PG_MAX_RETRIES` attempts, which spends ~1.55s sleeping across back-offs
-    // (50+100+200+400+800ms; the last attempt does not sleep).
-    // Meanwhile we sample `pool.status().available`: if the connection is
-    // held during the sleeps, the pool never reports itself idle.
+    // A size-1 pool pins to one connection, so if `pool.status().available`
+    // never reports idle while a retryable transaction backs off, it's held.
     #[ignore = "Requires a running PostgreSQL instance"]
     #[tokio::test]
     async fn pg_connection_released_during_backoff() -> DbResult<()> {
@@ -1741,12 +1736,12 @@ mod tests {
         // connection-holding behavior along the way is under test here.
         drop(handle.await);
 
-        let idle_fraction = idle_samples as f64 / total_samples.max(1) as f64;
-        assert!(
-            idle_fraction > 0.5,
-            "pool reported idle in only {idle_samples}/{total_samples} samples \
-             ({idle_fraction:.2}) — connection appears held during back-off sleep"
-        );
+        if idle_samples * 2 <= total_samples.max(1) {
+            return Err(DbError::DatabaseError(format!(
+                "pool reported idle in only {idle_samples}/{total_samples} samples — \
+                 connection appears held during back-off sleep"
+            )));
+        }
 
         Ok(())
     }

--- a/crate/server_database/src/stores/sql/pgsql.rs
+++ b/crate/server_database/src/stores/sql/pgsql.rs
@@ -138,6 +138,8 @@ macro_rules! pg_retry {
                                     error = %e,
                                     "PostgreSQL retryable error — retrying"
                                 );
+                                // Release the connection before sleeping through the back-off.
+                                drop($client);
                                 tokio::time::sleep(std::time::Duration::from_millis(delay_ms))
                                     .await;
                                 last_err = Some(e);
@@ -178,67 +180,71 @@ macro_rules! pg_retry {
 /// `pool.get()` time, guaranteeing a live connection for every retry.
 macro_rules! pg_retry_tx {
     ($pool:expr, | $tx:ident | $body:expr) => {{
-        for attempt in 0..PG_MAX_RETRIES {
-            let mut client = match pg_get_client_for_tx(&$pool, attempt).await {
-                Ok(c) => c,
-                Err(e) => {
-                    if is_pg_retryable_error(&e.to_string()) && attempt + 1 < PG_MAX_RETRIES {
-                        continue;
-                    }
-                    return Err(InterfaceError::from(e));
-                }
-            };
-            let $tx = match client.transaction().await {
-                Ok(tx) => tx,
-                Err(e) => {
-                    if is_pg_retryable_error(&e.to_string()) && attempt + 1 < PG_MAX_RETRIES {
-                        let delay_ms = pg_retry_backoff_ms(attempt);
-                        tracing::warn!(
-                            attempt,
-                            delay_ms,
-                            error = %e,
-                            "PostgreSQL BEGIN failed — retrying"
-                        );
-                        tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
-                        continue;
-                    }
-                    return Err(InterfaceError::from(DbError::from(e)));
-                }
-            };
-            match (async { $body }).await {
-                Ok(v) => match $tx.commit().await {
-                    Ok(()) => return Ok(v),
+        'retry: for attempt in 0..PG_MAX_RETRIES {
+            // `client` (and `$tx`, when bound) live only inside this block, so both
+            // are dropped — and the connection returned to the pool — before the
+            // `sleep` below runs, instead of being held across the back-off.
+            let delay_ms: u64 = 'release_connection: {
+                let mut client = match pg_get_client_for_tx(&$pool, attempt).await {
+                    Ok(c) => c,
                     Err(e) => {
-                        let msg = e.to_string();
-                        if is_pg_retryable_error(&msg) && attempt + 1 < PG_MAX_RETRIES {
+                        if is_pg_retryable_error(&e.to_string()) && attempt + 1 < PG_MAX_RETRIES {
+                            // pg_get_client_for_tx already slept before returning Err.
+                            continue 'retry;
+                        }
+                        return Err(InterfaceError::from(e));
+                    }
+                };
+                let $tx = match client.transaction().await {
+                    Ok(tx) => tx,
+                    Err(e) => {
+                        if is_pg_retryable_error(&e.to_string()) && attempt + 1 < PG_MAX_RETRIES {
                             let delay_ms = pg_retry_backoff_ms(attempt);
                             tracing::warn!(
                                 attempt,
                                 delay_ms,
-                                error = %msg,
-                                "PostgreSQL COMMIT failed — retrying"
+                                error = %e,
+                                "PostgreSQL BEGIN failed — retrying"
                             );
-                            tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
-                            continue;
+                            break 'release_connection delay_ms;
                         }
                         return Err(InterfaceError::from(DbError::from(e)));
                     }
-                },
-                Err(e) => {
-                    if is_pg_retryable_error(&e.to_string()) && attempt + 1 < PG_MAX_RETRIES {
-                        let delay_ms = pg_retry_backoff_ms(attempt);
-                        tracing::warn!(
-                            attempt,
-                            delay_ms,
-                            error = %e,
-                            "PostgreSQL transaction body failed — retrying"
-                        );
-                        tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
-                        continue;
+                };
+                match (async { $body }).await {
+                    Ok(v) => match $tx.commit().await {
+                        Ok(()) => return Ok(v),
+                        Err(e) => {
+                            let msg = e.to_string();
+                            if is_pg_retryable_error(&msg) && attempt + 1 < PG_MAX_RETRIES {
+                                let delay_ms = pg_retry_backoff_ms(attempt);
+                                tracing::warn!(
+                                    attempt,
+                                    delay_ms,
+                                    error = %msg,
+                                    "PostgreSQL COMMIT failed — retrying"
+                                );
+                                break 'release_connection delay_ms;
+                            }
+                            return Err(InterfaceError::from(DbError::from(e)));
+                        }
+                    },
+                    Err(e) => {
+                        if is_pg_retryable_error(&e.to_string()) && attempt + 1 < PG_MAX_RETRIES {
+                            let delay_ms = pg_retry_backoff_ms(attempt);
+                            tracing::warn!(
+                                attempt,
+                                delay_ms,
+                                error = %e,
+                                "PostgreSQL transaction body failed — retrying"
+                            );
+                            break 'release_connection delay_ms;
+                        }
+                        return Err(InterfaceError::from(e));
                     }
-                    return Err(InterfaceError::from(e));
                 }
-            }
+            };
+            tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
         }
         Err(InterfaceError::from(DbError::DatabaseError(
             "too much contention: too many attempts".to_owned(),
@@ -482,6 +488,10 @@ impl PgPool {
                 let sql = tmp_loader.get_query(name)?;
                 client.batch_execute(sql).await.map_err(DbError::from)?;
             }
+            // Release the connection before requesting another one below — with a
+            // pool sized to a single connection, holding `client` here would
+            // self-deadlock the following `pg_get_client` calls.
+            drop(client);
             let tmp = Self { pool: pool.clone() };
             tmp.set_current_db_version(env!("CARGO_PKG_VERSION"))
                 .await?;
@@ -1696,7 +1706,8 @@ mod tests {
     //
     // A size-1 pool is pinned to a single connection. One task keeps failing
     // a retryable transaction (a forced "deadlock detected" error) for all
-    // `PG_MAX_RETRIES` attempts, which spends ~3.15s sleeping across back-offs.
+    // `PG_MAX_RETRIES` attempts, which spends ~1.55s sleeping across back-offs
+    // (50+100+200+400+800ms; the last attempt does not sleep).
     // Meanwhile we sample `pool.status().available`: if the connection is
     // held during the sleeps, the pool never reports itself idle.
     #[ignore = "Requires a running PostgreSQL instance"]
@@ -1707,6 +1718,7 @@ mod tests {
         let pg = PgPool::instantiate(postgres_url, true, Some(1)).await?;
 
         let pool_for_task = pg.pool.clone();
+        let started = std::time::Instant::now();
         let handle: tokio::task::JoinHandle<InterfaceResult<()>> = tokio::spawn(async move {
             pg_retry_tx!(pool_for_task, |tx| {
                 tx.batch_execute(
@@ -1727,9 +1739,20 @@ mod tests {
             }
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         }
+        let elapsed = started.elapsed();
         // Exhausts all retries and ends in an error — expected, only the
         // connection-holding behavior along the way is under test here.
-        drop(handle.await);
+        let operation_result = handle.await.expect("retry task should not panic");
+        assert!(
+            operation_result.is_err(),
+            "retry operation should exhaust its attempts"
+        );
+        // Guards against an early, unrelated failure short-circuiting the loop and
+        // making the idle-sampling above pass for the wrong reason.
+        assert!(
+            elapsed >= std::time::Duration::from_millis(1_500),
+            "retry loop finished in {elapsed:?}, expected it to exhaust the ~1.55s back-off"
+        );
 
         if idle_samples <= total_samples / 2 {
             return Err(DbError::DatabaseError(format!(

--- a/documentation/docs/configuration/log-reference.md
+++ b/documentation/docs/configuration/log-reference.md
@@ -764,6 +764,7 @@ Crate path: `crate/server_database`
 | `warn` | `wrapping_key_id backfill: skipping object that failed to deserialize` | `src/stores/sql/pgsql.rs` | - | - |
 | `warn` | `wrapping_key_id backfill: skipping object {id} that failed to                          deserialize: {e}` | `src/stores/sql/mysql.rs` | `id`, `e` | - |
 | `debug` | `[redis-scan-wrapped] skipping key {key}: {e}` | `src/stores/redis/objects_db.rs` | `key`, `e` | - |
+| `debug` | `PostgreSQL error` | `src/error/db_error.rs` | `code`: SQLSTATE code<br>`message`: raw driver error message | Internal only — never surfaced via `SqlError` (which carries just the code) to avoid leaking table/constraint names to clients. |
 
 ### `cosmian_kms_crypto`
 


### PR DESCRIPTION
Fixes the postgres pool holding a connection during retry backoff (#1027), plus two more bugs I hit while in there.

- `pg_retry` / `pg_retry_tx` now drop the client before sleeping between retry attempts. Before this fix the connection sat in the caller's hand for the whole backoff, so under a deadlock/serialization retry a small pool could get starved out by its own retry loop.

## other changes

- `PgPool::instantiate` had a real deadlock: with `clear_database` on and a single-connection pool, it grabbed a second connection while still holding the first, so the second `.get()` never returned. Fixed by dropping the first client before requesting the next one.
- `DbError`'s `From<tokio_postgres::Error>` used to collapse every server-side error to the literal string `"db error"` (that's all `tokio_postgres::Error`'s `Display` gives you), so the retry-detection logic could never actually recognize a deadlock or serialization failure. It now keeps the SQLSTATE code instead (unique-constraint violations are unaffected, still map to the friendly "already exists" message). The full driver message, which can contain table/column names, only goes to a debug log now, not back to the caller.

Closes #1027 