### PR TITLE
fix(deps): bump axum-server 0.7 -> 0.8 to drop unmaintained rustls-pemfile (RUSTSEC-2025-0134)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,12 +733,13 @@ dependencies = [
 
 [[package]]
 name = "axum-server"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ab4a3ec9ea8a657c72d99a03a824af695bd0fb5ec639ccbd9cd3543b41a5f9"
+checksum = "b1df331683d982a0b9492b38127151e6453639cd34926eb9c07d4cd8c6d22bfc"
 dependencies = [
  "arc-swap",
  "bytes",
+ "either",
  "fs-err",
  "http 1.5.0",
  "http-body",
@@ -746,7 +747,6 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "rustls",
- "rustls-pemfile",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -2579,7 +2579,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3395,7 +3395,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -4277,7 +4277,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4367,7 +4367,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "chrono",
  "getrandom 0.2.17",
  "http 1.5.0",
@@ -5094,7 +5094,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -5132,9 +5132,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5547,7 +5547,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5576,15 +5576,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -6300,10 +6291,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7352,7 +7343,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ actix-web = { version = "4.12", default-features = false }
 async-recursion = "1.1"
 async-trait = "0.1"
 axum = "0.8"
-axum-server = "0.7"
+axum-server = "0.8"
 base64 = "0.22"
 bitflags = "2.9"
 chrono = "0.4"

--- a/deny.toml
+++ b/deny.toml
@@ -70,7 +70,6 @@ ignore = [
   # "a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
   # { crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
   { id = "RUSTSEC-2023-0071", reason = "Marvin Attack: potential key recovery through timing sidechannels. KMS depends now on jsonwebtoken that has 2 crypto backends (rust_crypto and aws-lc). aws-lc not being Windows compatible, we must choose rust_crypto" },
-  { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile is unmaintained but pulled transitively by axum-server; no safe upgrade available" },
   # h2 0.3.x (used by actix-http 3.x) accepts unbounded empty DATA frames, potentially causing OOM or panic.
   # The fix is in h2 >=0.4.16, but actix-http 3.x (and its master branch as of 2026-08) is hardcoded to h2 ^0.3
   # and there is no actix-http 4.x / actix-web 5.x release yet. No upstream upgrade path exists.


### PR DESCRIPTION
## Résumé

`axum-server 0.7.x` tirait `rustls-pemfile` (non maintenu, RUSTSEC-2025-0134) via la feature `tls-rustls-no-provider`. La version `0.8.0` a supprimé cette dépendance transitive.

## Changements

- `Cargo.toml`: `axum-server = "0.7"` → `"0.8"`
- `Cargo.lock`: mise à jour de `axum-server` (0.7.3 → 0.8.0), `rustls-pemfile` disparaît totalement du graphe de dépendances
- `deny.toml`: suppression de l'exception `RUSTSEC-2025-0134` (devenue obsolète)

Seul consommateur d'`axum-server` dans le workspace : `crate/clients/k8s/operator` (webhook TLS). Aucun changement de code nécessaire — API inchangée entre 0.7 et 0.8 pour notre usage.

## Vérifications

- `cargo build -p cosmian_kms_k8s_operator` ✅
- `cargo clippy -p cosmian_kms_k8s_operator --all-targets --all-features -- -D warnings` ✅ (zéro warning)
- `cargo test -p cosmian_kms_k8s_operator` ✅ (15/15 tests)
- `cargo fmt --all` ✅
- Pre-commit hooks (incl. `cargo test workspace` déclenché par le changement de `Cargo.lock`/`Cargo.toml`) ✅

## Note CI

Si la CI Nix signale un mismatch de hash sur `nix/expected-hashes/*.sha256` (vendor hash lié au `Cargo.lock` modifié), il faudra récupérer le hash correct depuis le log CI et l'appliquer.
