### PR TITLE
fix: MISE script

### DIFF
--- a/.mise/tasks/build/wasm
+++ b/.mise/tasks/build/wasm
@@ -21,7 +21,8 @@ unset RUSTFLAGS LDFLAGS
 
 wasm-pack build --target web "$WASM_CRATE" ${FEATURES_FLAG[@]+"${FEATURES_FLAG[@]}"}
 
-# Copy output to UI source
+# Copy output to UI source (ui/src/wasm/ is gitignored, may not exist on a fresh clone)
+mkdir -p "${REPO_ROOT}/ui/src/wasm"
 cp -r "${WASM_CRATE}/pkg/" "${REPO_ROOT}/ui/src/wasm/pkg/"
 
 print_success "WASM package built and copied to ui/src/wasm/pkg/"


### PR DESCRIPTION
just mkdir the folder

Fixes https://github.com/Cosmian/kms/issues/1149

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Create `ui/src/wasm` directory before copying package in `build/wasm` task
> The WASM build task failed on a fresh clone because `ui/src/wasm` did not exist. The task now creates that directory before copying the generated WASM package into it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c33ea8a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->